### PR TITLE
CI: re-enable caching for `cargo install`ed tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: rust
 sudo: false
 
+# Cache `cargo install`ed tools, but don't cache the project's `target`
+# directory (which ends up over-caching and filling all disk space!)
+cache:
+  directories:
+    - /home/travis/.cargo
+
 DEPLOY_TO_GITHUB: &DEPLOY_TO_GITHUB
   before_deploy:
     - git config --local user.name "Ashley Williams"


### PR DESCRIPTION
We hit the exact issues described in https://levans.fr/rust_travis_cache.html, which was why we disabled caching in the first place, but if we cache `$HOME/.cargo/bin` then that will help for our `cargo install`ed tools.