### PR TITLE
fix(changelog): Repair "Passing arbitrary data..." broken link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
     Read the [Passing arbitrary data to JS docs] to learn more!
 
-    [Passing arbitrary data to JS docs]: https://github.com/rustwasm/wasm-bindgen/blob/master/guide/src/passing-data.md
+    [Passing arbitrary data to JS docs]: https://github.com/rustwasm/wasm-bindgen/blob/master/guide/src/reference/arbitrary-data-with-serde.md
     [turboladen]: https://github.com/turboladen
     [issue/221]: https://github.com/rustwasm/wasm-pack/issues/221
     [pull/224]: https://github.com/rustwasm/wasm-pack/pull/224


### PR DESCRIPTION
- Repair a broken link in the changelog

Looks like it probably broke with https://github.com/rustwasm/wasm-bindgen/commit/2e7620e014ab53b450696529afd12e3c685221e1.

Fixes #337.

This is my first PR here; please let me know if I should tweak anything in this PR or in the related issue to be consistent with how things are done here. I'm excited about the WG-wasm roadmap and am looking forward to getting more involved!