### PR TITLE
added .idea folder to .gitignore to exclude user specific settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/.crates.toml
 tests/bin
 wasm-pack.log
 /build-installer
+.idea/


### PR DESCRIPTION
Not directly related to an issue but I was using IntelliJ with the Rust plugin to work on my pull request earlier today and noticed that the .idea folder showed up in git as untracked. I figured it might be good to add that to .gitignore so that user and machine specific settings for the JetBrains IDEs don't accidentally checked in. 

Let me know if just creating a pull request isn't the proper way to add something ad-hoc like this.

Thanks!

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
