### PR TITLE
[WIP] Add support for missing README files and other README file extensions

### DIFF
--- a/src/readme.rs
+++ b/src/readme.rs
@@ -23,8 +23,6 @@ pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), f
     PBAR.step(step, &msg);
     let crate_readme_path = path.join("README.md");
     let new_readme_path = out_dir.join("README.md");
-    if let Err(_) = fs::copy(&crate_readme_path, &new_readme_path) {
-        PBAR.warn("origin crate has no README");
-    };
+    fs::copy(&crate_readme_path, &new_readme_path)?;
     Ok(())
 }


### PR DESCRIPTION
Based on feedback from @fitzgen on #411 I went back and updated the copying of the README.md file to propagate the error as well if one occurs. I had referenced that functionality in writing the license copy so I figured it would be good to go back and update that one as well.

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
