### PR TITLE
Provide single quote separators around missing Cargo.toml fields to improve readability

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -156,7 +156,7 @@ pub fn write_package_json(
 
     let warn_fmt = |field| {
         format!(
-            "Field {} is missing from Cargo.toml. It is not necessary, but recommended",
+            "Field '{}' is missing from Cargo.toml. It is not necessary, but recommended",
             field
         )
     };


### PR DESCRIPTION
Before these changes, the CLI output would read:

  [4/8] 📂  Creating a pkg directory...
  [5/8] 📝  Writing a package.json...
  ⚠️   [WARN]: Field description is missing from Cargo.toml. It is not necessary, but recommended
  ⚠️   [WARN]: Field repository is missing from Cargo.toml. It is not necessary, but recommended
  ⚠️   [WARN]: Field license is missing from Cargo.toml. It is not necessary, but recommended

Which confused me at first glance, as I read literally that a field description was missing.  After this change, the output would be:

  [4/8] 📂  Creating a pkg directory...
  [5/8] 📝  Writing a package.json...
  ⚠️   [WARN]: Field 'description' is missing from Cargo.toml. It is not necessary, but recommended
  ⚠️   [WARN]: Field 'repository' is missing from Cargo.toml. It is not necessary, but recommended
  ⚠️   [WARN]: Field 'license' is missing from Cargo.toml. It is not necessary, but recommended

Which I feel reads a bit better :)
