### PR TITLE
Add rust-toolchain file set to nightly

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,10 @@
 Make sure these boxes are checked! 📦✅
 
-- [ ] You have the latest version of `rustfmt` installed and have your 
-      cloned directory set to nightly
+- [ ] You have the latest version of `rustfmt` installed
 ```bash
-$ rustup override set nightly
 $ rustup component add rustfmt-preview --toolchain nightly
 ```
-- [ ] You ran `rustfmt` on the code base before submitting
+- [ ] You ran `cargo fmt` on the code base before submitting
 - [ ] You reference which issue is being closed in the PR text
 
 ✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This allows new contributors to avoid manually running `rustup override set nightly`.