### PR TITLE
fix(mainfest): missing _bg.js file in package.json

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -71,6 +71,7 @@ impl CargoManifest {
     fn into_npm(mut self, scope: &Option<String>, disable_dts: bool) -> NpmPackage {
         let filename = self.package.name.replace("-", "_");
         let wasm_file = format!("{}_bg.wasm", filename);
+        let js_bg_file = format!("{}_bg.js", filename);
         let js_file = format!("{}.js", filename);
         let dts_file = if disable_dts == true {
             None
@@ -81,7 +82,7 @@ impl CargoManifest {
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
         }
-        let mut files = vec![wasm_file];
+        let mut files = vec![wasm_file, js_bg_file];
 
         match dts_file {
             Some(ref dts_file) => {

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -59,7 +59,10 @@ fn it_creates_a_package_json_default_path() {
         pkg.repository.url,
         "https://github.com/ashleygwilliams/wasm-pack.git"
     );
-    assert_eq!(pkg.files, ["wasm_pack_bg.wasm", "wasm_pack.d.ts"]);
+    assert_eq!(
+        pkg.files,
+        ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]
+    );
     assert_eq!(pkg.main, "wasm_pack.js");
     let types = pkg.types.unwrap_or_default();
     assert_eq!(types, "wasm_pack.d.ts");


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [ x] You ran `rustfmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
