### PR TITLE
Refactor license copy to remove unwrap()

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -12,7 +12,16 @@ use PBAR;
 
 fn glob_license_files(path: &Path) -> Result<Vec<String>, failure::Error> {
     let mut license_files: Vec<String> = Vec::new();
-    for entry in glob(path.join("LICENSE*").to_str().unwrap())? {
+    let path_string = match path.join("LICENSE*").to_str() {
+        Some(path_string) => path_string.to_owned(),
+        None => {
+            return Err(format_err!(
+                "Could not convert joined license path to String"
+            ));
+        }
+    };
+
+    for entry in glob(&path_string)? {
         match entry {
             Ok(globed_path) => {
                 let file_name = match globed_path.file_name() {
@@ -20,10 +29,10 @@ fn glob_license_files(path: &Path) -> Result<Vec<String>, failure::Error> {
                     None => return Err(format_err!("Could not get file name from path")),
                 };
                 let file_name_string = match file_name.to_str() {
-                    Some(file_name_string) => file_name_string,
-                    None => return Err(format_err!("Could not convert filename to string")),
+                    Some(file_name_string) => file_name_string.to_owned(),
+                    None => return Err(format_err!("Could not convert filename to String")),
                 };
-                license_files.push(String::from(file_name_string));
+                license_files.push(file_name_string);
             }
             Err(e) => println!("{:?}", e),
         }

--- a/src/license.rs
+++ b/src/license.rs
@@ -15,9 +15,15 @@ fn glob_license_files(path: &Path) -> Result<Vec<String>, failure::Error> {
     for entry in glob(path.join("LICENSE*").to_str().unwrap())? {
         match entry {
             Ok(globed_path) => {
-                license_files.push(String::from(
-                    globed_path.file_name().unwrap().to_str().unwrap(),
-                ));
+                let file_name = match globed_path.file_name() {
+                    Some(file_name) => file_name,
+                    None => return Err(format_err!("Could not get file name from path")),
+                };
+                let file_name_string = match file_name.to_str() {
+                    Some(file_name_string) => file_name_string,
+                    None => return Err(format_err!("Could not convert filename to string")),
+                };
+                license_files.push(String::from(file_name_string));
             }
             Err(e) => println!("{:?}", e),
         }
@@ -50,14 +56,14 @@ pub fn copy_from_crate(
 
             match license_files {
                 Ok(files) => {
-                    if files.len() == 0 {
+                    if files.is_empty() {
                         PBAR.info("License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory");
                         return Ok(());
                     }
                     for license_file in files {
                         let crate_license_path = path.join(&license_file);
                         let new_license_path = out_dir.join(&license_file);
-                        if let Err(_) = fs::copy(&crate_license_path, &new_license_path) {
+                        if fs::copy(&crate_license_path, &new_license_path).is_err() {
                             PBAR.info("origin crate has no LICENSE");
                         }
                     }


### PR DESCRIPTION
Closes #475 

I've changed the code that utilized `unwrap()`and handled the `None` case of the option explicitly returning an Error if we get a `None`.

Side note: I also refactored a couple of places in the file based on some clippy linting warnings.

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
