### PR TITLE
Temporarily remove indicatif dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,14 +243,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.9.0"
+name = "humantime"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -431,6 +428,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -835,7 +837,7 @@ dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -933,7 +935,7 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21638c5955a6daf3ecc42cae702335fc37a72a4abcc6959ce457b31a7d43bbdd"
-"checksum indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a29b2fa6f00010c268bface64c18bb0310aaa70d46a195d5382d288c477fb016"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6c324313540cd4d7ba008d43dc6606a32a5579f13cc17b2804c13096f0a5c522"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -956,6 +958,7 @@ dependencies = [
 "checksum parking_lot_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06a2b6aae052309c2fd2161ef58f5067bc17bb758377a0de9d4b279d603fdd8a"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "295af93acfb1d5be29c16ca5b3f82d863836efd9cb0c14fd83811eb9a110e452"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ curl = "0.4.13"
 failure = "0.1.2"
 flate2 = "1.0.2"
 human-panic = "1.0.1"
-indicatif = "0.9.0"
+humantime = "1.1.1"
 lazy_static = "1.1.0"
 openssl = { version = '0.10.11', optional = true }
 parking_lot = "0.6"

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -3,7 +3,7 @@ use build;
 use command::utils::{create_pkg_dir, set_crate_path};
 use emoji;
 use error::Error;
-use indicatif::HumanDuration;
+use humantime::format_duration;
 use manifest;
 use progressbar::Step;
 use readme;
@@ -108,7 +108,7 @@ impl Build {
             step_counter.inc();
         }
 
-        let duration = HumanDuration(started.elapsed());
+        let duration = format_duration(started.elapsed());
         info!(&log, "Done in {}.", &duration);
         info!(
             &log,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ extern crate curl;
 #[macro_use]
 extern crate failure;
 extern crate flate2;
-extern crate indicatif;
 #[macro_use]
 extern crate lazy_static;
 extern crate parking_lot;
@@ -18,6 +17,7 @@ extern crate serde_json;
 extern crate structopt;
 #[macro_use]
 extern crate slog;
+extern crate humantime;
 extern crate slog_async;
 extern crate slog_term;
 extern crate tar;

--- a/src/progressbar.rs
+++ b/src/progressbar.rs
@@ -2,13 +2,11 @@
 
 use console::style;
 use emoji;
-use indicatif::{ProgressBar, ProgressStyle};
 use parking_lot::RwLock;
 use std::fmt;
 
 /// Synchronized progress bar and status message printing.
 pub struct ProgressOutput {
-    spinner: RwLock<ProgressBar>,
     messages: RwLock<String>,
 }
 
@@ -16,7 +14,6 @@ impl ProgressOutput {
     /// Construct a new `ProgressOutput`.
     pub fn new() -> Self {
         Self {
-            spinner: RwLock::new(ProgressBar::new_spinner()),
             messages: RwLock::new(String::from("")),
         }
     }
@@ -29,9 +26,6 @@ impl ProgressOutput {
     }
 
     fn finish(&self) {
-        let spinner = self.spinner.read();
-        spinner.finish();
-
         let mut message = self.messages.write();
         print!("{}", *message);
         message.clear();
@@ -39,10 +33,8 @@ impl ProgressOutput {
 
     /// Print the given message.
     pub fn message(&self, message: &str) {
+        self.add_message(message);
         self.finish();
-
-        let mut spinner = self.spinner.write();
-        *spinner = Self::progressbar(message);
     }
 
     fn add_message(&self, msg: &str) {
@@ -83,18 +75,6 @@ impl ProgressOutput {
             message
         );
         self.add_message(&err);
-    }
-
-    fn progressbar(msg: &str) -> ProgressBar {
-        let pb = ProgressBar::new_spinner();
-        pb.enable_steady_tick(200);
-        pb.set_style(
-            ProgressStyle::default_spinner()
-                .tick_chars("/|\\- ")
-                .template("{spinner:.dim.bold} {wide_msg}"),
-        );
-        pb.set_message(&msg);
-        pb
     }
 
     /// After having built up a series of messages, print all of them out.


### PR DESCRIPTION
Fixes #284

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
