### PR TITLE
Add section on IDE config files to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,10 @@ Machine specific configuration files may be generaged by your IDE while working 
 
 Some examples of these files are the `.idea` folder created by JetBrains products (WebStorm, IntelliJ, etc) as well as `.vscode` created by Visual Studio Code for workspace specific settings. 
 
+For help setting up a global .gitignore check out this [GitHub article]!
+
+[GitHub article]: https://help.github.com/articles/ignoring-files/#create-a-global-gitignore
+
 ## Conduct
 
 As mentioned in the readme file, this project is a part of the [`rust-wasm` working group],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,11 @@ cargo +nightly fmt
 
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 
+### IDE Configuration files
+Machine specific configuration files may be generaged by your IDE while working on the project. Please make sure to add these files to a global .gitignore so they are kept from accidentally being commited to the project and causing issues for other contributors.
+
+Some examples of these files are the `.idea` folder created by JetBrains products (WebStorm, IntelliJ, etc) as well as `.vscode` created by Visual Studio Code for workspace specific settings. 
+
 ## Conduct
 
 As mentioned in the readme file, this project is a part of the [`rust-wasm` working group],


### PR DESCRIPTION
closes #352 

Added a section to the `CONTRIBUTING.md` file that covers adding IDE configuration files to a global .gitignore. Any feedback on better wording, formatting, etc is much appreciated! 😄 

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
