### PR TITLE
Include *_bg.js wasm-bindgen outputs in package.json

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -72,6 +72,8 @@ impl CargoManifest {
         let filename = self.package.name.replace("-", "_");
         let wasm_file = format!("{}_bg.wasm", filename);
         let js_file = format!("{}.js", filename);
+        let bindgen_js_file = format!("{}_bg.js", filename);
+
         let dts_file = if disable_dts == true {
             None
         } else {
@@ -81,7 +83,7 @@ impl CargoManifest {
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
         }
-        let mut files = vec![wasm_file];
+        let mut files = vec![wasm_file, bindgen_js_file];
 
         match dts_file {
             Some(ref dts_file) => {

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -84,6 +84,8 @@ fn it_creates_a_package_json_provided_path() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "js-hello-world");
+    assert_eq!(pkg.main, "js_hello_world.js");
+
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
@@ -107,6 +109,7 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "@test/scopes-hello-world");
+    assert_eq!(pkg.main, "scopes_hello_world.js");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -84,6 +84,13 @@ fn it_creates_a_package_json_provided_path() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "js-hello-world");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = ["js_hello_world_bg.wasm", "js_hello_world_bg.js", "js_hello_world.d.ts"]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
+    assert_eq!(actual_files, expected_files);
 }
 
 #[test]
@@ -97,6 +104,13 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "@test/scopes-hello-world");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = ["scopes_hello_world_bg.wasm", "scopes_hello_world_bg.js", "scopes_hello_world.d.ts"]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
+    assert_eq!(actual_files, expected_files);
 }
 
 #[test]

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -65,12 +65,12 @@ fn it_creates_a_package_json_default_path() {
     assert_eq!(types, "wasm_pack.d.ts");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]
-        .iter()
-        .map(|&s| String::from(s))
-        .collect();
+    let expected_files: HashSet<String> =
+        ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]
+            .iter()
+            .map(|&s| String::from(s))
+            .collect();
     assert_eq!(actual_files, expected_files);
-
 }
 
 #[test]
@@ -86,8 +86,11 @@ fn it_creates_a_package_json_provided_path() {
     assert_eq!(pkg.name, "js-hello-world");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["js_hello_world_bg.wasm", "js_hello_world_bg.js", "js_hello_world.d.ts"]
-        .iter()
+    let expected_files: HashSet<String> = [
+        "js_hello_world_bg.wasm",
+        "js_hello_world_bg.js",
+        "js_hello_world.d.ts",
+    ].iter()
         .map(|&s| String::from(s))
         .collect();
     assert_eq!(actual_files, expected_files);
@@ -106,8 +109,11 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert_eq!(pkg.name, "@test/scopes-hello-world");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["scopes_hello_world_bg.wasm", "scopes_hello_world_bg.js", "scopes_hello_world.d.ts"]
-        .iter()
+    let expected_files: HashSet<String> = [
+        "scopes_hello_world_bg.wasm",
+        "scopes_hello_world_bg.js",
+        "scopes_hello_world.d.ts",
+    ].iter()
         .map(|&s| String::from(s))
         .collect();
     assert_eq!(actual_files, expected_files);

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -59,7 +59,7 @@ fn it_creates_a_package_json_default_path() {
         pkg.repository.url,
         "https://github.com/ashleygwilliams/wasm-pack.git"
     );
-    assert_eq!(pkg.files, ["wasm_pack_bg.wasm", "wasm_pack.d.ts"]);
+    assert_eq!(pkg.files, ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]);
     assert_eq!(pkg.main, "wasm_pack.js");
     let types = pkg.types.unwrap_or_default();
     assert_eq!(types, "wasm_pack.d.ts");

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -86,7 +86,6 @@ fn it_creates_a_package_json_provided_path() {
     assert_eq!(pkg.name, "js-hello-world");
     assert_eq!(pkg.main, "js_hello_world.js");
 
-
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
         "js_hello_world_bg.wasm",

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -6,6 +6,7 @@ extern crate wasm_pack;
 
 mod utils;
 
+use std::collections::HashSet;
 use std::fs;
 
 use wasm_pack::manifest;
@@ -59,10 +60,17 @@ fn it_creates_a_package_json_default_path() {
         pkg.repository.url,
         "https://github.com/ashleygwilliams/wasm-pack.git"
     );
-    assert_eq!(pkg.files, ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]);
     assert_eq!(pkg.main, "wasm_pack.js");
     let types = pkg.types.unwrap_or_default();
     assert_eq!(types, "wasm_pack.d.ts");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
+    assert_eq!(actual_files, expected_files);
+
 }
 
 #[test]


### PR DESCRIPTION
Fixes #199!

As @ashleygwilliams suggested, I updated the manifest module to add the `*_bg.js`-qualified output in `package.json`'s `files` attribute. I updated existing tests to expect the new file. I added a few other asserts in existing tests to expect the files in `package.json`.

I came upon this issue after taking a `wasm-pack pack` output and using it in a new node project. Would we want an automated test to make sure that use-case always works? I'm not sure what that kind of test might look like, but if we feel its valuable I'd be happy to dig deeper!

I haven't looked into how this issue came to be. Did something change in `wasm-bindgen`; would our solution here be sufficient for any future changes? If there's a need, I'd be happy to help build a more resilient fix.

Thanks for all of your help and effort in building `wasm-pack`!

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
