### PR TITLE
Use PathBuf instead of String to handle paths

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -3,6 +3,7 @@
 use emoji;
 use error::Error;
 use progressbar::Step;
+use std::path::Path;
 use std::process::Command;
 use PBAR;
 
@@ -30,7 +31,7 @@ pub fn cargo_install_wasm_bindgen(step: &Step) -> Result<(), Error> {
 /// Run the `wasm-bindgen` CLI to generate bindings for the current crate's
 /// `.wasm`.
 pub fn wasm_bindgen_build(
-    path: &str,
+    path: &Path,
     name: &str,
     disable_dts: bool,
     target: &str,

--- a/src/build.rs
+++ b/src/build.rs
@@ -3,6 +3,7 @@
 use emoji;
 use error::Error;
 use progressbar::Step;
+use std::path::Path;
 use std::process::Command;
 use PBAR;
 
@@ -46,7 +47,7 @@ fn ensure_nightly() -> Result<(), Error> {
 
 /// Run `cargo build` with the `nightly` toolchain and targetting
 /// `wasm32-unknown-unknown`.
-pub fn cargo_build_wasm(path: &str, debug: bool, step: &Step) -> Result<(), Error> {
+pub fn cargo_build_wasm(path: &Path, debug: bool, step: &Step) -> Result<(), Error> {
     let msg = format!("{}Compiling to WASM...", emoji::CYCLONE);
     PBAR.step(step, &msg);
     let output = {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -12,6 +12,7 @@ use self::pack::pack;
 use self::publish::publish;
 use error::Error;
 use slog::Logger;
+use std::path::PathBuf;
 use std::result;
 use PBAR;
 
@@ -22,7 +23,8 @@ pub enum Command {
     /// 🐣  initialize a package.json based on your compiled wasm!
     Init {
         /// The path to the Rust crate.
-        path: Option<String>,
+        #[structopt(parse(from_os_str))]
+        path: Option<PathBuf>,
 
         /// The npm scope to use in package.json, if any.
         #[structopt(long = "scope", short = "s")]
@@ -49,15 +51,17 @@ pub enum Command {
     #[structopt(name = "pack")]
     /// 🍱  create a tar of your npm package but don't publish!
     Pack {
-        /// The path to the Rust crate.
-        path: Option<String>,
+        /// The path to the Rust crate.  
+        #[structopt(parse(from_os_str))]
+        path: Option<PathBuf>,
     },
 
     #[structopt(name = "publish")]
     /// 🎆  pack up your npm package and publish!
     Publish {
         /// The path to the Rust crate.
-        path: Option<String>,
+        #[structopt(parse(from_os_str))]
+        path: Option<PathBuf>,
     },
 
     #[structopt(name = "login", alias = "adduser", alias = "add-user")]

--- a/src/command/pack.rs
+++ b/src/command/pack.rs
@@ -14,7 +14,7 @@ pub fn pack(path: Option<PathBuf>, log: &Logger) -> result::Result<(), Error> {
     info!(&log, "Packing up the npm package...");
     let pkg_directory = find_pkg_directory(&crate_path).ok_or(Error::PkgNotFound {
         message: format!(
-            "Unable to find the pkg directory at path {:?}, or in a child directory of {:?}",
+            "Unable to find the pkg directory at path {:#?}, or in a child directory of {:#?}",
             &crate_path, &crate_path
         ),
     })?;

--- a/src/command/pack.rs
+++ b/src/command/pack.rs
@@ -14,7 +14,7 @@ pub fn pack(path: Option<PathBuf>, log: &Logger) -> result::Result<(), Error> {
     info!(&log, "Packing up the npm package...");
     let pkg_directory = find_pkg_directory(&crate_path).ok_or(Error::PkgNotFound {
         message: format!(
-            "Unable to find the pkg directory at path {:?}', or in a child directory of {:?}",
+            "Unable to find the pkg directory at path {:?}, or in a child directory of {:?}",
             &crate_path, &crate_path
         ),
     })?;

--- a/src/command/pack.rs
+++ b/src/command/pack.rs
@@ -2,26 +2,28 @@ use command::utils::{find_pkg_directory, set_crate_path};
 use error::Error;
 use npm;
 use slog::Logger;
+use std::path::PathBuf;
 use std::result;
 use PBAR;
 
 /// Executes the 'npm pack' command on the 'pkg' directory
 /// which creates a tarball that can be published to the NPM registry
-pub fn pack(path: Option<String>, log: &Logger) -> result::Result<(), Error> {
+pub fn pack(path: Option<PathBuf>, log: &Logger) -> result::Result<(), Error> {
     let crate_path = set_crate_path(path);
 
     info!(&log, "Packing up the npm package...");
     let pkg_directory = find_pkg_directory(&crate_path).ok_or(Error::PkgNotFound {
         message: format!(
-            "Unable to find the pkg directory at path '{}', or in a child directory of '{}'",
+            "Unable to find the pkg directory at path {:?}', or in a child directory of {:?}",
             &crate_path, &crate_path
         ),
     })?;
     npm::npm_pack(&pkg_directory.to_string_lossy())?;
-    #[cfg(not(target_os = "windows"))]
-    info!(&log, "Your package is located at {}/pkg", &crate_path);
-    #[cfg(target_os = "windows")]
-    info!(&log, "Your package is located at {}\\pkg", &crate_path);
+    info!(
+        &log,
+        "Your package is located at {:#?}",
+        crate_path.join("pkg")
+    );
 
     PBAR.message("🎒  packed up your package!");
     Ok(())

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -2,19 +2,20 @@ use command::utils::{find_pkg_directory, set_crate_path};
 use error::Error;
 use npm;
 use slog::Logger;
+use std::path::PathBuf;
 use std::result;
 use PBAR;
 
 /// Creates a tarball from a 'pkg' directory
 /// and publishes it to the NPM registry
-pub fn publish(path: Option<String>, log: &Logger) -> result::Result<(), Error> {
+pub fn publish(path: Option<PathBuf>, log: &Logger) -> result::Result<(), Error> {
     let crate_path = set_crate_path(path);
 
     info!(&log, "Publishing the npm package...");
     info!(&log, "npm info located in the npm debug log");
     let pkg_directory = find_pkg_directory(&crate_path).ok_or(Error::PkgNotFound {
         message: format!(
-            "Unable to find the pkg directory at path '{}', or in a child directory of '{}'",
+            "Unable to find the pkg directory at path '{:#?}', or in a child directory of '{:#?}'",
             &crate_path, &crate_path
         ),
     })?;

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 
 /// If an explicit path is given, then use it, otherwise assume the current
 /// directory is the crate path.
-pub fn set_crate_path(path: Option<String>) -> String {
+pub fn set_crate_path(path: Option<PathBuf>) -> PathBuf {
     let crate_path = match path {
         Some(p) => p,
-        None => ".".to_string(),
+        None => PathBuf::from("."),
     };
 
     crate_path
@@ -15,10 +15,9 @@ pub fn set_crate_path(path: Option<String>) -> String {
 
 /// Locates the pkg directory from a specific path
 /// Returns None if unable to find the 'pkg' directory
-pub fn find_pkg_directory(guess_path: &str) -> Option<PathBuf> {
-    let path = PathBuf::from(guess_path);
-    if is_pkg_directory(&path) {
-        return Some(path);
+pub fn find_pkg_directory(path: &Path) -> Option<PathBuf> {
+    if is_pkg_directory(path) {
+        return Some(path.to_owned());
     }
 
     path.read_dir().ok().and_then(|entries| {

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -2,17 +2,18 @@
 
 use error::Error;
 use std::fs;
+use std::path::Path;
 
 use emoji;
 use progressbar::Step;
 use PBAR;
 
 /// Copy the crate's README into the `pkg` directory.
-pub fn copy_from_crate(path: &str, step: &Step) -> Result<(), Error> {
+pub fn copy_from_crate(path: &Path, step: &Step) -> Result<(), Error> {
     let msg = format!("{}Copying over your README...", emoji::DANCERS);
     PBAR.step(step, &msg);
-    let crate_readme_path = format!("{}/README.md", path);
-    let new_readme_path = format!("{}/pkg/README.md", path);
+    let crate_readme_path = path.join("README.md");
+    let new_readme_path = path.join("pkg").join("README.md");
     if let Err(_) = fs::copy(&crate_readme_path, &new_readme_path) {
         PBAR.warn("origin crate has no README");
     };

--- a/tests/manifest/main.rs
+++ b/tests/manifest/main.rs
@@ -8,49 +8,55 @@ mod utils;
 
 use std::collections::HashSet;
 use std::fs;
+use std::path::PathBuf;
 
 use wasm_pack::manifest;
 
 #[test]
 fn it_gets_the_crate_name_default_path() {
-    assert!(manifest::get_crate_name(".").is_ok());
-    assert_eq!(manifest::get_crate_name(".").unwrap(), "wasm-pack");
+    let path = &PathBuf::from(".");
+    assert!(manifest::get_crate_name(path).is_ok());
+    assert_eq!(manifest::get_crate_name(path).unwrap(), "wasm-pack");
 }
 
 #[test]
 fn it_gets_the_crate_name_provided_path() {
-    assert!(manifest::get_crate_name("tests/fixtures/js-hello-world").is_ok());
-    assert_eq!(
-        manifest::get_crate_name("tests/fixtures/js-hello-world").unwrap(),
-        "js-hello-world"
-    );
+    let path = &PathBuf::from("tests/fixtures/js-hello-world");
+    assert!(manifest::get_crate_name(path).is_ok());
+    assert_eq!(manifest::get_crate_name(path).unwrap(), "js-hello-world");
 }
 
 #[test]
 fn it_checks_has_cdylib_default_path() {
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(manifest::check_crate_config(".", &step).is_err());
+    assert!(manifest::check_crate_config(&PathBuf::from("."), &step).is_err());
 }
 
 #[test]
 fn it_checks_has_cdylib_provided_path() {
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(manifest::check_crate_config("tests/fixtures/js-hello-world", &step).is_ok());
+    assert!(
+        manifest::check_crate_config(&PathBuf::from("tests/fixtures/js-hello-world"), &step)
+            .is_ok()
+    );
 }
 
 #[test]
 fn it_checks_has_cdylib_wrong_crate_type() {
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(manifest::check_crate_config("tests/fixtures/bad-cargo-toml", &step).is_err());
+    assert!(
+        manifest::check_crate_config(&PathBuf::from("tests/fixtures/bad-cargo-toml"), &step)
+            .is_err()
+    );
 }
 
 #[test]
 fn it_creates_a_package_json_default_path() {
     let step = wasm_pack::progressbar::Step::new(1);
-    let path = ".".to_string();
+    let path = PathBuf::from(".");
     wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
     assert!(manifest::write_package_json(&path, &None, false, "", &step).is_ok());
-    let package_json_path = format!("{}/pkg/package.json", &path);
+    let package_json_path = &path.join("pkg").join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
@@ -75,10 +81,10 @@ fn it_creates_a_package_json_default_path() {
 #[test]
 fn it_creates_a_package_json_provided_path() {
     let step = wasm_pack::progressbar::Step::new(1);
-    let path = "tests/fixtures/js-hello-world".to_string();
+    let path = PathBuf::from("tests/fixtures/js-hello-world");
     wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
     assert!(manifest::write_package_json(&path, &None, false, "", &step).is_ok());
-    let package_json_path = format!("{}/pkg/package.json", &path);
+    let package_json_path = &path.join("pkg").join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
@@ -96,12 +102,12 @@ fn it_creates_a_package_json_provided_path() {
 #[test]
 fn it_creates_a_package_json_provided_path_with_scope() {
     let step = wasm_pack::progressbar::Step::new(1);
-    let path = "tests/fixtures/scopes".to_string();
+    let path = PathBuf::from("tests/fixtures/scopes");
     wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
     assert!(
         manifest::write_package_json(&path, &Some("test".to_string()), false, "", &step).is_ok()
     );
-    let package_json_path = format!("{}/pkg/package.json", &path);
+    let package_json_path = &path.join("pkg").join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
@@ -119,10 +125,10 @@ fn it_creates_a_package_json_provided_path_with_scope() {
 #[test]
 fn it_creates_a_pkg_json_with_correct_files_on_node() {
     let step = wasm_pack::progressbar::Step::new(1);
-    let path = ".".to_string();
+    let path = PathBuf::from(".");
     wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
     assert!(manifest::write_package_json(&path, &None, false, "nodejs", &step).is_ok());
-    let package_json_path = format!("{}/pkg/package.json", &path);
+    let package_json_path = &path.join("pkg").join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
@@ -148,10 +154,10 @@ fn it_creates_a_pkg_json_with_correct_files_on_node() {
 #[test]
 fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
     let step = wasm_pack::progressbar::Step::new(1);
-    let path = ".".to_string();
+    let path = PathBuf::from(".");
     wasm_pack::command::init::create_pkg_dir(&path, &step).unwrap();
     assert!(manifest::write_package_json(&path, &None, true, "", &step).is_ok());
-    let package_json_path = format!("{}/pkg/package.json", &path);
+    let package_json_path = &path.join("pkg").join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::read_package_json(&path).is_ok());
     let pkg = utils::read_package_json(&path).unwrap();
@@ -174,11 +180,15 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
 #[test]
 fn it_errors_when_wasm_bindgen_is_not_declared() {
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(manifest::check_crate_config("tests/fixtures/bad-cargo-toml", &step).is_err());
+    assert!(
+        manifest::check_crate_config(&PathBuf::from("tests/fixtures/bad-cargo-toml"), &step)
+            .is_err()
+    );
 }
 
 #[test]
 fn it_does_not_error_when_wasm_bindgen_is_declared() {
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(manifest::check_crate_config("tests/fixtures/js-hello-world", &step).is_ok());
+    let path = PathBuf::from("tests/fixtures/js-hello-world");
+    assert!(manifest::check_crate_config(&path, &step).is_ok());
 }

--- a/tests/manifest/utils.rs
+++ b/tests/manifest/utils.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::prelude::*;
+use std::path::Path;
 
 use failure::Error;
 use serde_json;
@@ -23,8 +24,8 @@ pub struct Repository {
     pub url: String,
 }
 
-pub fn read_package_json(path: &str) -> Result<NpmPackage, Error> {
-    let manifest_path = format!("{}/pkg/package.json", path);
+pub fn read_package_json(path: &Path) -> Result<NpmPackage, Error> {
+    let manifest_path = path.join("pkg").join("package.json");
     let mut pkg_file = File::open(manifest_path)?;
     let mut pkg_contents = String::new();
     pkg_file.read_to_string(&mut pkg_contents)?;

--- a/tests/readme/main.rs
+++ b/tests/readme/main.rs
@@ -4,16 +4,17 @@ extern crate wasm_pack;
 mod utils;
 
 use std::fs;
+use std::path::PathBuf;
 
 use wasm_pack::readme;
 
 #[test]
 fn it_copies_a_readme_default_path() {
     let step = wasm_pack::progressbar::Step::new(1);
-    let path = ".".to_string();
+    let path = PathBuf::from(".");
     assert!(readme::copy_from_crate(&path, &step).is_ok());
-    let crate_readme_path = format!("{}/README.md", &path);
-    let pkg_readme_path = format!("{}/pkg/README.md", &path);
+    let crate_readme_path = &path.join("README.md");
+    let pkg_readme_path = &path.join("pkg").join("README.md");
     assert!(fs::metadata(&pkg_readme_path).is_ok());
     let crate_readme = utils::read_file(&crate_readme_path).unwrap();
     let pkg_readme = utils::read_file(&pkg_readme_path).unwrap();
@@ -23,10 +24,10 @@ fn it_copies_a_readme_default_path() {
 #[test]
 fn it_creates_a_package_json_provided_path() {
     let step = wasm_pack::progressbar::Step::new(1);
-    let path = "tests/fixtures/js-hello-world".to_string();
+    let path = PathBuf::from("tests/fixtures/js-hello-world");
     assert!(readme::copy_from_crate(&path, &step).is_ok());
-    let crate_readme_path = format!("{}/README.md", &path);
-    let pkg_readme_path = format!("{}/pkg/README.md", &path);
+    let crate_readme_path = &path.join("README.md");
+    let pkg_readme_path = &path.join("pkg").join("README.md");
     assert!(fs::metadata(&pkg_readme_path).is_ok());
     let crate_readme = utils::read_file(&crate_readme_path).unwrap();
     let pkg_readme = utils::read_file(&pkg_readme_path).unwrap();

--- a/tests/readme/utils.rs
+++ b/tests/readme/utils.rs
@@ -1,9 +1,9 @@
+use failure::Error;
 use std::fs::File;
 use std::io::Read;
+use std::path::Path;
 
-use failure::Error;
-
-pub fn read_file(path: &str) -> Result<String, Error> {
+pub fn read_file(path: &Path) -> Result<String, Error> {
     let mut file = File::open(path)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;


### PR DESCRIPTION
I think this is it. I want to take another look tomorrow to validate that I didn't miss something.

Fixes #213 

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
