### PR TITLE
Add optional --package-name argument to override package name.

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -47,7 +47,7 @@ wasm-pack build --target nodejs
 
 ## Scope
 
-The init command also accepts an optional `--scope` argument. This will scope
+The `build` command also accepts an optional `--scope` argument. This will scope
 your package name, which is useful if your package name might conflict with
 something in the public registry. For example:
 
@@ -60,6 +60,20 @@ This command would create a `package.json` file for a package called
 the npm documentation [here][npm-scope-documentation].
 
 [npm-scope-documentation]: https://docs.npmjs.com/misc/scope
+
+## Package Name
+
+The `build` command also accepts an optional `--package-name` argument. This
+flag allows you to override the default package name, which is the same as your
+crate's package name. This argument can be used in conjunction with `--scope`.
+For example:
+
+```
+wasm-pack build examples/js-hello-world --scope test --package-name custom-name
+```
+
+This command would create a `package.json` file for a package called
+`@test/custom-name`.
 
 ## Mode
 

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -19,6 +19,7 @@ use PBAR;
 /// Everything required to configure and run the `wasm-pack init` command.
 pub(crate) struct Build {
     pub crate_path: PathBuf,
+    pub package_name: Option<String>,
     pub scope: Option<String>,
     pub disable_dts: bool,
     pub target: String,
@@ -67,6 +68,11 @@ pub struct BuildOptions {
     #[structopt(parse(from_os_str))]
     pub path: Option<PathBuf>,
 
+    /// The package name to apply in package.json, if specified. Omission
+    /// means we should use the crate name.
+    #[structopt(long = "package-name")]
+    pub package_name: Option<String>,
+
     /// The npm scope to use in package.json, if any.
     #[structopt(long = "scope", short = "s")]
     pub scope: Option<String>,
@@ -105,6 +111,7 @@ impl Build {
         // let build_config = manifest::xxx(&crate_path).xxx();
         Ok(Build {
             crate_path,
+            package_name: build_opts.package_name,
             scope: build_opts.scope,
             disable_dts: build_opts.disable_dts,
             target: build_opts.target,
@@ -242,6 +249,7 @@ impl Build {
         manifest::write_package_json(
             &self.crate_path,
             &self.out_dir,
+            &self.package_name,
             &self.scope,
             self.disable_dts,
             &self.target,

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -95,7 +95,12 @@ fn read_cargo_toml(path: &Path) -> Result<CargoManifest, failure::Error> {
 }
 
 impl CargoManifest {
-    fn into_commonjs(mut self, scope: &Option<String>, disable_dts: bool) -> NpmPackage {
+    fn into_commonjs(
+        mut self,
+        package_name: &Option<String>,
+        scope: &Option<String>,
+        disable_dts: bool,
+    ) -> NpmPackage {
         let filename = self.package.name.replace("-", "_");
         let wasm_file = format!("{}_bg.wasm", filename);
         let js_file = format!("{}.js", filename);
@@ -103,6 +108,10 @@ impl CargoManifest {
 
         let js_bg_file = format!("{}_bg.js", filename);
         files.push(js_bg_file.to_string());
+
+        if let Some(s) = package_name {
+            self.package.name = s.to_string();
+        }
 
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
@@ -134,7 +143,12 @@ impl CargoManifest {
         })
     }
 
-    fn into_esmodules(mut self, scope: &Option<String>, disable_dts: bool) -> NpmPackage {
+    fn into_esmodules(
+        mut self,
+        package_name: &Option<String>,
+        scope: &Option<String>,
+        disable_dts: bool,
+    ) -> NpmPackage {
         let filename = self.package.name.replace("-", "_");
         let wasm_file = format!("{}_bg.wasm", filename);
         let js_file = format!("{}.js", filename);
@@ -147,6 +161,10 @@ impl CargoManifest {
         } else {
             None
         };
+
+        if let Some(s) = package_name {
+            self.package.name = s.to_string();
+        }
 
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
@@ -171,7 +189,12 @@ impl CargoManifest {
         })
     }
 
-    fn into_nomodules(mut self, scope: &Option<String>, disable_dts: bool) -> NpmPackage {
+    fn into_nomodules(
+        mut self,
+        package_name: &Option<String>,
+        scope: &Option<String>,
+        disable_dts: bool,
+    ) -> NpmPackage {
         let filename = self.package.name.replace("-", "_");
         let wasm_file = format!("{}_bg.wasm", filename);
         let js_file = format!("{}.js", filename);
@@ -184,6 +207,10 @@ impl CargoManifest {
         } else {
             None
         };
+
+        if let Some(s) = package_name {
+            self.package.name = s.to_string();
+        }
 
         if let Some(s) = scope {
             self.package.name = format!("@{}/{}", s, self.package.name);
@@ -212,6 +239,7 @@ impl CargoManifest {
 pub fn write_package_json(
     path: &Path,
     out_dir: &Path,
+    package_name: &Option<String>,
     scope: &Option<String>,
     disable_dts: bool,
     target: &str,
@@ -224,11 +252,11 @@ pub fn write_package_json(
     let mut pkg_file = File::create(pkg_file_path)?;
     let crate_data = read_cargo_toml(path)?;
     let npm_data = if target == "nodejs" {
-        crate_data.into_commonjs(scope, disable_dts)
+        crate_data.into_commonjs(package_name, scope, disable_dts)
     } else if target == "no-modules" {
-        crate_data.into_nomodules(scope, disable_dts)
+        crate_data.into_nomodules(package_name, scope, disable_dts)
     } else {
-        crate_data.into_esmodules(scope, disable_dts)
+        crate_data.into_esmodules(package_name, scope, disable_dts)
     };
 
     let npm_json = serde_json::to_string_pretty(&npm_data)?;

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -62,7 +62,10 @@ fn it_creates_a_package_json_default_path() {
     let out_dir = fixture.path.join("pkg");
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
-    assert!(manifest::write_package_json(&fixture.path, &out_dir, &None, false, "", &step).is_ok());
+    assert!(
+        manifest::write_package_json(&fixture.path, &out_dir, &None, &None, false, "", &step)
+            .is_ok()
+    );
     let package_json_path = &fixture.path.join("pkg").join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::manifest::read_package_json(&fixture.path, &out_dir).is_ok());
@@ -95,7 +98,10 @@ fn it_creates_a_package_json_provided_path() {
     let out_dir = fixture.path.join("pkg");
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
-    assert!(manifest::write_package_json(&fixture.path, &out_dir, &None, false, "", &step).is_ok());
+    assert!(
+        manifest::write_package_json(&fixture.path, &out_dir, &None, &None, false, "", &step)
+            .is_ok()
+    );
     let package_json_path = &fixture.path.join("pkg").join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
@@ -124,6 +130,7 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     assert!(manifest::write_package_json(
         &fixture.path,
         &out_dir,
+        &None,
         &Some("test".to_string()),
         false,
         "",
@@ -150,15 +157,56 @@ fn it_creates_a_package_json_provided_path_with_scope() {
 }
 
 #[test]
+fn it_creates_a_package_json_provided_path_with_package_name() {
+    let fixture = fixture::js_hello_world();
+    let out_dir = fixture.path.join("pkg");
+    let step = wasm_pack::progressbar::Step::new(1);
+    wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
+    assert!(manifest::write_package_json(
+        &fixture.path,
+        &out_dir,
+        &Some("custom-package-name".to_string()),
+        &None,
+        false,
+        "",
+        &step
+    )
+    .is_ok());
+    let package_json_path = &fixture.path.join("pkg").join("package.json");
+    assert!(fs::metadata(package_json_path).is_ok());
+    assert!(utils::manifest::read_package_json(&fixture.path, &out_dir).is_ok());
+    let pkg = utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
+    assert_eq!(pkg.name, "custom-package-name");
+    assert_eq!(pkg.module, "js_hello_world.js");
+
+    let actual_files: HashSet<String> = pkg.files.into_iter().collect();
+    let expected_files: HashSet<String> = [
+        "js_hello_world_bg.wasm",
+        "js_hello_world.d.ts",
+        "js_hello_world.js",
+    ]
+    .iter()
+    .map(|&s| String::from(s))
+    .collect();
+    assert_eq!(actual_files, expected_files);
+}
+
+#[test]
 fn it_creates_a_pkg_json_with_correct_files_on_node() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
-    assert!(
-        manifest::write_package_json(&fixture.path, &out_dir, &None, false, "nodejs", &step)
-            .is_ok()
-    );
+    assert!(manifest::write_package_json(
+        &fixture.path,
+        &out_dir,
+        &None,
+        &None,
+        false,
+        "nodejs",
+        &step
+    )
+    .is_ok());
     let package_json_path = &out_dir.join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
@@ -193,6 +241,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_nomodules() {
     assert!(manifest::write_package_json(
         &fixture.path,
         &out_dir,
+        &None,
         &None,
         false,
         "no-modules",
@@ -230,7 +279,10 @@ fn it_creates_a_pkg_json_in_out_dir() {
     let out_dir = fixture.path.join("./custom/out");
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
-    assert!(manifest::write_package_json(&fixture.path, &out_dir, &None, false, "", &step).is_ok());
+    assert!(
+        manifest::write_package_json(&fixture.path, &out_dir, &None, &None, false, "", &step)
+            .is_ok()
+    );
 
     let package_json_path = &fixture.path.join(&out_dir).join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
@@ -243,7 +295,10 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
     let out_dir = fixture.path.join("pkg");
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
-    assert!(manifest::write_package_json(&fixture.path, &out_dir, &None, true, "", &step).is_ok());
+    assert!(
+        manifest::write_package_json(&fixture.path, &out_dir, &None, &None, true, "", &step)
+            .is_ok()
+    );
     let package_json_path = &out_dir.join("package.json");
     assert!(fs::metadata(package_json_path).is_ok());
     assert!(utils::manifest::read_package_json(&fixture.path, &out_dir).is_ok());


### PR DESCRIPTION
This PR attempts to address #427 by introducing an optional `--package-name` build-time flag.