### PR TITLE
Change to INFO when alerting users about missing fields Cargo.toml

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -38,7 +38,7 @@ struct CargoPackage {
 
 impl CargoPackage {
     fn check_optional_fields(&self) {
-        let warn_fmt = |field| {
+        let info_fmt = |field| {
             format!(
                 "Field '{}' is missing from Cargo.toml. It is not necessary, but recommended",
                 field
@@ -46,13 +46,13 @@ impl CargoPackage {
         };
 
         if self.description.is_none() {
-            PBAR.warn(&warn_fmt("description"));
+            PBAR.info(&info_fmt("description"));
         }
         if self.repository.is_none() {
-            PBAR.warn(&warn_fmt("repository"));
+            PBAR.info(&info_fmt("repository"));
         }
         if self.license.is_none() {
-            PBAR.warn(&warn_fmt("license"));
+            PBAR.info(&info_fmt("license"));
         }
     }
 }


### PR DESCRIPTION
Closes #393 

I switched the level displayed in the progress bar from `PBAR.warn` to `PBAR.info` and changed the format closure from `warn_format` to `info_format` for consistency.

How the new terminal output looks:
![info_output](https://user-images.githubusercontent.com/6796542/46533326-d4ac8f00-c869-11e8-9bc0-72ccd597c38a.png)


Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
