### PR TITLE
greenkeeper is not a bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ This tool seeks to be a one-stop shop for building and working with rust-
 generated WebAssembly that you would like to interop with JavaScript, in the
 browser or with Node.js. `wasm-pack` helps you build and publish rust-generated
 WebAssembly to the npm registry to be used alongside any other javascript
-package in workflows that you already use, such as a bundler like
-[webpack] or [greenkeeper].
+package in workflows that you already use, such as [webpack] or [greenkeeper].
 
 [bundler-support]: https://github.com/rustwasm/team/blob/master/goals/bundler-integration.md#details
 [webpack]: https://webpack.js.org/


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ ] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [ ] You ran `rustfmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
