### PR TITLE
Edits to `packaging-and-publishing` tutorial step.

### DIFF
--- a/docs/src/tutorial/packaging-and-publishing.md
+++ b/docs/src/tutorial/packaging-and-publishing.md
@@ -1,37 +1,36 @@
 # Package Code for npm
 
-We've made our code so now we need to package it all up. In your project directory run the following
+We have written our code, so now we need to package it all up. In your project directory run the following
 command:
 
 ```bash
-$ wasm-pack init --scope MYSCOPE
+$ wasm-pack build --scope MYSCOPE
 ```
 
-where `MYSCOPE` is your npm username. Normally you could just type `wasm-pack init` but since
-other people are doing this tutorial as well we don't want conflicts with the `wasm-add` package
+where `MYSCOPE` is your npm username. Normally you could just type `wasm-pack build`, but since
+other people are doing this tutorial as well, we don't want conflicts with the `wasm-add` package
 name! This command when run does a few things:
 
-1. It'll compile your code to wasm if you haven't already
-2. It'll generate a pkg folder with the wasm file, a JS wrapper file around the wasm, your README,
-   and a `package.json` file.
+1. It will compile your code to wasm if you have not already.
+2. It will generate an output folder containing the wasm file, a JS wrapper file around the wasm, your README,
+   and a `package.json` file. This folder is named `pkg` by default, but can be specified using the `--out-dir` option.
 
 This is everything you need to upload your code to npm! Let's do just that!
 
-First off you'll need to login to npm with the account you made earlier if you didn't already have
-one:
+First off, you will need to login to npm with the account you made earlier:
 
 ```bash
 $ npm login
 ```
 
-Next you'll need to go into the `pkg` directory and actually upload the package:
+Next you will need to go into the output directory and actually upload the package:
 
 ```bash
 $ cd pkg
 $ npm publish --access=public
 ```
 
-Now normally if things are not scoped you can just do `npm publish` but if you give it a scope
-you'll need to tell npm that this is actually public so it can publish it. We need to do that here
-since we gave our packages a scope to avoid conflicting with each other! Next up is actually running
+Normally if things are not scoped you can just do `npm publish`, but if you give it a scope
+you will need to tell npm that this is actually public so that it can be published. We need to do that here
+because we gave our packages a scope to avoid conflicting with each other! Next up is actually running
 the code and verifying we got it from npm and how we can use that code.


### PR DESCRIPTION
This makes some minor changes to update the `packaging-and-publishing` file in the tutorial. This changes the `init` command to `build`, now that #216 has landed. Additionally, the `--out-dir` flag from #263 is mentioned, so this shouldn't be merged until that PR is complete.

Aside from those changes, there are some minor edits that are somewhat subjective, but improve readability (imo). Adding a period for consistency in the `build` command's description, removing contractions, etc.

Happy to adjust these edits if anybody has feedback, or if I made any mistakes here :smiley_cat: :heart: 

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
