### PR TITLE
Skip serializing empty or None values to package.json

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -49,13 +49,19 @@ struct CargoLib {
 #[derive(Serialize)]
 struct NpmPackage {
     name: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     collaborators: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     license: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     repository: Option<Repository>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     files: Vec<String>,
     main: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     types: Option<String>,
 }
 


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
