### PR TITLE
add support for otp when publishing to npm

### DIFF
--- a/src/npm.rs
+++ b/src/npm.rs
@@ -22,6 +22,8 @@ pub fn npm_publish(path: &str) -> Result<(), Error> {
     let output = Command::new("npm")
         .current_dir(path)
         .arg("publish")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
         .output()?;
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
closes #257 

I added `Stdio::inherit()` for `stdin` and `stdout` to`npm_publish` to get the CLI output from npm when a user tries to publish with otp enabled. This will allow the user to enter their otp and successfully publish their package to the registry.

Please let me know if there's any thing I need to tweak or fix!

Thanks!

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨