### PR TITLE
Windows fixes

### DIFF
--- a/src/npm.rs
+++ b/src/npm.rs
@@ -4,14 +4,13 @@ use child;
 use command::publish::access::Access;
 use failure::{self, ResultExt};
 use slog::Logger;
-use std::process::Command;
 
 /// The default npm registry used when we aren't working with a custom registry.
 pub const DEFAULT_NPM_REGISTRY: &'static str = "https://registry.npmjs.org/";
 
 /// Run the `npm pack` command.
 pub fn npm_pack(log: &Logger, path: &str) -> Result<(), failure::Error> {
-    let mut cmd = Command::new("npm");
+    let mut cmd = child::new_command("npm");
     cmd.current_dir(path).arg("pack");
     child::run(log, cmd, "npm pack").context("Packaging up your code failed")?;
     Ok(())
@@ -19,7 +18,7 @@ pub fn npm_pack(log: &Logger, path: &str) -> Result<(), failure::Error> {
 
 /// Run the `npm publish` command.
 pub fn npm_publish(log: &Logger, path: &str, access: Option<Access>) -> Result<(), failure::Error> {
-    let mut cmd = Command::new("npm");
+    let mut cmd = child::new_command("npm");
     match access {
         Some(a) => cmd
             .current_dir(path)
@@ -56,7 +55,7 @@ pub fn npm_login(
 
     // Interactively ask user for npm login info.
     //  (child::run does not support interactive input)
-    let mut cmd = Command::new("npm");
+    let mut cmd = child::new_command("npm");
     cmd.args(args);
 
     info!(log, "Running {:?}", cmd);

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -4,7 +4,7 @@ use child;
 use command::publish::access::Access;
 use failure::{self, ResultExt};
 use slog::Logger;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 /// The default npm registry used when we aren't working with a custom registry.
 pub const DEFAULT_NPM_REGISTRY: &'static str = "https://registry.npmjs.org/";
@@ -24,14 +24,8 @@ pub fn npm_publish(log: &Logger, path: &str, access: Option<Access>) -> Result<(
         Some(a) => cmd
             .current_dir(path)
             .arg("publish")
-            .arg(&format!("{}", a.to_string()))
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit()),
-        None => cmd
-            .current_dir(path)
-            .arg("publish")
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit()),
+            .arg(&format!("{}", a.to_string())),
+        None => cmd.current_dir(path).arg("publish"),
     };
 
     child::run(log, cmd, "npm publish").context("Publishing to npm failed")?;
@@ -52,7 +46,7 @@ pub fn npm_login(
         args.push(format!("--scope={}", scope));
     }
 
-    if always_auth == true {
+    if always_auth {
         args.push(format!("--always_auth"));
     }
 


### PR DESCRIPTION
Issue #277 - Affects running login, pack, and publish on Windows.

Wraps `Command::new` by `child::new_command(program: &str)`. This prepends `cmd /c` to the program name if `cfg!(windows)`. See rustc: #42436, #42791, #44542

See commits for more details. Tested build/login/pack/publish on the latest stable Windows, Mac, and Ubuntu.

- [✅] You have the latest version of `rustfmt` installed
- [✅] You ran `cargo fmt` on the code base before submitting
- [✅] You reference which issue is being closed in the PR text
