### PR TITLE
fix(doc): fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ visiting that repo!
 
 ## 🎙️ Commands
 
-- [`init`](docs/init.md): Generate an npm wasm pkg from a rustwasm crate
-- [`build`](docs/build.md): Generate an npm wasm pkg from a rustwasm crate
-- [`pack` and `publish`](docs/pack-and-publish.md): Create a tarball of your rustwasm pkg and/or publish to a registry
+- [`build`](docs/src/commands/build.md): Generate an npm wasm pkg from a rustwasm crate
+- [`pack` and `publish`](docs/src/commands/pack-and-publish.md): Create a tarball of your rustwasm pkg and/or publish to a registry
 
 ## 📝 Logging
 
@@ -49,7 +48,7 @@ customize the log verbosity using the verbosity flag.
 Read our [guide] on getting up and running for developing `wasm-pack`, and
 check out our [contribution policy].
 
-[guide]: docs/contributing.md
+[guide]: docs/src/contributing.md
 [contribution policy]: CONTRIBUTING.md
 
 ## ⚡ Quickstart Guide

--- a/docs/src/command/pack-and-publish.md
+++ b/docs/src/command/pack-and-publish.md
@@ -1,1 +1,0 @@
-# pack and publish


### PR DESCRIPTION
# The obligatory README-link-fix-PR

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text #253

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
