### PR TITLE
test(command/build): add a test for build command

### DIFF
--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -20,3 +20,20 @@ fn build_in_non_crate_directory_doesnt_panic() {
     let err_msg = result.unwrap_err().to_string();
     assert!(err_msg.contains("missing a `Cargo.toml`"));
 }
+
+#[test]
+fn it_should_build_js_hello_world_example() {
+    let fixture = utils::fixture::js_hello_world();
+    let cli = Cli::from_iter_safe(vec![
+        "wasm-pack",
+        "build",
+        &fixture.path.display().to_string(),
+    ])
+    .unwrap();
+    let logger = logger::new(&cli.cmd, cli.verbosity).unwrap();
+    let result = command::run_wasm_pack(cli.cmd, &logger);
+    assert!(
+        result.is_ok(),
+        "running wasm-pack in a js-hello-world directory should succeed.",
+    );
+}


### PR DESCRIPTION
this PR is to check if a minimal example `fixture::js_hello_world` can be built in the test.

it provides precondition for #396 

---
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
