### PR TITLE
Fix typo in test function name for copying the README

### DIFF
--- a/tests/all/readme.rs
+++ b/tests/all/readme.rs
@@ -32,7 +32,7 @@ fn it_copies_a_readme_default_path() {
 }
 
 #[test]
-fn it_creates_a_package_json_provided_path() {
+fn it_copies_a_readme_provided_path() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     fs::create_dir(&out_dir).expect("should create pkg directory OK");


### PR DESCRIPTION
I found this while working on #411, just a small typo in the test file for copying the README. I figured it would be better to make a separate PR for this instead of including it in 411 since it was unrelated to the rest of the implementation of that feature.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
