### PR TITLE
Remove `branch: master` from AppVeyor deploy

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ install:
 build: false
 
 test_script:
-  - cargo test --release --locked -- --test-threads 1
+  - cargo test --release --locked
 
 before_deploy:
   - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,5 +31,4 @@ deploy:
   autho_token:
     secure: iHsRUqwGf/Zh7OuYpHOWQL8buaOL+c8/6kXLRly8V2j0LCUo7CcDs0NxQ0vl2bhZ
   on:
-    branch: master
     appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ install:
 build: false
 
 test_script:
-  - cargo test --locked -- --test-threads 1
+  - cargo test --release --locked -- --test-threads 1
 
 before_deploy:
   - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,10 @@
+environment:
+  global:
+    RUSTFLAGS: -C target-feature=+crt-static
+
 install:
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - if not defined RUSTFLAGS rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -V
   - cargo -V


### PR DESCRIPTION
fixes #147 

It looks like Windows releases aren't getting build for wasm-pack tags
unfortunately and taking a look at the [last logs][logs] it looks like the
reason is that the `master` branch is required. I'm not actually entirely sure
what's required here but by removing this it's closer to `wasm-bindgen`'s
configuration which I think is working!

[logs]: https://ci.appveyor.com/project/ashleygwilliams/wasm-pack-071k0/build/1.0.72

