### PR TITLE
Generate self-.gitignore as part of pkg folder

### DIFF
--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -18,6 +18,7 @@ pub fn create_pkg_dir(out_dir: &Path, step: &Step) -> Result<(), failure::Error>
     let msg = format!("{}Creating a pkg directory...", emoji::FOLDER);
     PBAR.step(step, &msg);
     fs::create_dir_all(&out_dir)?;
+    fs::write(out_dir.join(".gitignore"), "*")?;
     Ok(())
 }
 


### PR DESCRIPTION
As per discussion with @ashleygwilliams in https://twitter.com/ag_dubs/status/1068173944807727110, `pkg` should be commonly ignored, and the simplest way to do that is to just generate nested `.gitignore` inside it ignoring everything (including `.gitignore` itself).

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `rustfmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
