### PR TITLE
Return `Result<T, failure::Error>` instead of `Result<T, wasm_pack::error::Error>`

### DIFF
--- a/src/binaries.rs
+++ b/src/binaries.rs
@@ -175,7 +175,8 @@ where
                 .map(|s| s.to_string_lossy())
                 .collect::<Vec<_>>()
                 .join(", "),
-        )).into())
+        ))
+        .into())
     }
 }
 
@@ -226,7 +227,8 @@ where
                 .map(|s| s.to_string_lossy())
                 .collect::<Vec<_>>()
                 .join(", "),
-        )).into())
+        ))
+        .into())
     }
 }
 

--- a/src/binaries.rs
+++ b/src/binaries.rs
@@ -138,7 +138,7 @@ pub fn install_binaries_from_targz_at_url<'a, I>(
     crate_path: &Path,
     url: &str,
     binaries: I,
-) -> Result<(), Error>
+) -> Result<(), failure::Error>
 where
     I: IntoIterator<Item = &'a str>,
 {
@@ -175,7 +175,7 @@ where
                 .map(|s| s.to_string_lossy())
                 .collect::<Vec<_>>()
                 .join(", "),
-        )))
+        )).into())
     }
 }
 
@@ -186,7 +186,7 @@ pub fn install_binaries_from_zip_at_url<'a, I>(
     crate_path: &Path,
     url: &str,
     binaries: I,
-) -> Result<(), Error>
+) -> Result<(), failure::Error>
 where
     I: IntoIterator<Item = &'a str>,
 {
@@ -226,7 +226,7 @@ where
                 .map(|s| s.to_string_lossy())
                 .collect::<Vec<_>>()
                 .join(", "),
-        )))
+        )).into())
     }
 }
 

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -55,7 +55,10 @@ pub fn install_wasm_bindgen(
 }
 
 /// Download a tarball containing a pre-built `wasm-bindgen` binary.
-pub fn download_prebuilt_wasm_bindgen(root_path: &Path, version: &str) -> Result<(), failure::Error> {
+pub fn download_prebuilt_wasm_bindgen(
+    root_path: &Path,
+    version: &str,
+) -> Result<(), failure::Error> {
     let target = if target::LINUX && target::x86_64 {
         "x86_64-unknown-linux-musl"
     } else if target::MACOS && target::x86_64 {
@@ -65,7 +68,8 @@ pub fn download_prebuilt_wasm_bindgen(root_path: &Path, version: &str) -> Result
     } else {
         return Err(Error::unsupported(
             "there are no pre-built `wasm-bindgen` binaries for this target",
-        ).into());
+        )
+        .into());
     };
 
     let url = format!(

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -55,7 +55,7 @@ pub fn install_wasm_bindgen(
 }
 
 /// Download a tarball containing a pre-built `wasm-bindgen` binary.
-pub fn download_prebuilt_wasm_bindgen(root_path: &Path, version: &str) -> Result<(), Error> {
+pub fn download_prebuilt_wasm_bindgen(root_path: &Path, version: &str) -> Result<(), failure::Error> {
     let target = if target::LINUX && target::x86_64 {
         "x86_64-unknown-linux-musl"
     } else if target::MACOS && target::x86_64 {
@@ -65,7 +65,7 @@ pub fn download_prebuilt_wasm_bindgen(root_path: &Path, version: &str) -> Result
     } else {
         return Err(Error::unsupported(
             "there are no pre-built `wasm-bindgen` binaries for this target",
-        ));
+        ).into());
     };
 
     let url = format!(

--- a/src/build.rs
+++ b/src/build.rs
@@ -12,7 +12,7 @@ use std::str;
 use PBAR;
 
 /// Ensure that `rustc` is present and that it is >= 1.30.0
-pub fn check_rustc_version(step: &Step) -> Result<String, Error> {
+pub fn check_rustc_version(step: &Step) -> Result<String, failure::Error> {
     let msg = format!("{}Checking `rustc` version...", emoji::CRAB);
     PBAR.step(step, &msg);
     let local_minor_version = rustc_minor_version();
@@ -25,14 +25,14 @@ pub fn check_rustc_version(step: &Step) -> Result<String, Error> {
                   mv.to_string()
                 ),
                 local_minor_version: mv.to_string(),
-              })
+              }.into())
             } else {
               Ok(mv.to_string())
             }
       },
       None => Err(Error::RustcMissing {
         message: "We can't figure out what your Rust version is- which means you might not have Rust installed. Please install Rust version 1.30.0 or higher.".to_string(),
-      }),
+      }.into()),
     }
 }
 

--- a/src/child.rs
+++ b/src/child.rs
@@ -172,6 +172,6 @@ pub fn run(
         return Ok(stdout);
     } else {
         let msg = format!("`{}` did not exit successfully", command_name);
-        return Err(Error::cli(&msg, stderr.into(), exit).into());
+        return Err(Error::cli(&msg, stdout.into(), stderr.into(), exit).into());
     }
 }

--- a/src/child.rs
+++ b/src/child.rs
@@ -1,0 +1,176 @@
+//! Utilties for managing child processes.
+//!
+//! This module helps us ensure that:
+//!
+//! * All child processes that we spawn get properly logged and their output is
+//!   logged as well.
+//!
+//! * That any "quick running" child process does not spam the console with its
+//!   output.
+//!
+//! * That any "long running" child process gets its output copied to our
+//!   stderr, so that the user isn't sitting there wondering if anything at all
+//!   is happening. This is important for showing `cargo build`'s output, for
+//!   example.
+
+use error::Error;
+use failure;
+use slog::Logger;
+use std::{
+    io::{self, BufRead},
+    process,
+    sync::mpsc,
+    thread, time,
+};
+use PBAR;
+
+fn taking_too_long(since: time::Instant) -> bool {
+    since.elapsed() > time::Duration::from_millis(200)
+}
+
+enum Output<S: AsRef<str>> {
+    Stdout(S),
+    Stderr(S),
+}
+
+fn print_child_output<S>(out: Result<Output<S>, io::Error>, command_name: &str)
+where
+    S: AsRef<str>,
+{
+    let message = match out {
+        Ok(Output::Stdout(line)) => format!("{} (stdout): {}", command_name, line.as_ref()),
+        Ok(Output::Stderr(line)) => format!("{} (stderr): {}", command_name, line.as_ref()),
+        Err(e) => format!("error reading {} output: {}", command_name, e),
+    };
+    PBAR.message(&message);
+}
+
+fn handle_output<I, S>(
+    output: I,
+    logger: &Logger,
+    should_print: bool,
+    stdout: &mut String,
+    stderr: &mut String,
+    command_name: &str,
+) where
+    I: IntoIterator<Item = Result<Output<S>, io::Error>>,
+    S: AsRef<str>,
+{
+    for out in output {
+        match out {
+            Ok(Output::Stdout(ref line)) => {
+                let line = line.as_ref().trim_end();
+                info!(logger, "{} (stdout): {}", command_name, line);
+                stdout.push_str(line);
+            }
+            Ok(Output::Stderr(ref line)) => {
+                let line = line.as_ref().trim_end();
+                info!(logger, "{} (stderr): {}", command_name, line);
+                stderr.push_str(line);
+            }
+            Err(ref e) => {
+                warn!(logger, "error reading output: {}", e);
+            }
+        }
+        if should_print {
+            print_child_output(out, command_name);
+        }
+    }
+}
+
+/// Run the given command and return its stdout.
+///
+/// If the command takes "too long", then its stdout and stderr are also piped
+/// to our stdout and stderr so that the user has an idea of what is going on
+/// behind the scenes.
+pub fn run(
+    logger: &Logger,
+    mut command: process::Command,
+    command_name: &str,
+) -> Result<String, failure::Error> {
+    info!(logger, "Running {:?}", command);
+
+    let mut child = command
+        .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
+        .spawn()?;
+
+    let since = time::Instant::now();
+
+    let stdout = io::BufReader::new(child.stdout.take().unwrap());
+    let stderr = io::BufReader::new(child.stderr.take().unwrap());
+
+    let (send, recv) = mpsc::channel();
+    let stdout_send = send.clone();
+    let stderr_send = send;
+
+    // Because pipes have a fixed-size buffer, we need to keep reading stdout
+    // and stderr on a separate thread to avoid potential dead locks with
+    // waiting on the child process.
+
+    let stdout_handle = thread::spawn(move || {
+        for line in stdout.lines() {
+            stdout_send.send(line.map(Output::Stdout)).unwrap();
+        }
+    });
+
+    let stderr_handle = thread::spawn(move || {
+        for line in stderr.lines() {
+            stderr_send.send(line.map(Output::Stderr)).unwrap();
+        }
+    });
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let mut is_long_running = false;
+
+    loop {
+        if !is_long_running && taking_too_long(since) {
+            // The command has now been taking too long. Print the buffered stdout and
+            // stderr, and then continue waiting on the child.
+            stdout
+                .lines()
+                .map(|l| Ok(Output::Stdout(l)))
+                .chain(stderr.lines().map(|l| Ok(Output::Stderr(l))))
+                .for_each(|l| print_child_output(l, command_name));
+
+            is_long_running = true;
+        }
+
+        // Get any output that's been sent on the channel without blocking.
+        handle_output(
+            recv.try_iter(),
+            logger,
+            is_long_running,
+            &mut stdout,
+            &mut stderr,
+            command_name,
+        );
+
+        if let Some(exit) = child.try_wait()? {
+            // Block on collecting the rest of the child's output.
+            handle_output(
+                recv,
+                logger,
+                is_long_running,
+                &mut stdout,
+                &mut stderr,
+                command_name,
+            );
+
+            // Join the threads reading the child's output to make sure the
+            // finish OK.
+            stdout_handle.join().unwrap();
+            stderr_handle.join().unwrap();
+
+            if exit.success() {
+                return Ok(stdout);
+            } else {
+                let msg = format!("`{}` did not exit successfully", command_name);
+                return Err(Error::cli(&msg, stderr.into(), exit).into());
+            }
+        }
+
+        thread::yield_now();
+    }
+}

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -1,4 +1,3 @@
-use error::Error;
 use npm;
 use slog::Logger;
 use std::result;
@@ -10,7 +9,7 @@ pub fn login(
     always_auth: bool,
     auth_type: Option<String>,
     log: &Logger,
-) -> result::Result<(), Error> {
+) -> result::Result<(), failure::Error> {
     let registry = registry.unwrap_or(npm::DEFAULT_NPM_REGISTRY.to_string());
 
     info!(&log, "Logging in to npm...");
@@ -23,7 +22,7 @@ pub fn login(
         &auth_type
     );
     info!(&log, "npm info located in the npm debug log");
-    npm::npm_login(&registry, &scope, always_auth, &auth_type)?;
+    npm::npm_login(log, &registry, &scope, always_auth, &auth_type)?;
     info!(&log, "Logged you in!");
 
     PBAR.message(&format!("👋  logged you in!"));

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -84,7 +84,7 @@ pub enum Command {
 }
 
 /// Run a command with the given logger!
-pub fn run_wasm_pack(command: Command, log: &Logger) -> result::Result<(), Error> {
+pub fn run_wasm_pack(command: Command, log: &Logger) -> result::Result<(), failure::Error> {
     // Run the correct command based off input and store the result of it so that we can clear
     // the progress bar then return it
     let status = match command {
@@ -129,7 +129,12 @@ pub fn run_wasm_pack(command: Command, log: &Logger) -> result::Result<(), Error
         Ok(_) => {}
         Err(ref e) => {
             error!(&log, "{}", e);
-            PBAR.error(e.error_type());
+            for c in e.iter_chain() {
+                if let Some(e) = c.downcast_ref::<Error>() {
+                    PBAR.error(e.error_type());
+                    break;
+                }
+            }
         }
     }
 

--- a/src/command/pack.rs
+++ b/src/command/pack.rs
@@ -8,7 +8,7 @@ use PBAR;
 
 /// Executes the 'npm pack' command on the 'pkg' directory
 /// which creates a tarball that can be published to the NPM registry
-pub fn pack(path: Option<PathBuf>, log: &Logger) -> result::Result<(), Error> {
+pub fn pack(path: Option<PathBuf>, log: &Logger) -> result::Result<(), failure::Error> {
     let crate_path = set_crate_path(path)?;
 
     info!(&log, "Packing up the npm package...");
@@ -18,7 +18,7 @@ pub fn pack(path: Option<PathBuf>, log: &Logger) -> result::Result<(), Error> {
             &crate_path, &crate_path
         ),
     })?;
-    npm::npm_pack(&pkg_directory.to_string_lossy())?;
+    npm::npm_pack(log, &pkg_directory.to_string_lossy())?;
     info!(
         &log,
         "Your package is located at {:#?}",

--- a/src/command/publish/mod.rs
+++ b/src/command/publish/mod.rs
@@ -16,7 +16,7 @@ pub fn publish(
     path: Option<PathBuf>,
     access: Option<Access>,
     log: &Logger,
-) -> result::Result<(), Error> {
+) -> result::Result<(), failure::Error> {
     let crate_path = set_crate_path(path)?;
 
     info!(&log, "Publishing the npm package...");
@@ -28,7 +28,7 @@ pub fn publish(
         ),
     })?;
 
-    npm::npm_publish(&pkg_directory.to_string_lossy(), access)?;
+    npm::npm_publish(log, &pkg_directory.to_string_lossy(), access)?;
     info!(&log, "Published your package!");
 
     PBAR.message("💥  published your package!");

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions for commands.
 
 use emoji;
-use error::Error;
+use failure;
 use progressbar::Step;
 use std::fs;
 use std::io;
@@ -20,7 +20,7 @@ pub fn set_crate_path(path: Option<PathBuf>) -> io::Result<PathBuf> {
 }
 
 /// Construct our `pkg` directory in the crate.
-pub fn create_pkg_dir(out_dir: &Path, step: &Step) -> Result<(), Error> {
+pub fn create_pkg_dir(out_dir: &Path, step: &Step) -> Result<(), failure::Error> {
     let msg = format!("{}Creating a pkg directory...", emoji::FOLDER);
     PBAR.step(step, &msg);
     fs::create_dir_all(&out_dir)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,14 +48,17 @@ pub enum Error {
 
     /// An error invoking another CLI tool.
     #[fail(
-        display = "Process exited with {}: {}. stderr:\n\n{}",
+        display = "Process exited with {}: {}.\n\nstdout:{}\n\nstderr:\n\n{}",
         exit_status,
         message,
+        stdout,
         stderr
     )]
     Cli {
         /// Error message.
         message: String,
+        /// The underlying CLI's `stdout` output.
+        stdout: String,
         /// The underlying CLI's `stderr` output.
         stderr: String,
         /// The exit status of the subprocess
@@ -101,9 +104,10 @@ pub enum Error {
 
 impl Error {
     /// Construct a CLI error.
-    pub fn cli(message: &str, stderr: Cow<str>, exit_status: ExitStatus) -> Self {
+    pub fn cli(message: &str, stdout: Cow<str>, stderr: Cow<str>, exit_status: ExitStatus) -> Self {
         Error::Cli {
             message: message.to_string(),
+            stdout: stdout.to_string(),
             stderr: stderr.to_string(),
             exit_status,
         }
@@ -161,6 +165,7 @@ impl Error {
             } => "Your rustc version is not supported. Please install version 1.30.0 or higher.",
             Error::Cli {
                 message: _,
+                stdout: _,
                 stderr: _,
                 exit_status: _,
             } => "There was an error while calling another CLI tool. Details:\n\n",

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,19 +101,19 @@ pub enum Error {
 
 impl Error {
     /// Construct a CLI error.
-    pub fn cli(message: &str, stderr: Cow<str>, exit_status: ExitStatus) -> Result<(), Self> {
-        Err(Error::Cli {
+    pub fn cli(message: &str, stderr: Cow<str>, exit_status: ExitStatus) -> Self {
+        Error::Cli {
             message: message.to_string(),
             stderr: stderr.to_string(),
             exit_status,
-        })
+        }
     }
 
     /// Construct a crate configuration error.
-    pub fn crate_config(message: &str) -> Result<(), Self> {
-        Err(Error::CrateConfig {
+    pub fn crate_config(message: &str) -> Self {
+        Error::CrateConfig {
             message: message.to_string(),
-        })
+        }
     }
 
     /// Construct an archive error.

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use std::process;
 
 use atty;
-use failure::{Error, ResultExt};
+use failure::{self, ResultExt};
 use which;
 
 pub fn install() -> ! {
@@ -47,7 +47,7 @@ pub fn install() -> ! {
     process::exit(0);
 }
 
-fn do_install() -> Result<(), Error> {
+fn do_install() -> Result<(), failure::Error> {
     // Find `rustup.exe` in PATH, we'll be using its installation directory as
     // our installation directory.
     let rustup = match which::which("rustup") {
@@ -85,7 +85,7 @@ fn do_install() -> Result<(), Error> {
     Ok(())
 }
 
-fn confirm_can_overwrite(dst: &Path) -> Result<(), Error> {
+fn confirm_can_overwrite(dst: &Path) -> Result<(), failure::Error> {
     // If the `-f` argument was passed, we can always overwrite everything.
     if env::args().any(|arg| arg == "-f") {
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ extern crate zip;
 pub mod binaries;
 pub mod bindgen;
 pub mod build;
+pub mod child;
 pub mod command;
 pub mod emoji;
 pub mod error;

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -69,14 +69,16 @@ fn get_lockfile_path(crate_path: &Path) -> Result<PathBuf, failure::Error> {
     let crate_root = cargo_metadata::metadata(Some(&manifest))
         .map_err(|_| Error::CrateConfig {
             message: String::from("Error while processing crate metadata"),
-        })?.workspace_root;
+        })?
+        .workspace_root;
     // Check that a lock file can be found in the directory. Return an error
     // if it cannot, otherwise return the path buffer.
     let lockfile_path = Path::new(&crate_root).join("Cargo.lock");
     if !lockfile_path.is_file() {
         Err(Error::CrateConfig {
             message: format!("Could not find lockfile at {:?}", lockfile_path),
-        }.into())
+        }
+        .into())
     } else {
         Ok(lockfile_path)
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -23,10 +23,10 @@ struct Package {
 
 impl Lockfile {
     /// Read the `Cargo.lock` file for the crate at the given path.
-    pub fn new(crate_path: &Path) -> Result<Lockfile, Error> {
+    pub fn new(crate_path: &Path) -> Result<Lockfile, failure::Error> {
         let lock_path = get_lockfile_path(crate_path)?;
         let lockfile = fs::read_to_string(lock_path)?;
-        toml::from_str(&lockfile).map_err(Error::from)
+        toml::from_str(&lockfile).map_err(|err| Error::from(err).into())
     }
 
     /// Get the version of `wasm-bindgen` dependency used in the `Cargo.lock`.
@@ -36,7 +36,7 @@ impl Lockfile {
 
     /// Like `wasm_bindgen_version`, except it returns an error instead of
     /// `None`.
-    pub fn require_wasm_bindgen(&self) -> Result<&str, Error> {
+    pub fn require_wasm_bindgen(&self) -> Result<&str, failure::Error> {
         self.wasm_bindgen_version().ok_or_else(|| {
             let message = format!(
                 "Ensure that you have \"{}\" as a dependency in your Cargo.toml file:\n\
@@ -44,7 +44,7 @@ impl Lockfile {
                  wasm-bindgen = \"0.2\"",
                 style("wasm-bindgen").bold().dim(),
             );
-            Error::CrateConfig { message }
+            Error::CrateConfig { message }.into()
         })
     }
 
@@ -63,21 +63,20 @@ impl Lockfile {
 
 /// Given the path to the crate that we are buliding, return a `PathBuf`
 /// containing the location of the lock file, by finding the workspace root.
-fn get_lockfile_path(crate_path: &Path) -> Result<PathBuf, Error> {
+fn get_lockfile_path(crate_path: &Path) -> Result<PathBuf, failure::Error> {
     // Identify the crate's root directory, or return an error.
     let manifest = crate_path.join("Cargo.toml");
     let crate_root = cargo_metadata::metadata(Some(&manifest))
         .map_err(|_| Error::CrateConfig {
             message: String::from("Error while processing crate metadata"),
-        })?
-        .workspace_root;
+        })?.workspace_root;
     // Check that a lock file can be found in the directory. Return an error
     // if it cannot, otherwise return the path buffer.
     let lockfile_path = Path::new(&crate_root).join("Cargo.lock");
     if !lockfile_path.is_file() {
         Err(Error::CrateConfig {
             message: format!("Could not find lockfile at {:?}", lockfile_path),
-        })
+        }.into())
     } else {
         Ok(lockfile_path)
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,7 +1,7 @@
 //! Logging facilities for `wasm-pack`.
 
 use command::Command;
-use error::Error;
+use failure;
 use slog::{Drain, Level, Logger};
 use slog_async::Async;
 use slog_term::{FullFormat, PlainDecorator};
@@ -9,7 +9,7 @@ use std::fs::OpenOptions;
 use std::path::PathBuf;
 
 /// Create the logger for wasm-pack that will output any info warning or errors we encounter
-pub fn new(cmd: &Command, verbosity: u8) -> Result<Logger, Error> {
+pub fn new(cmd: &Command, verbosity: u8) -> Result<Logger, failure::Error> {
     let log_path = log_file_path(&cmd);
     let file = OpenOptions::new()
         .create(true)

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -78,11 +78,10 @@ struct CargoLib {
 fn read_cargo_toml(path: &Path) -> Result<CargoManifest, Error> {
     let manifest_path = path.join("Cargo.toml");
     if !manifest_path.is_file() {
-        return Error::crate_config(&format!(
+        return Err(Error::crate_config(&format!(
             "Crate directory is missing a `Cargo.toml` file; is `{}` the wrong directory?",
             path.display()
-        ))
-        .map(|_| unreachable!());
+        )));
     }
     let mut cargo_file = File::open(manifest_path)?;
     let mut cargo_contents = String::new();
@@ -254,10 +253,10 @@ fn check_crate_type(path: &Path) -> Result<(), Error> {
     }) {
         return Ok(());
     }
-    Error::crate_config(
+    Err(Error::crate_config(
       "crate-type must be cdylib to compile to wasm32-unknown-unknown. Add the following to your \
        Cargo.toml file:\n\n\
        [lib]\n\
        crate-type = [\"cdylib\", \"rlib\"]"
-    )
+    ))
 }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -11,8 +11,8 @@ use self::npm::{
     repository::Repository, CommonJSPackage, ESModulesPackage, NoModulesPackage, NpmPackage,
 };
 use emoji;
-use failure;
 use error::Error;
+use failure;
 use progressbar::Step;
 use serde_json;
 use toml;
@@ -82,7 +82,8 @@ fn read_cargo_toml(path: &Path) -> Result<CargoManifest, failure::Error> {
         return Err(Error::crate_config(&format!(
             "Crate directory is missing a `Cargo.toml` file; is `{}` the wrong directory?",
             path.display()
-        )).into());
+        ))
+        .into());
     }
     let mut cargo_file = File::open(manifest_path)?;
     let mut cargo_contents = String::new();

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -1,7 +1,7 @@
 //! Generating `README` files for the packaged wasm.
 
-use error::Error;
 use std::fs;
+use failure;
 use std::path::Path;
 
 use emoji;
@@ -9,7 +9,7 @@ use progressbar::Step;
 use PBAR;
 
 /// Copy the crate's README into the `pkg` directory.
-pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), Error> {
+pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), failure::Error> {
     assert!(
         fs::metadata(path).ok().map_or(false, |m| m.is_dir()),
         "crate directory should exist"

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -1,7 +1,7 @@
 //! Generating `README` files for the packaged wasm.
 
-use std::fs;
 use failure;
+use std::fs;
 use std::path::Path;
 
 use emoji;

--- a/src/test/webdriver.rs
+++ b/src/test/webdriver.rs
@@ -5,6 +5,7 @@ use binaries::{
 };
 use command::build::BuildMode;
 use error::Error;
+use failure;
 use slog::Logger;
 use std::path::{Path, PathBuf};
 use target;
@@ -15,7 +16,7 @@ pub fn get_or_install_chromedriver(
     log: &Logger,
     crate_path: &Path,
     mode: BuildMode,
-) -> Result<PathBuf, Error> {
+) -> Result<PathBuf, failure::Error> {
     match (mode, bin_path(log, crate_path, "chromedriver")) {
         (_, Some(path)) => Ok(path),
         (BuildMode::Normal, None) => install_chromedriver(crate_path),
@@ -24,7 +25,7 @@ pub fn get_or_install_chromedriver(
             "No crate-local `chromedriver` binary found, and could not find a global \
              `chromedriver` on the `$PATH`. Not installing `chromedriver` because of noinstall \
              mode.",
-        )),
+        ).into()),
     }
 }
 
@@ -52,7 +53,7 @@ fn get_chromedriver_url() -> Result<String, Error> {
 }
 
 /// Download and install a pre-built `chromedriver` binary.
-pub fn install_chromedriver(crate_path: &Path) -> Result<PathBuf, Error> {
+pub fn install_chromedriver(crate_path: &Path) -> Result<PathBuf, failure::Error> {
     let url = get_chromedriver_url()?;
     install_binaries_from_zip_at_url(crate_path, &url, Some("chromedriver"))?;
     let chromedriver = get_local_chromedriver_path(crate_path);
@@ -66,7 +67,7 @@ pub fn get_or_install_geckodriver(
     log: &Logger,
     crate_path: &Path,
     mode: BuildMode,
-) -> Result<PathBuf, Error> {
+) -> Result<PathBuf, failure::Error> {
     match (mode, bin_path(log, crate_path, "geckodriver")) {
         (_, Some(path)) => Ok(path),
         (BuildMode::Normal, None) => install_geckodriver(crate_path),
@@ -74,7 +75,7 @@ pub fn get_or_install_geckodriver(
         (BuildMode::Noinstall, None) => Err(Error::crate_config(
             "No crate-local `geckodriver` binary found, and could not find a global `geckodriver` \
              on the `$PATH`. Not installing `geckodriver` because of noinstall mode.",
-        )),
+        ).into()),
     }
 }
 
@@ -107,7 +108,7 @@ fn get_local_geckodriver_path(crate_path: &Path) -> PathBuf {
 }
 
 /// Download and install a pre-built `geckodriver` binary.
-pub fn install_geckodriver(crate_path: &Path) -> Result<PathBuf, Error> {
+pub fn install_geckodriver(crate_path: &Path) -> Result<PathBuf, failure::Error> {
     let url = get_geckodriver_url()?;
 
     if url.ends_with("tar.gz") {

--- a/src/test/webdriver.rs
+++ b/src/test/webdriver.rs
@@ -25,7 +25,8 @@ pub fn get_or_install_chromedriver(
             "No crate-local `chromedriver` binary found, and could not find a global \
              `chromedriver` on the `$PATH`. Not installing `chromedriver` because of noinstall \
              mode.",
-        ).into()),
+        )
+        .into()),
     }
 }
 
@@ -75,7 +76,8 @@ pub fn get_or_install_geckodriver(
         (BuildMode::Noinstall, None) => Err(Error::crate_config(
             "No crate-local `geckodriver` binary found, and could not find a global `geckodriver` \
              on the `$PATH`. Not installing `geckodriver` because of noinstall mode.",
-        ).into()),
+        )
+        .into()),
     }
 }
 

--- a/src/test/webdriver.rs
+++ b/src/test/webdriver.rs
@@ -20,12 +20,11 @@ pub fn get_or_install_chromedriver(
         (_, Some(path)) => Ok(path),
         (BuildMode::Normal, None) => install_chromedriver(crate_path),
         (BuildMode::Force, None) => install_chromedriver(crate_path),
-        (BuildMode::Noinstall, None) => Error::crate_config(
+        (BuildMode::Noinstall, None) => Err(Error::crate_config(
             "No crate-local `chromedriver` binary found, and could not find a global \
              `chromedriver` on the `$PATH`. Not installing `chromedriver` because of noinstall \
              mode.",
-        )
-        .map(|_| unreachable!()),
+        )),
     }
 }
 
@@ -72,11 +71,10 @@ pub fn get_or_install_geckodriver(
         (_, Some(path)) => Ok(path),
         (BuildMode::Normal, None) => install_geckodriver(crate_path),
         (BuildMode::Force, None) => install_geckodriver(crate_path),
-        (BuildMode::Noinstall, None) => Error::crate_config(
+        (BuildMode::Noinstall, None) => Err(Error::crate_config(
             "No crate-local `geckodriver` binary found, and could not find a global `geckodriver` \
              on the `$PATH`. Not installing `geckodriver` because of noinstall mode.",
-        )
-        .map(|_| unreachable!()),
+        )),
     }
 }
 
@@ -133,6 +131,8 @@ pub fn get_safaridriver(log: &Logger, crate_path: &Path) -> Result<PathBuf, Erro
     if let Some(p) = bin_path(log, crate_path, "safaridriver") {
         Ok(p)
     } else {
-        Error::crate_config("could not find `safaridriver` on the `$PATH`").map(|_| unreachable!())
+        Err(Error::crate_config(
+            "could not find `safaridriver` on the `$PATH`",
+        ))
     }
 }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -2,6 +2,8 @@ extern crate failure;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+#[macro_use]
+extern crate slog;
 extern crate structopt;
 extern crate tempfile;
 extern crate wasm_pack;

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -1,3 +1,4 @@
+use super::logger::null_logger;
 use std::env;
 use std::fs;
 use std::io;
@@ -6,9 +7,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Once, ONCE_INIT};
 use std::thread;
-use wasm_pack;
-
 use tempfile::TempDir;
+use wasm_pack;
 
 fn hard_link_or_copy<P1: AsRef<Path>, P2: AsRef<Path>>(from: P1, to: P2) -> io::Result<()> {
     let from = from.as_ref();
@@ -151,7 +151,11 @@ impl Fixture {
             const WASM_BINDGEN_VERSION: &str = "0.2.21";
             wasm_pack::bindgen::download_prebuilt_wasm_bindgen(&tests, WASM_BINDGEN_VERSION)
                 .or_else(|_| {
-                    wasm_pack::bindgen::cargo_install_wasm_bindgen(&tests, WASM_BINDGEN_VERSION)
+                    wasm_pack::bindgen::cargo_install_wasm_bindgen(
+                        &null_logger(),
+                        &tests,
+                        WASM_BINDGEN_VERSION,
+                    )
                 })
                 .unwrap();
         });

--- a/tests/all/utils/logger.rs
+++ b/tests/all/utils/logger.rs
@@ -1,0 +1,6 @@
+use slog::Logger;
+
+// Create a logger that ignores log messages for testing.
+pub fn null_logger() -> Logger {
+    Logger::root(slog::Discard, o!())
+}

--- a/tests/all/utils/mod.rs
+++ b/tests/all/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod file;
 pub mod fixture;
+pub mod logger;
 pub mod manifest;


### PR DESCRIPTION
:zap: Do not merge this at this point. :zap:

This PR intends to fix #280. This PR is branched out from @fitzgen branch in #392.