### PR TITLE
Fix broken links in book by replacing absolute paths with relative paths

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,7 +11,7 @@
 - [Commands](./commands/index.md)
   - [`init` (DEPRECATED)](./commands/init.md)
   - [`build`](./commands/build.md)
-  - [`pack` and `publish`](./command/pack-and-publish.md)
+  - [`pack` and `publish`](./commands/pack-and-publish.md)
 - [Tutorial](./tutorial/index.md)
   - [Writing a Rust-WebAssembly Library](./tutorial/writing-a-rust-webassembly-library.md)
   - [Packaging and Publishing](./tutorial/packaging-and-publishing.md)

--- a/docs/src/commands/index.md
+++ b/docs/src/commands/index.md
@@ -7,5 +7,5 @@ a Rust-generated WebAssembly project.
 - `build`: This command builds a `pkg` directory for you with compiled wasm and generated JS. [Learn more][build]
 - `pack` and `publish`: These command will create a tarball, and optionally publish it to a registry, such as npm. [Learn more][pack-pub]
 
-[build]: /commands/build.html
-[pack-pub]: /commands/pack-and-publish.html
+[build]: ./build.html
+[pack-pub]: ./pack-and-publish.html

--- a/docs/src/commands/init.md
+++ b/docs/src/commands/init.md
@@ -3,4 +3,4 @@
 This command has been deprecated in favor of `build`, which does the same thing, but is
 a much more representative name for the command. [Read the docs for `build`.][build]
 
-[build]: /commands/build.html
+[build]: ./build.html

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -7,8 +7,8 @@ using it. You can find them documented [here][1].
 
 You'll also want to check out the contributing [guidelines].
 
-[1]: docs/prerequisites.md
-[guidelines]: CONTRIBUTING.md
+[1]: ./prerequisites/index.html
+[guidelines]: https://github.com/rustwasm/wasm-pack/blob/master/CONTRIBUTING.md
 
 ## 🏃‍♀️ Up and Running
 
@@ -19,13 +19,13 @@ You'll also want to check out the contributing [guidelines].
 
 ## Documentation
 
-Documentation lives in the [`/docs`](docs) directory. Each command has it's own page.
-Additionally there are extra pages explaining the prerequisites, setup, and how to 
+Documentation lives in the `/docs` directory. Each command has it's own page.
+Additionally there are extra pages explaining the prerequisites, setup, and how to
 contribute (which you are reading now!).
 
 ## Tests
 
-Tests live in the [`/tests`](tests) directory. To run the tests you can run:
+Tests live in the `/tests` directory. To run the tests you can run:
 
 ```
 cargo  test

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -3,5 +3,5 @@
 In this section, we'll teach you how to get `wasm-pack` installed and how to setup a project
 to use `wasm-pack` with.
 
-- [Installation](/getting-started/installation.html)
-- [Project Setup](/getting-started/project-setup/index.html)
+- [Installation](./installation.html)
+- [Project Setup](./project-setup/index.html)

--- a/docs/src/getting-started/project-setup/index.md
+++ b/docs/src/getting-started/project-setup/index.md
@@ -4,5 +4,5 @@ There are a few things you need to do to setup a project for `wasm-pack`.
 We strongly recommending [using a template], but you can also set the project
 up [manually].
 
-[using a template]: /getting-started/project-setup/using-a-template.html
-[manually]: /getting-started/project-setup/manual-setup.html
+[using a template]: ./using-a-template.html
+[manually]: ./manual-setup.html

--- a/docs/src/prerequisites/index.md
+++ b/docs/src/prerequisites/index.md
@@ -2,5 +2,5 @@
 
 To run `wasm-pack` you'll need to have both Rust and npm installed and configured.
 
-- [Rust](/prerequisites/rust.html)
-- [npm](/prerequisites/npm.html)
+- [Rust](./rust.html)
+- [npm](./npm.html)

--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -7,6 +7,6 @@ much Rust knowledge to complete this tutorial.
 
 Be sure to have done the following before starting:
 
-1. Read and install all the [Prerequisites](/prerequisites.html).
-2. [Install `wasm-pack`](/getting-started/installation.html).
-3. [Setup a new project](/getting-started/project-setup/using-a-template.html).
+1. Read and install all the [Prerequisites](../prerequisites/index.html).
+2. [Install `wasm-pack`](../../getting-started/installation.html).
+3. [Setup a new project](../../getting-started/project-setup/using-a-template.html).


### PR DESCRIPTION
fixes #325 

Switched the links from using absolute paths to relative paths. Should now work locally served with mdBooks and when served on pages.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
