### PR TITLE
Fix link to manual setup instructions from getting started

### DIFF
--- a/docs/src/tutorial/getting-started.md
+++ b/docs/src/tutorial/getting-started.md
@@ -25,4 +25,4 @@ further in this guide.
 ⚠️ If you'd rather not use a template, or are having trouble with the template, you can
 do a manual setup by following [these instructions].
 
-[these instructions]: ../project-setup/manual-setup/index.html
+[these instructions]: ../project-setup/manual-setup.html


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ ] You have the latest version of `rustfmt` installed and have your 
      cloned directory set to nightly
```bash
$ rustup override set nightly
$ rustup component add rustfmt-preview --toolchain nightly
```
- [ ] You ran `rustfmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
