### PR TITLE
Pass `--debug` to `wasm-bindgen` in debug mode

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -140,14 +140,19 @@ pub fn wasm_bindgen_build(
             _ => "--browser",
         };
         let bindgen_path = Path::new(&wasm_bindgen_path);
-        let output = Command::new(bindgen_path)
-            .current_dir(path)
+        let mut cmd = Command::new(bindgen_path);
+        cmd.current_dir(path)
             .arg(&wasm_path)
             .arg("--out-dir")
             .arg(out_dir)
             .arg(dts_arg)
-            .arg(target_arg)
-            .output()?;
+            .arg(target_arg);
+
+        if debug {
+            cmd.arg("--debug");
+        }
+
+        let output = cmd.output()?;
         if !output.status.success() {
             let s = String::from_utf8_lossy(&output.stderr);
             Error::cli("wasm-bindgen failed to execute properly", s)


### PR DESCRIPTION
In debug mode `wasm-bindgen` emits more JS glue to check more invariants
and otherwise provide more sanity checks. This is omitted by default
with wasm-pack as it runs in release mode by default, but if `--debug`
is passed let's be sure to include it!
