### PR TITLE
Refactor: fix clippy warnings

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 8

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -192,7 +192,7 @@ impl Build {
 
     /// Execute this `Build` command.
     pub fn run(&mut self) -> Result<(), Error> {
-        let process_steps = Build::get_process_steps(&self.mode);
+        let process_steps = Build::get_process_steps(self.mode);
 
         let mut step_counter = Step::new(process_steps.len());
 

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -220,7 +220,7 @@ impl Build {
         Ok(())
     }
 
-    fn get_process_steps(mode: &BuildMode) -> Vec<(&'static str, BuildStep)> {
+    fn get_process_steps(mode: BuildMode) -> Vec<(&'static str, BuildStep)> {
         macro_rules! steps {
             ($($name:ident),+) => {
                 {

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -5,11 +5,11 @@ use PBAR;
 
 pub fn login(
     registry: Option<String>,
-    scope: Option<String>,
+    scope: &Option<String>,
     always_auth: bool,
-    auth_type: Option<String>,
+    auth_type: &Option<String>,
 ) -> result::Result<(), failure::Error> {
-    let registry = registry.unwrap_or(npm::DEFAULT_NPM_REGISTRY.to_string());
+    let registry = registry.unwrap_or_else(|| npm::DEFAULT_NPM_REGISTRY.to_string());
 
     info!("Logging in to npm...");
     info!(
@@ -20,6 +20,6 @@ pub fn login(
     npm::npm_login(&registry, &scope, always_auth, &auth_type)?;
     info!("Logged you in!");
 
-    PBAR.message(&format!("👋  logged you in!"));
+    PBAR.message(&"👋  logged you in!".to_string());
     Ok(())
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -107,7 +107,7 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
         } => {
             info!("Running publish command...");
             info!("Path: {:?}", &path);
-            publish(target, path, access)
+            publish(&target, path, access)
         }
         Command::Login {
             registry,

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -90,7 +90,7 @@ pub enum Command {
 pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
     // Run the correct command based off input and store the result of it so that we can clear
     // the progress bar then return it
-    let status = match command {
+    match command {
         Command::Build(build_opts) => {
             info!("Running build command...");
             Build::try_from_opts(build_opts).and_then(|mut b| b.run())
@@ -120,14 +120,11 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
                 "Registry: {:?}, Scope: {:?}, Always Auth: {}, Auth Type: {:?}",
                 &registry, &scope, &always_auth, &auth_type
             );
-            login(registry, scope, always_auth, auth_type)
+            login(registry, &scope, always_auth, &auth_type)
         }
         Command::Test(test_opts) => {
             info!("Running test command...");
             Test::try_from_opts(test_opts).and_then(|t| t.run())
         }
-    };
-
-    // Return the actual status of the program to the main function
-    status
+    }
 }

--- a/src/command/publish/mod.rs
+++ b/src/command/publish/mod.rs
@@ -15,7 +15,7 @@ use PBAR;
 /// Creates a tarball from a 'pkg' directory
 /// and publishes it to the NPM registry
 pub fn publish(
-    _target: String,
+    _target: &str,
     path: Option<PathBuf>,
     access: Option<Access>,
 ) -> result::Result<(), Error> {

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -11,7 +11,7 @@ use PBAR;
 /// If an explicit path is given, then use it, otherwise assume the current
 /// directory is the crate path.
 pub fn set_crate_path(path: Option<PathBuf>) -> Result<PathBuf, failure::Error> {
-    Ok(path.unwrap_or(PathBuf::from(".")))
+    Ok(path.unwrap_or_else(|| PathBuf::from(".")))
 }
 
 /// Construct our `pkg` directory in the crate.

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -114,7 +114,7 @@ fn confirm_can_overwrite(dst: &Path) -> Result<(), failure::Error> {
         .read_line(&mut line)
         .with_context(|_| "failed to read stdin")?;
 
-    if line.starts_with("y") || line.starts_with("Y") {
+    if line.starts_with('y') || line.starts_with('Y') {
         return Ok(());
     }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,5 +1,7 @@
 //! Reading Cargo.lock lock file.
 
+#![allow(clippy::new_ret_no_self)]
+
 use std::fs;
 use std::path::PathBuf;
 

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -1,5 +1,7 @@
 //! Reading and writing Cargo.toml and package.json manifests.
 
+#![allow(clippy::new_ret_no_self, clippy::needless_pass_by_value)]
+
 mod npm;
 
 use std::fs;
@@ -20,7 +22,7 @@ use strsim::levenshtein;
 use toml;
 use PBAR;
 
-const WASM_PACK_METADATA_KEY: &'static str = "package.metadata.wasm-pack";
+const WASM_PACK_METADATA_KEY: &str = "package.metadata.wasm-pack";
 
 /// Store for metadata learned about a crate
 pub struct CrateData {
@@ -145,7 +147,7 @@ impl CargoWasmPackProfile {
         D: serde::Deserializer<'de>,
     {
         let mut profile = <Option<Self>>::deserialize(deserializer)?.unwrap_or_default();
-        profile.update_with_defaults(Self::default_dev());
+        profile.update_with_defaults(&Self::default_dev());
         Ok(profile)
     }
 
@@ -154,7 +156,7 @@ impl CargoWasmPackProfile {
         D: serde::Deserializer<'de>,
     {
         let mut profile = <Option<Self>>::deserialize(deserializer)?.unwrap_or_default();
-        profile.update_with_defaults(Self::default_release());
+        profile.update_with_defaults(&Self::default_release());
         Ok(profile)
     }
 
@@ -163,11 +165,11 @@ impl CargoWasmPackProfile {
         D: serde::Deserializer<'de>,
     {
         let mut profile = <Option<Self>>::deserialize(deserializer)?.unwrap_or_default();
-        profile.update_with_defaults(Self::default_profiling());
+        profile.update_with_defaults(&Self::default_profiling());
         Ok(profile)
     }
 
-    fn update_with_defaults(&mut self, defaults: Self) {
+    fn update_with_defaults(&mut self, defaults: &Self) {
         macro_rules! d {
             ( $( $path:ident ).* ) => {
                 self. $( $path ).* .get_or_insert(defaults. $( $path ).* .unwrap());
@@ -248,7 +250,7 @@ impl CrateData {
             for e in errors[..errors.len() - 1].iter().rev() {
                 err = err.context(e.to_string()).into();
             }
-            return err;
+            err
         }
     }
 

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -6,7 +6,7 @@ use failure::{self, ResultExt};
 use log::info;
 
 /// The default npm registry used when we aren't working with a custom registry.
-pub const DEFAULT_NPM_REGISTRY: &'static str = "https://registry.npmjs.org/";
+pub const DEFAULT_NPM_REGISTRY: &str = "https://registry.npmjs.org/";
 
 /// Run the `npm pack` command.
 pub fn npm_pack(path: &str) -> Result<(), failure::Error> {
@@ -33,7 +33,7 @@ pub fn npm_publish(path: &str, access: Option<Access>) -> Result<(), failure::Er
 
 /// Run the `npm login` command.
 pub fn npm_login(
-    registry: &String,
+    registry: &str,
     scope: &Option<String>,
     always_auth: bool,
     auth_type: &Option<String>,

--- a/src/progressbar.rs
+++ b/src/progressbar.rs
@@ -75,7 +75,7 @@ impl ProgressOutput {
     }
 
     /// Add an error message.
-    pub fn error(&self, message: String) {
+    pub fn error(&self, message: &str) {
         let err = format!(
             "{} {}: {}",
             emoji::ERROR,
@@ -133,5 +133,11 @@ impl fmt::Display for Step {
 impl Drop for ProgressOutput {
     fn drop(&mut self) {
         self.done();
+    }
+}
+
+impl Default for ProgressOutput {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -23,8 +23,8 @@ pub fn copy_from_crate(path: &Path, out_dir: &Path, step: &Step) -> Result<(), f
     PBAR.step(step, &msg);
     let crate_readme_path = path.join("README.md");
     let new_readme_path = out_dir.join("README.md");
-    if let Err(_) = fs::copy(&crate_readme_path, &new_readme_path) {
+    if fs::copy(&crate_readme_path, &new_readme_path).is_err() {
         PBAR.warn("origin crate has no README");
-    };
+    }
     Ok(())
 }


### PR DESCRIPTION
closes #477 

This is a first pass PR at cleaning up the clippy warnings. Most of them were simple enough refactors that it only took minor modifications to the code to get rid of the warnings. There were a few warnings, marked by `#![allow()]`, that would require more significant changes to the code structure so instead of going ahead and implementing those changes I marked them as clippy allow until we can decide if the changes are something we want or not.  

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
