### PR TITLE
Specify output directory with CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 sudo: false
-cache: cargo
 
 DEPLOY_TO_GITHUB: &DEPLOY_TO_GITHUB
   before_deploy:

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -59,6 +59,7 @@ pub fn cargo_install_wasm_bindgen(
 /// `.wasm`.
 pub fn wasm_bindgen_build(
     path: &Path,
+    out_dir: &Path,
     name: &str,
     disable_dts: bool,
     target: &str,
@@ -69,6 +70,8 @@ pub fn wasm_bindgen_build(
     PBAR.step(step, &msg);
     let binary_name = name.replace("-", "_");
     let release_or_debug = if debug { "debug" } else { "release" };
+
+    let out_dir = out_dir.to_str().unwrap();
 
     if let Some(wasm_bindgen_path) = wasm_bindgen_path(path) {
         let wasm_path = format!(
@@ -89,7 +92,7 @@ pub fn wasm_bindgen_build(
             .current_dir(path)
             .arg(&wasm_path)
             .arg("--out-dir")
-            .arg("./pkg")
+            .arg(out_dir)
             .arg(dts_arg)
             .arg(target_arg)
             .output()?;

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -19,11 +19,10 @@ pub fn set_crate_path(path: Option<PathBuf>) -> PathBuf {
 }
 
 /// Construct our `pkg` directory in the crate.
-pub fn create_pkg_dir(path: &Path, step: &Step) -> Result<(), Error> {
+pub fn create_pkg_dir(out_dir: &Path, step: &Step) -> Result<(), Error> {
     let msg = format!("{}Creating a pkg directory...", emoji::FOLDER);
     PBAR.step(step, &msg);
-    let pkg_dir_path = path.join("pkg");
-    fs::create_dir_all(pkg_dir_path)?;
+    fs::create_dir_all(&out_dir)?;
     Ok(())
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -146,6 +146,7 @@ impl CargoManifest {
 /// Generate a package.json file inside in `./pkg`.
 pub fn write_package_json(
     path: &Path,
+    out_dir: &Path,
     scope: &Option<String>,
     disable_dts: bool,
     target: &str,
@@ -161,7 +162,7 @@ pub fn write_package_json(
     };
 
     PBAR.step(step, &msg);
-    let pkg_file_path = path.join("pkg").join("package.json");
+    let pkg_file_path = out_dir.join("package.json");
     let mut pkg_file = File::create(pkg_file_path)?;
     let crate_data = read_cargo_toml(path)?;
     let npm_data = crate_data.into_npm(scope, disable_dts, target);

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -9,22 +9,20 @@ use progressbar::Step;
 use PBAR;
 
 /// Copy the crate's README into the `pkg` directory.
-pub fn copy_from_crate(path: &Path, step: &Step) -> Result<(), Error> {
+pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), Error> {
     assert!(
         fs::metadata(path).ok().map_or(false, |m| m.is_dir()),
         "crate directory should exist"
     );
     assert!(
-        fs::metadata(path.join("pkg"))
-            .ok()
-            .map_or(false, |m| m.is_dir()),
+        fs::metadata(&out_dir).ok().map_or(false, |m| m.is_dir()),
         "crate's pkg directory should exist"
     );
 
     let msg = format!("{}Copying over your README...", emoji::DANCERS);
     PBAR.step(step, &msg);
     let crate_readme_path = path.join("README.md");
-    let new_readme_path = path.join("pkg").join("README.md");
+    let new_readme_path = out_dir.join("README.md");
     if let Err(_) = fs::copy(&crate_readme_path, &new_readme_path) {
         PBAR.warn("origin crate has no README");
     };

--- a/tests/all/readme.rs
+++ b/tests/all/readme.rs
@@ -9,13 +9,14 @@ use wasm_pack::readme;
 #[test]
 fn it_copies_a_readme_default_path() {
     let fixture = fixture::fixture(".");
-    fs::create_dir(fixture.path.join("pkg")).expect("should create pkg directory OK");
+    let out_dir = fixture.path.join("pkg");
+    fs::create_dir(&out_dir).expect("should create pkg directory OK");
 
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(readme::copy_from_crate(&fixture.path, &step).is_ok());
+    assert!(readme::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
 
     let crate_readme_path = fixture.path.join("README.md");
-    let pkg_readme_path = fixture.path.join("pkg").join("README.md");
+    let pkg_readme_path = out_dir.join("README.md");
     println!(
         "wasm-pack: should have copied README.md from '{}' to '{}'",
         crate_readme_path.display(),
@@ -33,12 +34,13 @@ fn it_copies_a_readme_default_path() {
 #[test]
 fn it_creates_a_package_json_provided_path() {
     let fixture = fixture::fixture("tests/fixtures/js-hello-world");
-    fs::create_dir(fixture.path.join("pkg")).expect("should create pkg directory OK");
+    let out_dir = fixture.path.join("pkg");
+    fs::create_dir(&out_dir).expect("should create pkg directory OK");
 
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(readme::copy_from_crate(&fixture.path, &step).is_ok());
+    assert!(readme::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
     let crate_readme_path = fixture.path.join("README.md");
-    let pkg_readme_path = fixture.path.join("pkg").join("README.md");
+    let pkg_readme_path = out_dir.join("README.md");
     println!(
         "wasm-pack: should have copied README.md from '{}' to '{}'",
         crate_readme_path.display(),

--- a/tests/all/utils/manifest.rs
+++ b/tests/all/utils/manifest.rs
@@ -24,8 +24,8 @@ pub struct Repository {
     pub url: String,
 }
 
-pub fn read_package_json(path: &Path) -> Result<NpmPackage, Error> {
-    let manifest_path = path.join("pkg").join("package.json");
+pub fn read_package_json(path: &Path, out_dir: &Path) -> Result<NpmPackage, Error> {
+    let manifest_path = path.join(out_dir).join("package.json");
     let mut pkg_file = File::open(manifest_path)?;
     let mut pkg_contents = String::new();
     pkg_file.read_to_string(&mut pkg_contents)?;


### PR DESCRIPTION
This PR addresses #235 

There is a new command line flag for the build command: `--out-dir` and `-d`. Supply a relative path and put your wasm somewhere else! Default is `pkg`. 

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
