### PR TITLE
Add exit_status to cli error to fix #291

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -97,6 +97,7 @@ pub fn cargo_install_wasm_bindgen(crate_path: &Path, version: &str) -> Result<()
         Err(Error::Cli {
             message,
             stderr: s.to_string(),
+            exit_status: output.status,
         })
     } else {
         assert!(binaries::local_bin_path(crate_path, "wasm-bindgen").is_file());
@@ -155,7 +156,7 @@ pub fn wasm_bindgen_build(
         let output = cmd.output()?;
         if !output.status.success() {
             let s = String::from_utf8_lossy(&output.stderr);
-            Error::cli("wasm-bindgen failed to execute properly", s)
+            Error::cli("wasm-bindgen failed to execute properly", s, output.status)
         } else {
             Ok(())
         }

--- a/src/build.rs
+++ b/src/build.rs
@@ -64,7 +64,11 @@ pub fn rustup_add_wasm_target(step: &Step) -> Result<(), Error> {
         .output()?;
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Adding the wasm32-unknown-unknown target failed", s)
+        Error::cli(
+            "Adding the wasm32-unknown-unknown target failed",
+            s,
+            output.status,
+        )
     } else {
         Ok(())
     }
@@ -74,19 +78,17 @@ pub fn rustup_add_wasm_target(step: &Step) -> Result<(), Error> {
 pub fn cargo_build_wasm(path: &Path, debug: bool, step: &Step) -> Result<(), Error> {
     let msg = format!("{}Compiling to WASM...", emoji::CYCLONE);
     PBAR.step(step, &msg);
-    let output = {
-        let mut cmd = Command::new("cargo");
-        cmd.current_dir(path).arg("build").arg("--lib");
-        if !debug {
-            cmd.arg("--release");
-        }
-        cmd.arg("--target").arg("wasm32-unknown-unknown");
-        cmd.output()?
-    };
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(path).arg("build").arg("--lib");
+    if !debug {
+        cmd.arg("--release");
+    }
+    cmd.arg("--target").arg("wasm32-unknown-unknown");
+    let output = cmd.output()?;
 
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Compilation of your program failed", s)
+        Error::cli("Compilation of your program failed", s, output.status)
     } else {
         Ok(())
     }
@@ -106,7 +108,7 @@ pub fn cargo_build_wasm_tests(path: &Path, debug: bool) -> Result<(), Error> {
 
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Compilation of your program failed", s)
+        Error::cli("Compilation of your program failed", s, output.status)
     } else {
         Ok(())
     }

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -12,7 +12,7 @@ pub fn npm_pack(path: &str) -> Result<(), Error> {
     let output = Command::new("npm").current_dir(path).arg("pack").output()?;
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Packaging up your code failed", s)
+        Error::cli("Packaging up your code failed", s, output.status)
     } else {
         Ok(())
     }
@@ -38,7 +38,7 @@ pub fn npm_publish(path: &str, access: Option<Access>) -> Result<(), Error> {
 
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Publishing to npm failed", s)
+        Error::cli("Publishing to npm failed", s, output.status)
     } else {
         Ok(())
     }
@@ -76,7 +76,11 @@ pub fn npm_login(
 
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli(&format!("Login to registry {} failed", registry), s)
+        Error::cli(
+            &format!("Login to registry {} failed", registry),
+            s,
+            output.status,
+        )
     } else {
         Ok(())
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -40,7 +40,7 @@ where
 
     if !output.status.success() {
         let s = String::from_utf8_lossy(&output.stderr);
-        Error::cli("Running wasm tests failed", s)
+        Error::cli("Running wasm tests failed", s, output.status)
     } else {
         for line in String::from_utf8_lossy(&output.stdout).lines() {
             info!(log, "test output: {}", line);


### PR DESCRIPTION
Example output:

```
  [1/9] Checking `rustc` version...
  [2/9] Checking crate configuration...
  [3/9] Adding WASM target...
| [4/9] Compiling to WASM...
Process exited with exit code: 101: Compilation of your program failed. stderr:

   Compiling a v0.1.0 (/home/konsti/wasm-pack/a)
error[E0425]: cannot find function `fail` in this scope
 --> src/lib.rs:3:5
  |
3 |     fail();
  |     ^^^^ not found in this scope

error: aborting due to previous error

For more information about this error, try `rustc --explain E0425`.
error: Could not compile `a`.
```

```
  [1/9] Checking `rustc` version...
  [2/9] Checking crate configuration...
  [3/9] Adding WASM target...
/ [4/9] Compiling to WASM...
Process exited with signal: 9: Compilation of your program failed. stderr:

   Compiling lazy_static v1.1.0
   Compiling log v0.4.5
   Compiling wasm-bindgen v0.2.23
   Compiling proc-macro2 v0.4.19
   Compiling ryu v0.2.6
   Compiling serde v1.0.79
```

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

