### PR TITLE
fix(bindgen): Test installed version with semver crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ indicatif = "0.9.0"
 lazy_static = "1.1.0"
 openssl = { version = '0.10.11', optional = true }
 parking_lot = "0.6"
+semver = "0.9.0"
 serde = "1.0.74"
 serde_derive = "1.0.74"
 serde_json = "1.0.26"

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -172,13 +172,18 @@ fn wasm_bindgen_version_check(bindgen_path: &PathBuf, dep_version: &str, log: &L
                 .split_whitespace()
                 .nth(1)
                 .map(|v| {
+                    use semver::{Version, VersionReq};
+
                     info!(
                         log,
-                        "Checking installed `wasm-bindgen` version == expected version: {} == {}",
+                        "Checking installed `wasm-bindgen` version {} meets contraint {}",
                         v,
                         dep_version
                     );
-                    v == dep_version
+
+                    let installed = Version::parse(v).unwrap();
+                    let constraint = VersionReq::parse(dep_version).unwrap();
+                    constraint.matches(&installed)
                 }).unwrap_or(false)
         }).unwrap_or(false)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate indicatif;
 #[macro_use]
 extern crate lazy_static;
 extern crate parking_lot;
+extern crate semver;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;


### PR DESCRIPTION
- Use the `semver` crate to more accurately validate whether an installed copy of `wasm-bindgen` meets the version requirements of the current project

Fixes https://github.com/rustwasm/wasm-pack/issues/341.