### PR TITLE
Don't attempt wasm-bindgen install if it exists in path.

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -11,7 +11,7 @@ static PATH_SEP: &str = ";";
 static PATH_SEP: &str = ":";
 
 pub fn cargo_install_wasm_bindgen() -> Result<(), Error> {
-    if wasm_bindgen_installed() {
+    if wasm_bindgen_installed()? {
         return Ok(());
     }
     let step = format!(
@@ -81,15 +81,13 @@ pub fn wasm_bindgen_build(
     }
 }
 
-fn wasm_bindgen_installed() -> bool {
-    if let Ok(path) = env::var("PATH") {
-        path.split(PATH_SEP)
-            .map(|p: &str| -> bool {
-                let prog_str = format!("{}/wasm-bindgen", p);
-                fs::metadata(prog_str).is_ok()
-            })
-            .fold(false, |res, b| res || b)
-    } else {
-        false
-    }
+fn wasm_bindgen_installed() -> Result<bool, Error> {
+    let path = env::var("PATH")?;
+    let is_installed = path.split(PATH_SEP)
+        .map(|p: &str| -> bool {
+            let prog_str = format!("{}/wasm-bindgen", p);
+            fs::metadata(prog_str).is_ok()
+        })
+        .fold(false, |res, b| res || b);
+    Ok(is_installed)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Code related to error handling for wasm-pack
 use serde_json;
 use std::borrow::Cow;
+use std::env;
 use std::io;
 use toml;
 
@@ -13,6 +14,8 @@ pub enum Error {
     SerdeJson(#[cause] serde_json::Error),
     #[fail(display = "{}", _0)]
     SerdeToml(#[cause] toml::de::Error),
+    #[fail(display = "{}", _0)]
+    VarError(#[cause] env::VarError),
     #[fail(display = "{}. stderr:\n\n{}", message, stderr)]
     Cli { message: String, stderr: String },
 }
@@ -30,6 +33,7 @@ impl Error {
             Error::Io(_) => "There was an I/O error. Details:\n\n",
             Error::SerdeJson(_) => "There was an JSON error. Details:\n\n",
             Error::SerdeToml(_) => "There was an TOML error. Details:\n\n",
+            Error::VarError(_) => "There was an error finding an environment variable. Details:\n\n",
             Error::Cli {
                 message: _,
                 stderr: _,
@@ -53,5 +57,11 @@ impl From<serde_json::Error> for Error {
 impl From<toml::de::Error> for Error {
     fn from(e: toml::de::Error) -> Self {
         Error::SerdeToml(e)
+    }
+}
+
+impl From<env::VarError> for Error {
+    fn from(e: env::VarError) -> Self {
+        Error::VarError(e)
     }
 }


### PR DESCRIPTION
(Fixing issue #51.)

After running into some of the problems in the previous PR [here], I squashed the commits from my previous PR down, and rebased it off of the recent changes to the repo.

[here]: https://github.com/ashleygwilliams/wasm-pack/pull/79

In case there are issues with the Travis build again, here are the rust-fmt and rustc versions I am using.

```
✨  cargo fmt --version
rustfmt 0.4.1-nightly (e784712 2018-04-09)

✨  rustc --version
rustc 1.27.0-nightly (ad610bed8 2018-04-11)
```

Thank you for bearing with me on the linting problems by the way, pardon me.