### PR TITLE
(WIP) Use `Cargo.lock` to identify wasm-bindgen version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,18 @@ version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cargo_metadata"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +170,14 @@ dependencies = [
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -533,6 +553,20 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +863,7 @@ dependencies = [
 name = "wasm-pack"
 version = "0.4.2"
 dependencies = [
+ "cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,6 +949,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
+"checksum cargo_metadata 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6809b327f87369e6f3651efd2c5a96c49847a3ed2559477ecba79014751ee1"
 "checksum cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "c37f0efaa4b9b001fa6f02d4b644dee4af97d3414df07c51e3e4f015f3a3e131"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
@@ -924,6 +960,7 @@ dependencies = [
 "checksum copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e4281031634644843bd2f5aa9c48cf98fc48d6b083bd90bb11becf10deaf8b0"
 "checksum curl 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "444c2f9e71458b34e75471ed8d756947a0bb920b8b8b9bfc56dfcc4fc6819a13"
 "checksum curl-sys 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "981bd902fcd8b8b999cf71b81447e27d66c3493a7f62f1372866fd32986c0c82"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
 "checksum filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da4b9849e77b13195302c174324b5ba73eec9b236b24c221a61000daefb95c5f"
@@ -969,6 +1006,8 @@ dependencies = [
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1fabf2a7b6483a141426e1afd09ad543520a77ac49bd03c286e7696ccfd77f"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "22d340507cea0b7e6632900a176101fea959c7065d93ba555072da90aaaafc87"
 "checksum serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "234fc8b737737b148ccd625175fc6390f5e4dacfdaa543cb93a3430d984a9119"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 categories = ["wasm"]
 
 [dependencies]
+cargo_metadata = "0.6.0"
 console = "0.6.1"
 curl = "0.4.13"
 failure = "0.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 
+extern crate cargo_metadata;
 extern crate console;
 extern crate curl;
 #[macro_use]
@@ -29,6 +30,7 @@ pub mod build;
 pub mod command;
 pub mod emoji;
 pub mod error;
+pub mod lockfile;
 pub mod logger;
 pub mod manifest;
 pub mod npm;

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,0 +1,63 @@
+//! Reading Cargo.lock lock file.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use cargo_metadata;
+use error::Error;
+use toml;
+
+/// This struct represents the contents of `Cargo.lock`.
+#[derive(Deserialize)]
+struct Lockfile {
+    package: HashMap<String, Package>,
+}
+
+/// This struct represents a single package entry in `Cargo.lock`
+#[derive(Deserialize)]
+struct Package {
+    name: String,
+    version: String,
+    source: Option<String>,
+}
+
+/// Get the version of `wasm-bindgen` specified as a dependency.
+pub fn get_wasm_bindgen_version(path: &Path) -> Result<Option<String>, Error> {
+    let lockfile = read_cargo_lock(&path)?;
+    let version = lockfile
+        .package
+        .get("wasm-bingen")
+        .map(|p| p.version.clone());
+    Ok(version)
+}
+
+/// Read the `Cargo.lock` file for the crate at the given path.
+fn read_cargo_lock(crate_path: &Path) -> Result<Lockfile, Error> {
+    let lock_path = get_lockfile_path(crate_path)?;
+    let mut lockfile = String::new();
+    File::open(lock_path)?.read_to_string(&mut lockfile)?;
+    toml::from_str(&lockfile).map_err(Error::from)
+}
+
+/// Given the path to the crate that we are buliding, return a `PathBuf`
+/// containing the location of the lock file, by finding the workspace root.
+fn get_lockfile_path(crate_path: &Path) -> Result<PathBuf, Error> {
+    // Identify the crate's root directory, or return an error.
+    let manifest = crate_path.join("Cargo.toml");
+    let crate_root = cargo_metadata::metadata(Some(&manifest))
+        .map_err(|_| Error::CrateConfig {
+            message: String::from("Error while processing crate metadata"),
+        })?.workspace_root;
+    // Check that a lock file can be found in the directory. Return an error
+    // if it cannot, otherwise return the path buffer.
+    let lockfile_path = Path::new(&crate_root).join("Cargo.lock");
+    if !lockfile_path.is_file() {
+        Err(Error::CrateConfig {
+            message: format!("Could not find lockfile at {:?}", lockfile_path),
+        })
+    } else {
+        Ok(lockfile_path)
+    }
+}

--- a/tests/all/lockfile.rs
+++ b/tests/all/lockfile.rs
@@ -1,0 +1,43 @@
+use std::path::Path;
+use std::process::Command;
+use utils::fixture;
+use wasm_pack::{build, lockfile};
+
+#[test]
+fn it_gets_wasm_bindgen_version() {
+    let fixture = fixture::fixture("tests/fixtures/js-hello-world");
+    build_wasm(&fixture.path);
+    assert_eq!(
+        lockfile::get_wasm_bindgen_version(&fixture.path)
+            .unwrap()
+            .unwrap(),
+        "0.2"
+    );
+}
+
+#[test]
+fn it_gets_wasm_bindgen_version_with_underscores() {
+    let fixture = fixture::fixture("tests/fixtures/with-underscores");
+    build_wasm(&fixture.path);
+    assert_eq!(
+        lockfile::get_wasm_bindgen_version(&fixture.path)
+            .unwrap()
+            .unwrap(),
+        "0.2"
+    );
+}
+
+/// The `step_install_wasm_bindgen` and `step_run_wasm_bindgen` steps only
+/// occur after the `step_build_wasm` step. In order to read the lockfile
+/// in the test fixture's temporary directory, we should first build the
+/// crate, targeting `wasm32-unknown-unknown`.
+fn build_wasm(path: &Path) {
+    Command::new("cargo")
+        .current_dir(path)
+        .arg("+nightly")
+        .arg("build")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .output()
+        .expect("Could not build test fixture's wasm!");
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -11,6 +11,7 @@ extern crate lazy_static;
 
 mod bindgen;
 mod build;
+mod lockfile;
 mod manifest;
 mod readme;
 mod utils;

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -192,21 +192,3 @@ fn it_does_not_error_when_wasm_bindgen_is_declared() {
     let step = wasm_pack::progressbar::Step::new(1);
     assert!(manifest::check_crate_config(&fixture.path, &step).is_ok());
 }
-
-#[test]
-fn it_gets_wasm_bindgen_version() {
-    let fixture = fixture::fixture("tests/fixtures/js-hello-world");
-    assert_eq!(
-        manifest::get_wasm_bindgen_version(&fixture.path).unwrap(),
-        "0.2"
-    );
-}
-
-#[test]
-fn it_gets_wasm_bindgen_version_with_underscores() {
-    let fixture = fixture::fixture("tests/fixtures/with-underscores");
-    assert_eq!(
-        manifest::get_wasm_bindgen_version(&fixture.path).unwrap(),
-        "0.2"
-    );
-}


### PR DESCRIPTION
Fixes #270. This aims to find the wasm-bindgen version using the lockfile.

Note: This is still a WIP, and should probably land after #271. While working on this, I ran into some of the same problems that were solved by that PR, so I tried to remove any duplicate work. I can rebase this once that lands, but review/feedback is welcome in the meantime :)

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
