### PR TITLE
🌈 cargo: make command output with color

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -130,7 +130,9 @@ pub fn cargo_install_wasm_bindgen(
         .arg("--version")
         .arg(version)
         .arg("--root")
-        .arg(&tmp);
+        .arg(&tmp)
+        .arg("--color")
+        .arg("always");
 
     child::run(logger, cmd, "cargo install").context("Installing wasm-bindgen with cargo")?;
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -91,6 +91,7 @@ pub fn cargo_build_wasm(
         }
     }
     cmd.arg("--target").arg("wasm32-unknown-unknown");
+    cmd.arg("--color").arg("always");
     child::run(log, cmd, "cargo build").context("Compiling your crate to WebAssembly failed")?;
     Ok(())
 }
@@ -103,6 +104,7 @@ pub fn cargo_build_wasm_tests(log: &Logger, path: &Path, debug: bool) -> Result<
         cmd.arg("--release");
     }
     cmd.arg("--target").arg("wasm32-unknown-unknown");
+    cmd.arg("--color").arg("always");
     child::run(log, cmd, "cargo build").context("Compilation of your program failed")?;
     Ok(())
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -30,6 +30,7 @@ where
             cmd.arg("--release");
         }
         cmd.arg("--target").arg("wasm32-unknown-unknown");
+        cmd.arg("--color").arg("always");
         child::run(log, cmd, "cargo test")
             .context("Running Wasm tests with wasm-bindgen-test failed")?
     };

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -235,6 +235,8 @@ impl Fixture {
             .arg("check")
             .arg("--target")
             .arg("wasm32-unknown-unknown")
+            .arg("--color")
+            .arg("always")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()


### PR DESCRIPTION
All `cargo` calls were without color because
they were missing the `--color` flag with the
`always` value.

Examples of the terminal with color :rainbow: 
- Success
![screenshot from 2019-01-03 19-58-12](https://user-images.githubusercontent.com/15306309/50663900-61aed380-0f92-11e9-8a22-08a3af099a14.png)

- Error
![screenshot from 2019-01-03 20-57-06](https://user-images.githubusercontent.com/15306309/50666043-2e704280-0f9a-11e9-9263-89ca20708109.png)


Make sure these boxes are checked! 📦✅

- [ ] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt-preview --toolchain nightly
```
- [ ] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

This pull request closes this issue: https://github.com/rustwasm/wasm-pack/issues/480