### PR TITLE
Don't require cdylib crate-type for testing

### DIFF
--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -188,7 +188,6 @@ impl Test {
         match self.mode {
             BuildMode::Normal => steps![
                 step_check_rustc_version,
-                step_check_crate_config,
                 step_add_wasm_target,
                 step_build_tests,
                 step_install_wasm_bindgen,
@@ -213,7 +212,6 @@ impl Test {
                 step_test_safari if self.safari,
             ],
             BuildMode::Noinstall => steps![
-                step_check_crate_config,
                 step_build_tests,
                 step_install_wasm_bindgen,
                 step_test_node if self.node,
@@ -231,13 +229,6 @@ impl Test {
         info!(log, "Checking rustc version...");
         let _ = build::check_rustc_version(step)?;
         info!(log, "Rustc version is correct.");
-        Ok(())
-    }
-
-    fn step_check_crate_config(&mut self, step: &Step, log: &Logger) -> Result<(), Error> {
-        info!(log, "Checking crate configuration...");
-        self.crate_data.check_crate_config(step)?;
-        info!(log, "Crate is correctly configured.");
         Ok(())
     }
 

--- a/tests/all/test.rs
+++ b/tests/all/test.rs
@@ -286,3 +286,51 @@ fn renamed_crate_name_works() {
     });
     fixture.run(cmd).unwrap();
 }
+
+#[test]
+fn cdylib_not_required() {
+    let fixture = fixture::Fixture::new();
+    fixture
+        .readme()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                wasm-bindgen = "=0.2.21"
+
+                [dev-dependencies]
+                wasm-bindgen-test = "=0.2.21"
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                pub fn foo() -> u32 { 1 }
+            "#,
+        )
+        .file(
+            "tests/foo.rs",
+            r#"
+                extern crate wasm_bindgen_test;
+                use wasm_bindgen_test::*;
+
+                #[wasm_bindgen_test]
+                fn smoke() {
+                    foo::foo();
+                }
+            "#,
+        );
+    fixture.install_local_wasm_bindgen();
+    let cmd = Command::Test(test::TestOptions {
+        path: Some(fixture.path.clone()),
+        node: true,
+        mode: build::BuildMode::Noinstall,
+        ..Default::default()
+    });
+    fixture.run(cmd).unwrap();
+}


### PR DESCRIPTION
The `cdylib` crate type output isn't actually necessary for the
`wasm-pack test` stage because `wasm-bindgen` isn't run over a wasm
file. This commit removes the checks during `wasm-pack test` that the
`cdylib` crate type is configured.
