### PR TITLE
Login issues

### DIFF
--- a/src/npm.rs
+++ b/src/npm.rs
@@ -62,12 +62,14 @@ pub fn npm_login(
         args.push_str(&format!(" --auth_type={}", auth_type));
     }
 
+    // Interactively ask user for npm login info.
+    //  (child::run does not support interactive input)
     let mut cmd = Command::new("npm");
-    cmd.arg("login")
-        .arg(args)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit());
-    child::run(log, cmd, "npm login")
-        .with_context(|_| format!("Login to registry {} failed", registry))?;
-    Ok(())
+    cmd.arg("login").arg(args);
+
+    info!(log, "Running {:?}", cmd);
+    match cmd.status()?.success() {
+        true => Ok(()),
+        false => bail!("Login to registry {} failed", registry),
+    }
 }

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -46,26 +46,24 @@ pub fn npm_login(
     always_auth: bool,
     auth_type: &Option<String>,
 ) -> Result<(), failure::Error> {
-    let mut args = String::new();
-
-    args.push_str(&format!("--registry={}", registry));
+    let mut args = vec![format!("login"), format!("--registry={}", registry)];
 
     if let Some(scope) = scope {
-        args.push_str(&format!(" --scope={}", scope));
+        args.push(format!("--scope={}", scope));
     }
 
     if always_auth == true {
-        args.push_str(" --always_auth");
+        args.push(format!("--always_auth"));
     }
 
     if let Some(auth_type) = auth_type {
-        args.push_str(&format!(" --auth_type={}", auth_type));
+        args.push(format!("--auth_type={}", auth_type));
     }
 
     // Interactively ask user for npm login info.
     //  (child::run does not support interactive input)
     let mut cmd = Command::new("npm");
-    cmd.arg("login").arg(args);
+    cmd.args(args);
 
     info!(log, "Running {:?}", cmd);
     match cmd.status()?.success() {


### PR DESCRIPTION
1. Fixes Issue #486: Empty input prompt when `login`.
2. Fixes `login` arguments being accidentally merged together when spawning `npm adduser`.

See the text of each commit for more details.


- [✅] You have the latest version of `rustfmt` installed
- [✅] You ran `cargo fmt` on the code base before submitting
- [✅] You reference which issue is being closed in the PR text
