### PR TITLE
fix files behavior on node, and generally remove redundancy in the files key

### DIFF
--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -161,7 +161,13 @@ impl Init {
 
     fn step_create_json(&mut self, step: &Step, log: &Logger) -> Result<(), Error> {
         info!(&log, "Writing a package.json...");
-        manifest::write_package_json(&self.crate_path, &self.scope, self.disable_dts, &self.target, step)?;
+        manifest::write_package_json(
+            &self.crate_path,
+            &self.scope,
+            self.disable_dts,
+            &self.target,
+            step,
+        )?;
         #[cfg(not(target_os = "windows"))]
         info!(
             &log,

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -161,7 +161,7 @@ impl Init {
 
     fn step_create_json(&mut self, step: &Step, log: &Logger) -> Result<(), Error> {
         info!(&log, "Writing a package.json...");
-        manifest::write_package_json(&self.crate_path, &self.scope, self.disable_dts, step)?;
+        manifest::write_package_json(&self.crate_path, &self.scope, self.disable_dts, &self.target, step)?;
         #[cfg(not(target_os = "windows"))]
         info!(
             &log,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -72,6 +72,8 @@ impl CargoManifest {
         let filename = self.package.name.replace("-", "_");
         let wasm_file = format!("{}_bg.wasm", filename);
         let js_file = format!("{}.js", filename);
+        let bindgen_js_file = format!("{}_bg.js", filename);
+
         let dts_file = if disable_dts == true {
             None
         } else {
@@ -81,7 +83,7 @@ impl CargoManifest {
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
         }
-        let mut files = vec![wasm_file];
+        let mut files = vec![wasm_file, bindgen_js_file];
 
         match dts_file {
             Some(ref dts_file) => {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -80,9 +80,9 @@ impl CargoManifest {
         };
 
         let js_bg_file = if target == "nodejs" {
-          Some(format!("{}_bg.js", filename))
+            Some(format!("{}_bg.js", filename))
         } else {
-          None
+            None
         };
 
         if let Some(s) = scope {
@@ -98,10 +98,10 @@ impl CargoManifest {
         }
 
         match js_bg_file {
-          Some(ref js_bg_file) => {
-            files.push(js_bg_file.to_string());
-          }
-          None => {}
+            Some(ref js_bg_file) => {
+                files.push(js_bg_file.to_string());
+            }
+            None => {}
         }
 
         NpmPackage {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -68,11 +68,10 @@ fn read_cargo_toml(path: &str) -> Result<CargoManifest, Error> {
 }
 
 impl CargoManifest {
-    fn into_npm(mut self, scope: &Option<String>, disable_dts: bool) -> NpmPackage {
+    fn into_npm(mut self, scope: &Option<String>, disable_dts: bool, target: &str) -> NpmPackage {
         let filename = self.package.name.replace("-", "_");
         let wasm_file = format!("{}_bg.wasm", filename);
         let js_file = format!("{}.js", filename);
-        let bindgen_js_file = format!("{}_bg.js", filename);
 
         let dts_file = if disable_dts == true {
             None
@@ -80,16 +79,29 @@ impl CargoManifest {
             Some(format!("{}.d.ts", filename))
         };
 
+        let js_bg_file = if target == "nodejs" {
+          Some(format!("{}_bg.js", filename))
+        } else {
+          None
+        };
+
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
         }
-        let mut files = vec![wasm_file, bindgen_js_file];
+        let mut files = vec![wasm_file];
 
         match dts_file {
             Some(ref dts_file) => {
                 files.push(dts_file.to_string());
             }
             None => {}
+        }
+
+        match js_bg_file {
+          Some(ref js_bg_file) => {
+            files.push(js_bg_file.to_string());
+          }
+          None => {}
         }
 
         NpmPackage {
@@ -114,6 +126,7 @@ pub fn write_package_json(
     path: &str,
     scope: &Option<String>,
     disable_dts: bool,
+    target: &str,
     step: &Step,
 ) -> Result<(), Error> {
     let msg = format!("{}Writing a package.json...", emoji::MEMO);
@@ -129,7 +142,7 @@ pub fn write_package_json(
     let pkg_file_path = format!("{}/pkg/package.json", path);
     let mut pkg_file = File::create(pkg_file_path)?;
     let crate_data = read_cargo_toml(path)?;
-    let npm_data = crate_data.into_npm(scope, disable_dts);
+    let npm_data = crate_data.into_npm(scope, disable_dts, target);
 
     if npm_data.description.is_none() {
         PBAR.warn(&warn_fmt("description"));

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -84,6 +84,8 @@ fn it_creates_a_package_json_provided_path() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "js-hello-world");
+    assert_eq!(pkg.main, "js_hello_world.js");
+
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
@@ -107,6 +109,7 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "@test/scopes-hello-world");
+    assert_eq!(pkg.main, "scopes_hello_world.js");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -84,6 +84,13 @@ fn it_creates_a_package_json_provided_path() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "js-hello-world");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = ["js_hello_world_bg.wasm", "js_hello_world_bg.js", "js_hello_world.d.ts"]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
+    assert_eq!(actual_files, expected_files);
 }
 
 #[test]
@@ -97,6 +104,13 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
     assert_eq!(pkg.name, "@test/scopes-hello-world");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = ["scopes_hello_world_bg.wasm", "scopes_hello_world_bg.js", "scopes_hello_world.d.ts"]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
+    assert_eq!(actual_files, expected_files);
 }
 
 #[test]

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -65,12 +65,12 @@ fn it_creates_a_package_json_default_path() {
     assert_eq!(types, "wasm_pack.d.ts");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]
-        .iter()
-        .map(|&s| String::from(s))
-        .collect();
+    let expected_files: HashSet<String> =
+        ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]
+            .iter()
+            .map(|&s| String::from(s))
+            .collect();
     assert_eq!(actual_files, expected_files);
-
 }
 
 #[test]
@@ -86,8 +86,11 @@ fn it_creates_a_package_json_provided_path() {
     assert_eq!(pkg.name, "js-hello-world");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["js_hello_world_bg.wasm", "js_hello_world_bg.js", "js_hello_world.d.ts"]
-        .iter()
+    let expected_files: HashSet<String> = [
+        "js_hello_world_bg.wasm",
+        "js_hello_world_bg.js",
+        "js_hello_world.d.ts",
+    ].iter()
         .map(|&s| String::from(s))
         .collect();
     assert_eq!(actual_files, expected_files);
@@ -106,8 +109,11 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert_eq!(pkg.name, "@test/scopes-hello-world");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["scopes_hello_world_bg.wasm", "scopes_hello_world_bg.js", "scopes_hello_world.d.ts"]
-        .iter()
+    let expected_files: HashSet<String> = [
+        "scopes_hello_world_bg.wasm",
+        "scopes_hello_world_bg.js",
+        "scopes_hello_world.d.ts",
+    ].iter()
         .map(|&s| String::from(s))
         .collect();
     assert_eq!(actual_files, expected_files);

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -49,7 +49,82 @@ fn it_creates_a_package_json_default_path() {
     let step = wasm_pack::progressbar::Step::new(1);
     let path = ".".to_string();
     wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
-    assert!(manifest::write_package_json(&path, &None, false, &step).is_ok());
+    assert!(manifest::write_package_json(&path, &None, false, "", &step).is_ok());
+    let package_json_path = format!("{}/pkg/package.json", &path);
+    assert!(fs::metadata(package_json_path).is_ok());
+    assert!(utils::read_package_json(&path).is_ok());
+    let pkg = utils::read_package_json(&path).unwrap();
+    assert_eq!(pkg.name, "wasm-pack");
+    assert_eq!(pkg.repository.ty, "git");
+    assert_eq!(
+        pkg.repository.url,
+        "https://github.com/ashleygwilliams/wasm-pack.git"
+    );
+    assert_eq!(pkg.main, "wasm_pack.js");
+    let types = pkg.types.unwrap_or_default();
+    assert_eq!(types, "wasm_pack.d.ts");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> =
+        ["wasm_pack_bg.wasm", "wasm_pack.d.ts"]
+            .iter()
+            .map(|&s| String::from(s))
+            .collect();
+    assert_eq!(actual_files, expected_files);
+}
+
+#[test]
+fn it_creates_a_package_json_provided_path() {
+    let step = wasm_pack::progressbar::Step::new(1);
+    let path = "tests/fixtures/js-hello-world".to_string();
+    wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
+    assert!(manifest::write_package_json(&path, &None, false, "",  &step).is_ok());
+    let package_json_path = format!("{}/pkg/package.json", &path);
+    assert!(fs::metadata(package_json_path).is_ok());
+    assert!(utils::read_package_json(&path).is_ok());
+    let pkg = utils::read_package_json(&path).unwrap();
+    assert_eq!(pkg.name, "js-hello-world");
+    assert_eq!(pkg.main, "js_hello_world.js");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = [
+        "js_hello_world_bg.wasm",
+        "js_hello_world.d.ts",
+    ].iter()
+        .map(|&s| String::from(s))
+        .collect();
+    assert_eq!(actual_files, expected_files);
+}
+
+#[test]
+fn it_creates_a_package_json_provided_path_with_scope() {
+    let step = wasm_pack::progressbar::Step::new(1);
+    let path = "tests/fixtures/scopes".to_string();
+    wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
+    assert!(manifest::write_package_json(&path, &Some("test".to_string()), false, "", &step).is_ok());
+    let package_json_path = format!("{}/pkg/package.json", &path);
+    assert!(fs::metadata(package_json_path).is_ok());
+    assert!(utils::read_package_json(&path).is_ok());
+    let pkg = utils::read_package_json(&path).unwrap();
+    assert_eq!(pkg.name, "@test/scopes-hello-world");
+    assert_eq!(pkg.main, "scopes_hello_world.js");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = [
+        "scopes_hello_world_bg.wasm",
+        "scopes_hello_world.d.ts",
+    ].iter()
+        .map(|&s| String::from(s))
+        .collect();
+    assert_eq!(actual_files, expected_files);
+}
+
+#[test]
+fn it_creates_a_pkg_json_with_correct_files_on_node() {
+    let step = wasm_pack::progressbar::Step::new(1);
+    let path = ".".to_string();
+    wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
+    assert!(manifest::write_package_json(&path, &None, false, "nodejs", &step).is_ok());
     let package_json_path = format!("{}/pkg/package.json", &path);
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
@@ -70,54 +145,6 @@ fn it_creates_a_package_json_default_path() {
             .iter()
             .map(|&s| String::from(s))
             .collect();
-    assert_eq!(actual_files, expected_files);
-}
-
-#[test]
-fn it_creates_a_package_json_provided_path() {
-    let step = wasm_pack::progressbar::Step::new(1);
-    let path = "tests/fixtures/js-hello-world".to_string();
-    wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
-    assert!(manifest::write_package_json(&path, &None, false, &step).is_ok());
-    let package_json_path = format!("{}/pkg/package.json", &path);
-    assert!(fs::metadata(package_json_path).is_ok());
-    assert!(utils::read_package_json(&path).is_ok());
-    let pkg = utils::read_package_json(&path).unwrap();
-    assert_eq!(pkg.name, "js-hello-world");
-    assert_eq!(pkg.main, "js_hello_world.js");
-
-    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = [
-        "js_hello_world_bg.wasm",
-        "js_hello_world_bg.js",
-        "js_hello_world.d.ts",
-    ].iter()
-        .map(|&s| String::from(s))
-        .collect();
-    assert_eq!(actual_files, expected_files);
-}
-
-#[test]
-fn it_creates_a_package_json_provided_path_with_scope() {
-    let step = wasm_pack::progressbar::Step::new(1);
-    let path = "tests/fixtures/scopes".to_string();
-    wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
-    assert!(manifest::write_package_json(&path, &Some("test".to_string()), false, &step).is_ok());
-    let package_json_path = format!("{}/pkg/package.json", &path);
-    assert!(fs::metadata(package_json_path).is_ok());
-    assert!(utils::read_package_json(&path).is_ok());
-    let pkg = utils::read_package_json(&path).unwrap();
-    assert_eq!(pkg.name, "@test/scopes-hello-world");
-    assert_eq!(pkg.main, "scopes_hello_world.js");
-
-    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = [
-        "scopes_hello_world_bg.wasm",
-        "scopes_hello_world_bg.js",
-        "scopes_hello_world.d.ts",
-    ].iter()
-        .map(|&s| String::from(s))
-        .collect();
     assert_eq!(actual_files, expected_files);
 }
 

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -149,6 +149,33 @@ fn it_creates_a_pkg_json_with_correct_files_on_node() {
 }
 
 #[test]
+fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
+    let step = wasm_pack::progressbar::Step::new(1);
+    let path = ".".to_string();
+    wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
+    assert!(manifest::write_package_json(&path, &None, true, "", &step).is_ok());
+    let package_json_path = format!("{}/pkg/package.json", &path);
+    assert!(fs::metadata(package_json_path).is_ok());
+    assert!(utils::read_package_json(&path).is_ok());
+    let pkg = utils::read_package_json(&path).unwrap();
+    assert_eq!(pkg.name, "wasm-pack");
+    assert_eq!(pkg.repository.ty, "git");
+    assert_eq!(
+        pkg.repository.url,
+        "https://github.com/ashleygwilliams/wasm-pack.git"
+    );
+    assert_eq!(pkg.main, "wasm_pack.js");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> =
+        ["wasm_pack_bg.wasm"]
+            .iter()
+            .map(|&s| String::from(s))
+            .collect();
+    assert_eq!(actual_files, expected_files);
+}
+
+#[test]
 fn it_errors_when_wasm_bindgen_is_not_declared() {
     let step = wasm_pack::progressbar::Step::new(1);
     assert!(manifest::check_crate_config("tests/fixtures/bad-cargo-toml", &step).is_err());

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -59,7 +59,7 @@ fn it_creates_a_package_json_default_path() {
         pkg.repository.url,
         "https://github.com/ashleygwilliams/wasm-pack.git"
     );
-    assert_eq!(pkg.files, ["wasm_pack_bg.wasm", "wasm_pack.d.ts"]);
+    assert_eq!(pkg.files, ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]);
     assert_eq!(pkg.main, "wasm_pack.js");
     let types = pkg.types.unwrap_or_default();
     assert_eq!(types, "wasm_pack.d.ts");

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -86,7 +86,6 @@ fn it_creates_a_package_json_provided_path() {
     assert_eq!(pkg.name, "js-hello-world");
     assert_eq!(pkg.main, "js_hello_world.js");
 
-
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
         "js_hello_world_bg.wasm",

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -6,6 +6,7 @@ extern crate wasm_pack;
 
 mod utils;
 
+use std::collections::HashSet;
 use std::fs;
 
 use wasm_pack::manifest;
@@ -59,10 +60,17 @@ fn it_creates_a_package_json_default_path() {
         pkg.repository.url,
         "https://github.com/ashleygwilliams/wasm-pack.git"
     );
-    assert_eq!(pkg.files, ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]);
     assert_eq!(pkg.main, "wasm_pack.js");
     let types = pkg.types.unwrap_or_default();
     assert_eq!(types, "wasm_pack.d.ts");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = ["wasm_pack_bg.wasm", "wasm_pack_bg.js", "wasm_pack.d.ts"]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
+    assert_eq!(actual_files, expected_files);
+
 }
 
 #[test]

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -65,11 +65,10 @@ fn it_creates_a_package_json_default_path() {
     assert_eq!(types, "wasm_pack.d.ts");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> =
-        ["wasm_pack_bg.wasm", "wasm_pack.d.ts"]
-            .iter()
-            .map(|&s| String::from(s))
-            .collect();
+    let expected_files: HashSet<String> = ["wasm_pack_bg.wasm", "wasm_pack.d.ts"]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
     assert_eq!(actual_files, expected_files);
 }
 
@@ -78,7 +77,7 @@ fn it_creates_a_package_json_provided_path() {
     let step = wasm_pack::progressbar::Step::new(1);
     let path = "tests/fixtures/js-hello-world".to_string();
     wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
-    assert!(manifest::write_package_json(&path, &None, false, "",  &step).is_ok());
+    assert!(manifest::write_package_json(&path, &None, false, "", &step).is_ok());
     let package_json_path = format!("{}/pkg/package.json", &path);
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
@@ -87,10 +86,8 @@ fn it_creates_a_package_json_provided_path() {
     assert_eq!(pkg.main, "js_hello_world.js");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = [
-        "js_hello_world_bg.wasm",
-        "js_hello_world.d.ts",
-    ].iter()
+    let expected_files: HashSet<String> = ["js_hello_world_bg.wasm", "js_hello_world.d.ts"]
+        .iter()
         .map(|&s| String::from(s))
         .collect();
     assert_eq!(actual_files, expected_files);
@@ -101,7 +98,9 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     let step = wasm_pack::progressbar::Step::new(1);
     let path = "tests/fixtures/scopes".to_string();
     wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
-    assert!(manifest::write_package_json(&path, &Some("test".to_string()), false, "", &step).is_ok());
+    assert!(
+        manifest::write_package_json(&path, &Some("test".to_string()), false, "", &step).is_ok()
+    );
     let package_json_path = format!("{}/pkg/package.json", &path);
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
@@ -110,10 +109,8 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert_eq!(pkg.main, "scopes_hello_world.js");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = [
-        "scopes_hello_world_bg.wasm",
-        "scopes_hello_world.d.ts",
-    ].iter()
+    let expected_files: HashSet<String> = ["scopes_hello_world_bg.wasm", "scopes_hello_world.d.ts"]
+        .iter()
         .map(|&s| String::from(s))
         .collect();
     assert_eq!(actual_files, expected_files);
@@ -167,11 +164,10 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
     assert_eq!(pkg.main, "wasm_pack.js");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> =
-        ["wasm_pack_bg.wasm"]
-            .iter()
-            .map(|&s| String::from(s))
-            .collect();
+    let expected_files: HashSet<String> = ["wasm_pack_bg.wasm"]
+        .iter()
+        .map(|&s| String::from(s))
+        .collect();
     assert_eq!(actual_files, expected_files);
 }
 


### PR DESCRIPTION
fixes #199 (FOR REAL THIS TIME)

this PR does several things:
- passes the value of the target flag to the `write_package_json` method
- optionally includes a `_bg.js` file in the `files` key if the `target` is `nodejs`
- updates `files` key to NOT include the file in `main` (it is unecessary)
- adds a test to ensure correct behavior on node
- cleans up tests to test for correct `files` key