### PR TITLE
fix canonical paths windows

### DIFF
--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -4,19 +4,13 @@ use emoji;
 use failure;
 use progressbar::Step;
 use std::fs;
-use std::io;
 use std::path::{Path, PathBuf};
 use PBAR;
 
 /// If an explicit path is given, then use it, otherwise assume the current
 /// directory is the crate path.
-pub fn set_crate_path(path: Option<PathBuf>) -> io::Result<PathBuf> {
-    let crate_path = match path {
-        Some(p) => p,
-        None => PathBuf::from("."),
-    };
-
-    crate_path.canonicalize()
+pub fn set_crate_path(path: Option<PathBuf>) -> Result<PathBuf, failure::Error> {
+    Ok(path.unwrap_or(PathBuf::from(".")))
 }
 
 /// Construct our `pkg` directory in the crate.

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -125,3 +125,16 @@ fn renamed_crate_name_works() {
     .unwrap();
     fixture.run(cli.cmd).unwrap();
 }
+
+#[test]
+fn it_should_build_nested_project_with_transitive_dependencies() {
+    let fixture = utils::fixture::transitive_dependencies();
+    fixture.install_local_wasm_bindgen();
+    let cli = Cli::from_iter_safe(vec![
+        "wasm-pack",
+        "build",
+        &fixture.path.join("main").display().to_string(),
+    ])
+    .unwrap();
+    fixture.run(cli.cmd).unwrap();
+}

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -437,3 +437,156 @@ pub fn wbg_test_node() -> Fixture {
         );
     fixture
 }
+
+pub fn transitive_dependencies() -> Fixture {
+    fn project_main_fixture(fixture: &mut Fixture) {
+        fixture.file(PathBuf::from("main/README"), "# Main Fixture\n");
+        fixture.file(
+            PathBuf::from("main/Cargo.toml"),
+            r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "main_project"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["cdylib"]
+
+            [dependencies]
+            wasm-bindgen = "=0.2.21"
+            project_a = { path = "../project_a" }
+            project_b = { path = "../project_b" }
+
+            [dev-dependencies]
+            wasm-bindgen-test = "=0.2.21"
+        "#,
+        );
+        fixture.file(
+            PathBuf::from("main/src/lib.rs"),
+            r#"
+                extern crate wasm_bindgen;
+                use wasm_bindgen::prelude::*;
+
+                // Import the `window.alert` function from the Web.
+                #[wasm_bindgen]
+                extern {
+                    fn alert(s: &str);
+                }
+
+                // Export a `greet` function from Rust to JavaScript, that alerts a
+                // hello message.
+                #[wasm_bindgen]
+                pub fn greet(name: &str) {
+                    alert(&format!("Hello, {}!", name));
+                }
+            "#,
+        );
+    }
+
+    fn project_a_fixture(fixture: &mut Fixture) {
+        fixture.file(
+            PathBuf::from("project_a/README"),
+            "# Project Alpha Fixture\n",
+        );
+        fixture.file(
+            PathBuf::from("project_a/Cargo.toml"),
+            r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "project_a"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["cdylib"]
+
+            [dependencies]
+            wasm-bindgen = "=0.2.21"
+            project_b = { path = "../project_b" }
+
+            [dev-dependencies]
+            wasm-bindgen-test = "=0.2.21"
+        "#,
+        );
+        fixture.file(
+            PathBuf::from("project_a/src/lib.rs"),
+            r#"
+                extern crate wasm_bindgen;
+                // extern crate project_b;
+                use wasm_bindgen::prelude::*;
+
+                // Import the `window.alert` function from the Web.
+                #[wasm_bindgen]
+                extern {
+                    fn alert(s: &str);
+                }
+
+                // Export a `greet` function from Rust to JavaScript, that alerts a
+                // hello message.
+                #[wasm_bindgen]
+                pub fn greet(name: &str) {
+                    alert(&format!("Hello, {}!", name));
+                }
+            "#,
+        );
+    }
+
+    fn project_b_fixture(fixture: &mut Fixture) {
+        fixture.file(
+            PathBuf::from("project_b/README"),
+            "# Project Beta Fixture\n",
+        );
+        fixture.file(
+            PathBuf::from("project_b/Cargo.toml"),
+            r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "project_b"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["cdylib"]
+
+            [dependencies]
+            wasm-bindgen = "=0.2.21"
+
+            [dev-dependencies]
+            wasm-bindgen-test = "=0.2.21"
+        "#,
+        );
+        fixture.file(
+            PathBuf::from("project_b/src/lib.rs"),
+            r#"
+                extern crate wasm_bindgen;
+                use wasm_bindgen::prelude::*;
+
+                // Import the `window.alert` function from the Web.
+                #[wasm_bindgen]
+                extern {
+                    fn alert(s: &str);
+                }
+
+                // Export a `greet` function from Rust to JavaScript, that alerts a
+                // hello message.
+                #[wasm_bindgen]
+                pub fn greet(name: &str) {
+                    alert(&format!("Hello, {}!", name));
+                }
+            "#,
+        );
+    }
+
+    let mut fixture = Fixture::new();
+    project_b_fixture(&mut fixture);
+    project_a_fixture(&mut fixture);
+    project_main_fixture(&mut fixture);
+    fixture
+}


### PR DESCRIPTION
This PR addresses problems with canonical paths on windows that were reported in #380. I tested this by building a wasm app with a few dependencies on windows.

I would love somebody to check the work and try running it on another windows box targeting another wasm app 😄 .

Implementation:
Remove the usage of std::fs::canonicalize.

Unit test:
I added a unit test based on reported failures:
- a project with local transitive dependencies, see #413 