### PR TITLE
Coordinating wasm-bindgen versions

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -3,57 +3,8 @@
 use emoji;
 use error::Error;
 use progressbar::Step;
-use std::{env, fs, path, process::Command};
+use std::{env, path, process::Command};
 use PBAR;
-
-/// Return a string containing the path to the local `wasm-bindgen`.
-fn local_wasm_bindgen_path_str(crate_path: &str) -> String {
-    #[cfg(not(target_family = "windows"))]
-    return format!("{}/{}", crate_path, "bin/wasm-bindgen");
-    #[cfg(target_family = "windows")]
-    return format!("{}\\{}", crate_path, "bin\\wasm-bindgen");
-}
-
-/// Return a string containing the path to the global `wasm-bindgen`.
-fn global_wasm_bindgen_path_str() -> Result<Option<String>, Error> {
-    #[cfg(target_family = "windows")]
-    let path_sep: &str = ";";
-    #[cfg(not(target_family = "windows"))]
-    let path_sep: &str = ":";
-
-    let path = env::var("PATH")?;
-    for path_dir in path.split(path_sep)
-    {
-        let prog_str = format!("{}/wasm-bindgen", path_dir);
-        if fs::metadata(&prog_str).is_ok() {
-            return Ok(Some(prog_str))
-        }
-    }
-
-    Ok(None)
-}
-
-/// Check if the `wasm-bindgen` dependency is locally satisfied.
-fn wasm_bindgen_version_check(crate_path: &str, dep_version: &str) -> Result<bool, Error> {
-    let path_str = local_wasm_bindgen_path_str(crate_path);
-    let wasm_bindgen = path::Path::new(&path_str);
-
-    if !wasm_bindgen.is_file() {
-        return Ok(false);
-    }
-
-    let output = Command::new(wasm_bindgen).arg("--version").output()?;
-    if output.status.success() {
-        let s = String::from_utf8_lossy(&output.stdout);
-        let installed_version = s.trim();
-        Ok(installed_version == dep_version)
-    } else {
-        let error_msg = "Could not find version of local wasm-bindgen";
-        let s = String::from_utf8_lossy(&output.stderr);
-        let e = Error::cli(error_msg, s);
-        Err(e)
-    }
-}
 
 /// Install the `wasm-bindgen` CLI with `cargo install`.
 pub fn cargo_install_wasm_bindgen(
@@ -62,14 +13,26 @@ pub fn cargo_install_wasm_bindgen(
     install_permitted: bool,
     step: &Step,
 ) -> Result<(), Error> {
-    if wasm_bindgen_version_check(path, version)? {
+    // Determine if the `wasm-bindgen` dependency is already met for the given mode.
+    let dependency_met = if let Some(bindgen_path) = wasm_bindgen_path_str(path, install_permitted)?
+    {
+        wasm_bindgen_version_check(&bindgen_path, version)?
+    } else {
+        false
+    };
+
+    // If the `wasm-bindgen` dependency is already met, print a message and return.
+    if dependency_met {
         let msg = format!("{}WASM-bindgen already installed...", emoji::DOWN_ARROW);
         PBAR.step(step, &msg);
         return Ok(());
     }
 
+    // If the `wasm-bindgen` dependency was not met, and installs are not
+    // permitted, return a configuration error.
     if !install_permitted {
         return Err(Error::crate_config("WASM-bindgen is not installed!"));
+        // FIXUP: This error message can be improved.
     }
 
     let msg = format!("{}Installing WASM-bindgen...", emoji::DOWN_ARROW);
@@ -98,6 +61,7 @@ pub fn wasm_bindgen_build(
     name: &str,
     disable_dts: bool,
     target: &str,
+    install_permitted: bool,
     debug: bool,
     step: &Step,
 ) -> Result<(), Error> {
@@ -105,34 +69,104 @@ pub fn wasm_bindgen_build(
     PBAR.step(step, &msg);
     let binary_name = name.replace("-", "_");
     let release_or_debug = if debug { "debug" } else { "release" };
-    let wasm_path = format!(
-        "target/wasm32-unknown-unknown/{}/{}.wasm",
-        release_or_debug, binary_name
-    );
-    let dts_arg = if disable_dts == false {
-        "--typescript"
-    } else {
-        "--no-typescript"
-    };
 
-    let target_arg = match target {
-        "nodejs" => "--nodejs",
-        _ => "--browser",
-    };
+    if let Some(wasm_bindgen_path_str) = wasm_bindgen_path_str(path, install_permitted)? {
+        let wasm_path = format!(
+            "target/wasm32-unknown-unknown/{}/{}.wasm",
+            release_or_debug, binary_name
+        );
 
-    let wasm_bindgen = local_wasm_bindgen_path_str(path);
-    let output = Command::new(wasm_bindgen)
-        .current_dir(path)
-        .arg(&wasm_path)
-        .arg("--out-dir")
-        .arg("./pkg")
-        .arg(dts_arg)
-        .arg(target_arg)
-        .output()?;
-    if !output.status.success() {
-        let s = String::from_utf8_lossy(&output.stderr);
-        Err(Error::cli("wasm-bindgen failed to execute properly", s))
+        let dts_arg = if disable_dts == false {
+            "--typescript"
+        } else {
+            "--no-typescript"
+        };
+
+        let target_arg = match target {
+            "nodejs" => "--nodejs",
+            _ => "--browser",
+        };
+
+        let bindgen_path = path::Path::new(&wasm_bindgen_path_str);
+        let output = Command::new(bindgen_path)
+            .current_dir(path)
+            .arg(&wasm_path)
+            .arg("--out-dir")
+            .arg("./pkg")
+            .arg(dts_arg)
+            .arg(target_arg)
+            .output()?;
+        if !output.status.success() {
+            let s = String::from_utf8_lossy(&output.stderr);
+            Err(Error::cli("wasm-bindgen failed to execute properly", s))
+        } else {
+            Ok(())
+        }
     } else {
-        Ok(())
+        Err(Error::crate_config("Could not find `wasm-bindgen`"))
     }
+}
+
+/// Check if the `wasm-bindgen` dependency is locally satisfied.
+fn wasm_bindgen_version_check(bindgen_path: &str, dep_version: &str) -> Result<bool, Error> {
+    let wasm_bindgen = path::Path::new(bindgen_path);
+
+    let output = Command::new(wasm_bindgen).arg("--version").output()?;
+    if output.status.success() {
+        let s = String::from_utf8_lossy(&output.stdout);
+        let installed_version = s.trim();
+        Ok(installed_version == dep_version)
+    } else {
+        // FIXUP: This error message can be improved.
+        let error_msg = "Could not find version of local wasm-bindgen";
+        let s = String::from_utf8_lossy(&output.stderr);
+        let e = Error::cli(error_msg, s);
+        Err(e)
+    }
+}
+
+/// Return a string to `wasm-bindgen`, if it exists for the given mode.
+fn wasm_bindgen_path_str(
+    crate_path: &str,
+    install_permitted: bool,
+) -> Result<Option<String>, Error> {
+    if install_permitted {
+        if let path_str @ Some(_) = local_wasm_bindgen_path_str(crate_path) {
+            return Ok(path_str);
+        }
+    }
+
+    global_wasm_bindgen_path_str()
+}
+
+/// Return a string containing the path to the local `wasm-bindgen`, if it exists.
+fn local_wasm_bindgen_path_str(crate_path: &str) -> Option<String> {
+    #[cfg(not(target_family = "windows"))]
+    let local_path = format!("{}/{}", crate_path, "bin/wasm-bindgen");
+    #[cfg(target_family = "windows")]
+    let local_path = format!("{}\\{}", crate_path, "bin\\wasm-bindgen");
+
+    if path::Path::new(&local_path).is_file() {
+        Some(local_path)
+    } else {
+        None
+    }
+}
+
+/// Return a string containing the path to the global `wasm-bindgen`, if it exists.
+fn global_wasm_bindgen_path_str() -> Result<Option<String>, Error> {
+    #[cfg(target_family = "windows")]
+    let path_sep: &str = ";";
+    #[cfg(not(target_family = "windows"))]
+    let path_sep: &str = ":";
+
+    let path = env::var("PATH")?;
+    for path_dir in path.split(path_sep) {
+        let prog_str = format!("{}/wasm-bindgen", path_dir);
+        if path::Path::new(&prog_str).is_file() {
+            return Ok(Some(prog_str));
+        }
+    }
+
+    Ok(None)
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -21,7 +21,10 @@ pub fn rustup_add_wasm_target(step: &Step) -> Result<(), Error> {
         .output()?;
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Adding the wasm32-unknown-unknown target failed", s)
+        Err(Error::cli(
+            "Adding the wasm32-unknown-unknown target failed",
+            s,
+        ))
     } else {
         Ok(())
     }
@@ -38,7 +41,7 @@ fn ensure_nightly() -> Result<(), Error> {
             .output()?;
         if !res.status.success() {
             let s = String::from_utf8_lossy(&res.stderr);
-            return Error::cli("Adding the nightly toolchain failed", s);
+            return Err(Error::cli("Adding the nightly toolchain failed", s));
         }
     }
     Ok(())
@@ -61,7 +64,7 @@ pub fn cargo_build_wasm(path: &str, debug: bool, step: &Step) -> Result<(), Erro
 
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Compilation of your program failed", s)
+        Err(Error::cli("Compilation of your program failed", s))
     } else {
         Ok(())
     }

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -217,10 +217,12 @@ impl Init {
         info!(&log, "Identifying WASM-bindgen dependency...");
         let bindgen_version = manifest::get_wasm_bindgen_version(&self.crate_path)?;
         info!(&log, "Installing wasm-bindgen-cli...");
+
         let install_permitted = match self.mode {
             InitMode::Noinstall => false,
             _ => true,
         };
+
         bindgen::cargo_install_wasm_bindgen(
             &self.crate_path,
             &bindgen_version,
@@ -250,11 +252,16 @@ impl Init {
 
     fn step_run_wasm_bindgen(&mut self, step: &Step, log: &Logger) -> Result<(), Error> {
         info!(&log, "Building the wasm bindings...");
+        let install_permitted = match self.mode {
+            InitMode::Noinstall => false,
+            _ => true,
+        };
         bindgen::wasm_bindgen_build(
             &self.crate_path,
             &self.crate_name,
             self.disable_dts,
             &self.target,
+            install_permitted,
             self.debug,
             step,
         )?;

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -211,9 +211,15 @@ impl Init {
     }
 
     fn step_install_wasm_bindgen(&mut self, step: &Step, log: &Logger) -> Result<(), Error> {
-        info!(&log, "Installing wasm-bindgen-cli...");
-        bindgen::cargo_install_wasm_bindgen(step)?;
-        info!(&log, "Installing wasm-bindgen-cli was successful.");
+        info!(&log, "Checking WASM-bindgen version...");
+        let bindgen_version = manifest::get_wasm_bindgen_version(&self.crate_path)?;
+        let bindgen_installed =
+            bindgen::wasm_bindgen_version_check(&self.crate_path, &bindgen_version, step)?;
+        if !bindgen_installed {
+            info!(&log, "Installing wasm-bindgen-cli...");
+            bindgen::cargo_install_wasm_bindgen(&self.crate_path, &bindgen_version, step)?;
+            info!(&log, "Installing wasm-bindgen-cli was successful.");
+        }
 
         info!(&log, "Getting the crate name from the manifest...");
         self.crate_name = manifest::get_crate_name(&self.crate_path)?;

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -44,6 +44,7 @@ pub struct Init {
     target: String,
     debug: bool,
     crate_name: String,
+    mode: InitMode,
 }
 
 type InitStep = fn(&mut Init, &Step, &Logger) -> Result<(), Error>;
@@ -56,6 +57,7 @@ impl Init {
         disable_dts: bool,
         target: String,
         debug: bool,
+        mode: InitMode,
     ) -> Result<Init, Error> {
         let crate_path = set_crate_path(path);
         let crate_name = manifest::get_crate_name(&crate_path)?;
@@ -66,10 +68,11 @@ impl Init {
             target,
             debug,
             crate_name,
+            mode,
         })
     }
 
-    fn get_process_steps(mode: InitMode) -> Vec<(&'static str, InitStep)> {
+    fn get_process_steps(mode: &InitMode) -> Vec<(&'static str, InitStep)> {
         macro_rules! steps {
             ($($name:ident),+) => {
                 {
@@ -105,8 +108,8 @@ impl Init {
     }
 
     /// Execute this `Init` command.
-    pub fn process(&mut self, log: &Logger, mode: InitMode) -> Result<(), Error> {
-        let process_steps = Init::get_process_steps(mode);
+    pub fn process(&mut self, log: &Logger) -> Result<(), Error> {
+        let process_steps = Init::get_process_steps(&self.mode);
 
         let mut step_counter = Step::new(process_steps.len());
 
@@ -211,15 +214,20 @@ impl Init {
     }
 
     fn step_install_wasm_bindgen(&mut self, step: &Step, log: &Logger) -> Result<(), Error> {
-        info!(&log, "Checking WASM-bindgen version...");
+        info!(&log, "Identifying WASM-bindgen dependency...");
         let bindgen_version = manifest::get_wasm_bindgen_version(&self.crate_path)?;
-        let bindgen_installed =
-            bindgen::wasm_bindgen_version_check(&self.crate_path, &bindgen_version, step)?;
-        if !bindgen_installed {
-            info!(&log, "Installing wasm-bindgen-cli...");
-            bindgen::cargo_install_wasm_bindgen(&self.crate_path, &bindgen_version, step)?;
-            info!(&log, "Installing wasm-bindgen-cli was successful.");
-        }
+        info!(&log, "Installing wasm-bindgen-cli...");
+        let install_permitted = match self.mode {
+            InitMode::Noinstall => false,
+            _ => true,
+        };
+        bindgen::cargo_install_wasm_bindgen(
+            &self.crate_path,
+            &bindgen_version,
+            install_permitted,
+            step,
+        )?;
+        info!(&log, "Installing wasm-bindgen-cli was successful.");
 
         info!(&log, "Getting the crate name from the manifest...");
         self.crate_name = manifest::get_crate_name(&self.crate_path)?;
@@ -270,7 +278,7 @@ mod test {
 
     #[test]
     fn init_normal_build() {
-        let steps: Vec<&str> = Init::get_process_steps(InitMode::Normal)
+        let steps: Vec<&str> = Init::get_process_steps(&InitMode::Normal)
             .into_iter()
             .map(|(n, _)| n)
             .collect();
@@ -291,7 +299,7 @@ mod test {
 
     #[test]
     fn init_skip_build() {
-        let steps: Vec<&str> = Init::get_process_steps(InitMode::Nobuild)
+        let steps: Vec<&str> = Init::get_process_steps(&InitMode::Nobuild)
             .into_iter()
             .map(|(n, _)| n)
             .collect();
@@ -303,7 +311,7 @@ mod test {
 
     #[test]
     fn init_skip_install() {
-        let steps: Vec<&str> = Init::get_process_steps(InitMode::Noinstall)
+        let steps: Vec<&str> = Init::get_process_steps(&InitMode::Noinstall)
             .into_iter()
             .map(|(n, _)| n)
             .collect();

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -123,7 +123,7 @@ pub fn run_wasm_pack(command: Command, log: &Logger) -> result::Result<(), Error
                 "normal" => InitMode::Normal,
                 _ => InitMode::Normal,
             };
-            Init::new(path, scope, disable_dts, target, debug)?.process(&log, modetype)
+            Init::new(path, scope, disable_dts, target, debug, modetype)?.process(&log)
         }
         Command::Pack { path } => {
             info!(&log, "Running pack command...");

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -26,3 +26,4 @@ pub static DANCERS: Emoji = Emoji("👯  ", "");
 pub static ERROR: Emoji = Emoji("⛔  ", "");
 pub static INFO: Emoji = Emoji("ℹ️  ", "");
 pub static WRENCH: Emoji = Emoji("🔧  ", "");
+pub static CHECK: Emoji = Emoji("✓  ", "");

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 //! Code related to error handling for wasm-pack
 use serde_json;
 use std::borrow::Cow;
-use std::io;
 use std::env;
+use std::io;
 use toml;
 
 /// Errors that can potentially occur in `wasm-pack`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,18 +44,18 @@ pub enum Error {
 
 impl Error {
     /// Construct a CLI error.
-    pub fn cli(message: &str, stderr: Cow<str>) -> Result<(), Self> {
-        Err(Error::Cli {
+    pub fn cli(message: &str, stderr: Cow<str>) -> Self {
+        Error::Cli {
             message: message.to_string(),
             stderr: stderr.to_string(),
-        })
+        }
     }
 
     /// Construct a crate configuration error.
-    pub fn crate_config(message: &str) -> Result<(), Self> {
-        Err(Error::CrateConfig {
+    pub fn crate_config(message: &str) -> Self {
+        Error::CrateConfig {
             message: message.to_string(),
-        })
+        }
     }
 
     /// Get a string description of this error's type.

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -11,7 +11,7 @@ pub fn npm_pack(path: &str) -> Result<(), Error> {
     let output = Command::new("npm").current_dir(path).arg("pack").output()?;
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Packaging up your code failed", s)
+        Err(Error::cli("Packaging up your code failed", s))
     } else {
         Ok(())
     }
@@ -25,7 +25,7 @@ pub fn npm_publish(path: &str) -> Result<(), Error> {
         .output()?;
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Publishing to npm failed", s)
+        Err(Error::cli("Publishing to npm failed", s))
     } else {
         Ok(())
     }
@@ -62,8 +62,9 @@ pub fn npm_login(
         .output()?;
 
     if !output.status.success() {
+        let message = format!("Login to registry {} failed", registry);
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli(&format!("Login to registry {} failed", registry), s)
+        Err(Error::cli(&message, s))
     } else {
         Ok(())
     }


### PR DESCRIPTION
Fixes #146. This aims to solve the issue of making sure that there is (a) a locally installed `wasm-bindgen` and (b) that it is the same version as specified in the `Cargo.toml` file.

As of now, there are still some rough edges that I want to hone down here. It seemed like a good idea to check in the existing work on this issue that I got done today, to make sure that I am headed in the right direction on this. Any feedback is totally welcome!

I'll also close #81 now, since I believe this will also take care of #51.

I should be able to get this all wrapped up tomorrow, had to spend a little more time than expected today getting up to speed with the changes that have occurred since then. Loving all the stuff people have contributed! :smile: 

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
