### PR TITLE
Copy license file(s) to out directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,11 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "heck"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1053,7 @@ dependencies = [
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1172,6 +1178,7 @@ dependencies = [
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21638c5955a6daf3ecc42cae702335fc37a72a4abcc6959ce457b31a7d43bbdd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ failure = "0.1.2"
 flate2 = "1.0.2"
 hex = "0.3"
 human-panic = "1.0.1"
+glob = "0.2"
 indicatif = "0.9.0"
 lazy_static = "1.1.0"
 openssl = { version = '0.10.11', optional = true }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -7,6 +7,7 @@ use command::utils::{create_pkg_dir, set_crate_path};
 use emoji;
 use failure::Error;
 use indicatif::HumanDuration;
+use license;
 use lockfile::Lockfile;
 use manifest;
 use progressbar::Step;
@@ -209,6 +210,7 @@ impl Build {
                 step_create_dir,
                 step_create_json,
                 step_copy_readme,
+                step_copy_license,
                 step_install_wasm_bindgen,
                 step_run_wasm_bindgen,
             ],
@@ -219,6 +221,7 @@ impl Build {
                 step_create_dir,
                 step_create_json,
                 step_copy_readme,
+                step_copy_license,
                 step_run_wasm_bindgen
             ],
             BuildMode::Force => steps![
@@ -226,6 +229,7 @@ impl Build {
                 step_create_dir,
                 step_create_json,
                 step_copy_readme,
+                step_copy_license,
                 step_run_wasm_bindgen
             ],
         }
@@ -300,7 +304,18 @@ impl Build {
         Ok(())
     }
 
-    fn step_install_wasm_bindgen(&mut self, step: &Step, log: &Logger) -> Result<(), Error> {
+    fn step_copy_license(&mut self, step: &Step, log: &Logger) -> Result<(), failure::Error> {
+        info!(&log, "Copying license from crate...");
+        license::copy_from_crate(&self.crate_path, &self.out_dir, step)?;
+        info!(&log, "Copied license from crate to {:#?}.", &self.out_dir);
+        Ok(())
+    }
+
+    fn step_install_wasm_bindgen(
+        &mut self,
+        step: &Step,
+        log: &Logger,
+    ) -> Result<(), failure::Error> {
         info!(&log, "Identifying wasm-bindgen dependency...");
         let lockfile = Lockfile::new(&self.crate_data)?;
         let bindgen_version = lockfile.require_wasm_bindgen()?;

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -306,7 +306,7 @@ impl Build {
 
     fn step_copy_license(&mut self, step: &Step, log: &Logger) -> Result<(), failure::Error> {
         info!(&log, "Copying license from crate...");
-        license::copy_from_crate(&self.crate_path, &self.out_dir, step)?;
+        license::copy_from_crate(&self.crate_data, &self.crate_path, &self.out_dir, step)?;
         info!(&log, "Copied license from crate to {:#?}.", &self.out_dir);
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ extern crate dirs;
 #[macro_use]
 extern crate failure;
 extern crate flate2;
-extern crate hex;
 extern crate glob;
+extern crate hex;
 extern crate indicatif;
 #[macro_use]
 extern crate lazy_static;
@@ -37,7 +37,6 @@ pub mod build;
 pub mod child;
 pub mod command;
 pub mod emoji;
-pub mod error;
 pub mod license;
 pub mod lockfile;
 pub mod logger;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate dirs;
 extern crate failure;
 extern crate flate2;
 extern crate hex;
+extern crate glob;
 extern crate indicatif;
 #[macro_use]
 extern crate lazy_static;
@@ -36,6 +37,8 @@ pub mod build;
 pub mod child;
 pub mod command;
 pub mod emoji;
+pub mod error;
+pub mod license;
 pub mod lockfile;
 pub mod logger;
 pub mod manifest;

--- a/src/license.rs
+++ b/src/license.rs
@@ -68,7 +68,7 @@ pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), f
             }
         }
         None => {
-            PBAR.step(step, "No LICENSE found in Cargo.toml skipping...");
+            PBAR.step(step, "No LICENSE found in Cargo.toml, skipping...");
         }
     };
 

--- a/src/license.rs
+++ b/src/license.rs
@@ -1,0 +1,76 @@
+//! Copy `LICENSE` file(s) for the packaged wasm.
+
+use failure;
+use std::fs;
+use std::path::Path;
+
+use emoji;
+use glob::glob;
+use manifest;
+use progressbar::Step;
+use PBAR;
+
+fn get_license(path: &Path) -> Option<String> {
+    match manifest::get_crate_license(path) {
+        Ok(license) => license,
+        Err(_) => None,
+    }
+}
+
+fn glob_license_files(path: &Path) -> Result<Vec<String>, failure::Error> {
+    let mut license_files: Vec<String> = Vec::new();
+    for entry in glob(path.join("LICENSE*").to_str().unwrap())? {
+        match entry {
+            Ok(globed_path) => {
+                license_files.push(String::from(
+                    globed_path.file_name().unwrap().to_str().unwrap(),
+                ));
+            }
+            Err(e) => println!("{:?}", e),
+        }
+    }
+    Ok(license_files)
+}
+
+/// Copy the crate's license into the `pkg` directory.
+pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), failure::Error> {
+    assert!(
+        fs::metadata(path).ok().map_or(false, |m| m.is_dir()),
+        "crate directory should exist"
+    );
+
+    assert!(
+        fs::metadata(&out_dir).ok().map_or(false, |m| m.is_dir()),
+        "crate's pkg directory should exist"
+    );
+
+    match get_license(path) {
+        Some(_) => {
+            let msg = format!("{}Copying over your LICENSE...", emoji::DANCERS);
+            PBAR.step(step, &msg);
+            let license_files = glob_license_files(path);
+
+            match license_files {
+                Ok(files) => {
+                    if files.len() == 0 {
+                        PBAR.info("License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory");
+                        return Ok(());
+                    }
+                    for license_file in files {
+                        let crate_license_path = path.join(&license_file);
+                        let new_license_path = out_dir.join(&license_file);
+                        if let Err(_) = fs::copy(&crate_license_path, &new_license_path) {
+                            PBAR.info("origin crate has no LICENSE");
+                        }
+                    }
+                }
+                Err(_) => PBAR.info("origin crate has no LICENSE"),
+            }
+        }
+        None => {
+            PBAR.step(step, "No LICENSE found in Cargo.toml skipping...");
+        }
+    };
+
+    Ok(())
+}

--- a/src/license.rs
+++ b/src/license.rs
@@ -6,16 +6,9 @@ use std::path::Path;
 
 use emoji;
 use glob::glob;
-use manifest;
+use manifest::CrateData;
 use progressbar::Step;
 use PBAR;
-
-fn get_license(path: &Path) -> Option<String> {
-    match manifest::get_crate_license(path) {
-        Ok(license) => license,
-        Err(_) => None,
-    }
-}
 
 fn glob_license_files(path: &Path) -> Result<Vec<String>, failure::Error> {
     let mut license_files: Vec<String> = Vec::new();
@@ -33,7 +26,12 @@ fn glob_license_files(path: &Path) -> Result<Vec<String>, failure::Error> {
 }
 
 /// Copy the crate's license into the `pkg` directory.
-pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), failure::Error> {
+pub fn copy_from_crate(
+    crate_data: &CrateData,
+    path: &Path,
+    out_dir: &Path,
+    step: &Step,
+) -> Result<(), failure::Error> {
     assert!(
         fs::metadata(path).ok().map_or(false, |m| m.is_dir()),
         "crate directory should exist"
@@ -44,7 +42,7 @@ pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), f
         "crate's pkg directory should exist"
     );
 
-    match get_license(path) {
+    match crate_data.crate_license() {
         Some(_) => {
             let msg = format!("{}Copying over your LICENSE...", emoji::DANCERS);
             PBAR.step(step, &msg);

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -289,6 +289,11 @@ impl CrateData {
         }
     }
 
+    /// Get the license for the crate at the given path.
+    pub fn crate_license(&self) -> &Option<String> {
+        &self.manifest.package.license
+    }
+
     /// Returns the path to this project's target directory where artifacts are
     /// located after a cargo build.
     pub fn target_directory(&self) -> &Path {

--- a/tests/all/license.rs
+++ b/tests/all/license.rs
@@ -5,15 +5,17 @@ use std::fs;
 
 use utils::{self, fixture};
 use wasm_pack::license;
+use wasm_pack::manifest::CrateData;
 
 #[test]
 fn it_copies_a_license_default_path() {
     let fixture = fixture::single_license();
     let out_dir = fixture.path.join("pkg");
     fs::create_dir(&out_dir).expect("should create pkg directory OK");
+    let crate_data = CrateData::new(&fixture.path);
 
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(license::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
+    assert!(license::copy_from_crate(&crate_data.unwrap(), &fixture.path, &out_dir, &step).is_ok());
 
     let crate_license_path = fixture.path.join("LICENSE-WTFPL");
     let pkg_license_path = out_dir.join("LICENSE-WTFPL");
@@ -36,9 +38,10 @@ fn it_copies_a_license_provied_path() {
     let fixture = fixture::single_license();
     let out_dir = fixture.path.join("pkg");
     fs::create_dir(&out_dir).expect("should create pkg directory OK");
+    let crate_data = CrateData::new(&fixture.path);
 
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(license::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
+    assert!(license::copy_from_crate(&crate_data.unwrap(), &fixture.path, &out_dir, &step).is_ok());
     let crate_license_path = fixture.path.join("LICENSE-WTFPL");
     let pkg_license_path = out_dir.join("LICENSE-WTFPL");
     println!(
@@ -59,9 +62,10 @@ fn it_copies_all_licenses_default_path() {
     let fixture = fixture::dual_license();
     let out_dir = fixture.path.join("pkg");
     fs::create_dir(&out_dir).expect("should create pkg directory OK");
+    let crate_data = CrateData::new(&fixture.path);
 
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(license::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
+    assert!(license::copy_from_crate(&crate_data.unwrap(), &fixture.path, &out_dir, &step).is_ok());
 
     let crate_license_path = fixture.path.join("LICENSE-WTFPL");
     let pkg_license_path = out_dir.join("LICENSE-WTFPL");
@@ -94,9 +98,10 @@ fn it_copies_all_licenses_provided_path() {
     let fixture = fixture::dual_license();
     let out_dir = fixture.path.join("pkg");
     fs::create_dir(&out_dir).expect("should create pkg directory OK");
+    let crate_data = CrateData::new(&fixture.path);
 
     let step = wasm_pack::progressbar::Step::new(1);
-    assert!(license::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
+    assert!(license::copy_from_crate(&crate_data.unwrap(), &fixture.path, &out_dir, &step).is_ok());
 
     let crate_license_path = fixture.path.join("LICENSE-WTFPL");
     let pkg_license_path = out_dir.join("LICENSE-WTFPL");

--- a/tests/all/license.rs
+++ b/tests/all/license.rs
@@ -1,0 +1,125 @@
+extern crate failure;
+extern crate wasm_pack;
+
+use std::fs;
+
+use utils::{self, fixture};
+use wasm_pack::license;
+
+#[test]
+fn it_copies_a_license_default_path() {
+    let fixture = fixture::single_license();
+    let out_dir = fixture.path.join("pkg");
+    fs::create_dir(&out_dir).expect("should create pkg directory OK");
+
+    let step = wasm_pack::progressbar::Step::new(1);
+    assert!(license::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
+
+    let crate_license_path = fixture.path.join("LICENSE-WTFPL");
+    let pkg_license_path = out_dir.join("LICENSE-WTFPL");
+    println!(
+        "wasm-pack: should have copied LICENSE from '{}' to '{}'",
+        crate_license_path.display(),
+        pkg_license_path.display()
+    );
+    assert!(fs::metadata(&crate_license_path).is_ok());
+
+    assert!(fs::metadata(&pkg_license_path).is_ok());
+
+    let crate_license = utils::file::read_file(&crate_license_path).unwrap();
+    let pkg_license = utils::file::read_file(&pkg_license_path).unwrap();
+    assert_eq!(crate_license, pkg_license);
+}
+
+#[test]
+fn it_copies_a_license_provied_path() {
+    let fixture = fixture::single_license();
+    let out_dir = fixture.path.join("pkg");
+    fs::create_dir(&out_dir).expect("should create pkg directory OK");
+
+    let step = wasm_pack::progressbar::Step::new(1);
+    assert!(license::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
+    let crate_license_path = fixture.path.join("LICENSE-WTFPL");
+    let pkg_license_path = out_dir.join("LICENSE-WTFPL");
+    println!(
+        "wasm-pack: should have copied LICENSE-WTFPL from '{}' to '{}'",
+        crate_license_path.display(),
+        pkg_license_path.display()
+    );
+    assert!(fs::metadata(&crate_license_path).is_ok());
+    assert!(fs::metadata(&pkg_license_path).is_ok());
+
+    let crate_license = utils::file::read_file(&crate_license_path).unwrap();
+    let pkg_license = utils::file::read_file(&pkg_license_path).unwrap();
+    assert_eq!(crate_license, pkg_license);
+}
+
+#[test]
+fn it_copies_all_licenses_default_path() {
+    let fixture = fixture::dual_license();
+    let out_dir = fixture.path.join("pkg");
+    fs::create_dir(&out_dir).expect("should create pkg directory OK");
+
+    let step = wasm_pack::progressbar::Step::new(1);
+    assert!(license::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
+
+    let crate_license_path = fixture.path.join("LICENSE-WTFPL");
+    let pkg_license_path = out_dir.join("LICENSE-WTFPL");
+
+    let crate_license_path_2 = fixture.path.join("LICENSE-MIT");
+    let pkg_license_path_2 = out_dir.join("LICENSE-MIT");
+
+    println!(
+        "wasm-pack: should have copied LICENSE from '{}' to '{}'",
+        crate_license_path.display(),
+        pkg_license_path.display()
+    );
+    assert!(fs::metadata(&crate_license_path).is_ok());
+    assert!(fs::metadata(&pkg_license_path).is_ok());
+
+    assert!(fs::metadata(&crate_license_path_2).is_ok());
+    assert!(fs::metadata(&pkg_license_path_2).is_ok());
+
+    let crate_license = utils::file::read_file(&crate_license_path).unwrap();
+    let pkg_license = utils::file::read_file(&pkg_license_path).unwrap();
+    assert_eq!(crate_license, pkg_license);
+
+    let crate_license_2 = utils::file::read_file(&crate_license_path_2).unwrap();
+    let pkg_license_2 = utils::file::read_file(&pkg_license_path_2).unwrap();
+    assert_eq!(crate_license_2, pkg_license_2);
+}
+
+#[test]
+fn it_copies_all_licenses_provided_path() {
+    let fixture = fixture::dual_license();
+    let out_dir = fixture.path.join("pkg");
+    fs::create_dir(&out_dir).expect("should create pkg directory OK");
+
+    let step = wasm_pack::progressbar::Step::new(1);
+    assert!(license::copy_from_crate(&fixture.path, &out_dir, &step).is_ok());
+
+    let crate_license_path = fixture.path.join("LICENSE-WTFPL");
+    let pkg_license_path = out_dir.join("LICENSE-WTFPL");
+
+    let crate_license_path_2 = fixture.path.join("LICENSE-MIT");
+    let pkg_license_path_2 = out_dir.join("LICENSE-MIT");
+
+    println!(
+        "wasm-pack: should have copied LICENSE from '{}' to '{}'",
+        crate_license_path.display(),
+        pkg_license_path.display()
+    );
+    assert!(fs::metadata(&crate_license_path).is_ok());
+    assert!(fs::metadata(&pkg_license_path).is_ok());
+
+    assert!(fs::metadata(&crate_license_path_2).is_ok());
+    assert!(fs::metadata(&pkg_license_path_2).is_ok());
+
+    let crate_license = utils::file::read_file(&crate_license_path).unwrap();
+    let pkg_license = utils::file::read_file(&pkg_license_path).unwrap();
+    assert_eq!(crate_license, pkg_license);
+
+    let crate_license_2 = utils::file::read_file(&crate_license_path_2).unwrap();
+    let pkg_license_2 = utils::file::read_file(&pkg_license_path_2).unwrap();
+    assert_eq!(crate_license_2, pkg_license_2);
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -12,6 +12,7 @@ extern crate wasm_pack;
 
 mod bindgen;
 mod build;
+mod license;
 mod lockfile;
 mod manifest;
 mod readme;

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -73,7 +73,7 @@ impl Fixture {
         self.file(
             "LICENSE-WTFPL",
             r#"
-                DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                DO WHATEVER YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
                 Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
@@ -82,10 +82,10 @@ impl Fixture {
                 copies of this license document, and changing it is allowed as long
                 as the name is changed.
 
-                DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                DO WHATEVER YOU WANT TO PUBLIC LICENSE
                 TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-                0. You just DO WHAT THE FUCK YOU WANT TO.
+                0. You just DO WHATEVER YOU WANT TO.
             "#,
         )
     }

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -68,6 +68,44 @@ impl Fixture {
         )
     }
 
+    /// Add `WTFPL LICENSE` file to the fixture.
+    pub fn wtfpl_license(&self) -> &Self {
+        self.file(
+            "LICENSE-WTFPL",
+            r#"
+                DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
+
+                Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+                Everyone is permitted to copy and distribute verbatim or modified
+                copies of this license document, and changing it is allowed as long
+                as the name is changed.
+
+                DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+                0. You just DO WHAT THE FUCK YOU WANT TO.
+            "#,
+        )
+    }
+
+    /// Add `MIT LICENSE` file to the fixture.
+    pub fn mit_license(&self) -> &Self {
+        self.file(
+            "LICENSE-MIT",
+            r#"
+                Copyright <YEAR> <COPYRIGHT HOLDER>
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+            "#,
+        )
+    }
+
     /// Add a `Cargo.toml` with a correctly configured `wasm-bindgen`
     /// dependency, `wasm-bindgen-test` dev-dependency, and `crate-type =
     /// ["cdylib"]`.
@@ -588,5 +626,26 @@ pub fn transitive_dependencies() -> Fixture {
     project_b_fixture(&mut fixture);
     project_a_fixture(&mut fixture);
     project_main_fixture(&mut fixture);
+    fixture
+}
+
+pub fn single_license() -> Fixture {
+    let fixture = Fixture::new();
+    fixture
+        .readme()
+        .cargo_toml("single_license")
+        .wtfpl_license()
+        .hello_world_src_lib();
+    fixture
+}
+
+pub fn dual_license() -> Fixture {
+    let fixture = Fixture::new();
+    fixture
+        .readme()
+        .cargo_toml("dual_license")
+        .wtfpl_license()
+        .mit_license()
+        .hello_world_src_lib();
     fixture
 }


### PR DESCRIPTION
Closes #407 

Added a new step to `build` that will look in the Cargo.toml file to see if a license key has been set. If one has been set it will glob for `LICENSE*` and copy those file(s) to the specified `out` directory. If a license key has not been set this step will skip with the message `No LICENSE found in Cargo.toml skipping...`. If a key is set in the Cargo.toml but the glob doesn't match any files we will break out of the copying license step and print `License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory` to the console.

I would love some feed back on the file globing implementation. I am pretty new to Rust but as far as I can tell the best way to account for the different ways `LICENSE` files can be named was to implement a glob that looks for `LICENSE*` in the crate directory. I thought about using the actual value set in the `License` key in the Cargo.toml but due to the non-standard ways licenses can be referred to I figured it would be best to just check for it's existence rather than relying on the value set for the key itself. This seemed like the most robust way to go about this but I would love to know if there is a better way that I'm not aware of! 

I know it's common in the Rust community to dual license Apache 2.0 and MIT but since that pattern is less common in the JS community I'm not sure if we would want give the ability for users to select which license they want copied if more than one is found. Related, I'm not even sure if it would be desired or appropriate for a user to change the licensing of the wasm-packed output as compared to the Rust source code but it was just a thought I had while implementing this feature.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
