### PR TITLE
tidy: Don't use double negatives

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -75,10 +75,10 @@ pub fn wasm_bindgen_build(
             "target/wasm32-unknown-unknown/{}/{}.wasm",
             release_or_debug, binary_name
         );
-        let dts_arg = if disable_dts == false {
-            "--typescript"
-        } else {
+        let dts_arg = if disable_dts {
             "--no-typescript"
+        } else {
+            "--typescript"
         };
         let target_arg = match target {
             "nodejs" => "--nodejs",


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [ ] ~~You reference which issue is being closed in the PR text~~

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
