### PR TITLE
Support license-file field in Cargo.toml

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -57,8 +57,8 @@ pub fn copy_from_crate(
         "crate's pkg directory should exist"
     );
 
-    match crate_data.crate_license() {
-        Some(_) => {
+    match (crate_data.crate_license(), crate_data.crate_license_file()) {
+        (Some(_), _) => {
             let msg = format!("{}Copying over your LICENSE...", emoji::DANCERS);
             PBAR.step(step, &msg);
             let license_files = glob_license_files(path);
@@ -80,7 +80,14 @@ pub fn copy_from_crate(
                 Err(_) => PBAR.info("origin crate has no LICENSE"),
             }
         }
-        None => {
+        (None, Some(license_file)) => {
+            let crate_license_path = path.join(&license_file);
+            let new_license_path = out_dir.join(&license_file);
+            if fs::copy(&crate_license_path, &new_license_path).is_err() {
+                PBAR.info("origin crate has no LICENSE");
+            }
+        }
+        (None, None) => {
             PBAR.step(step, "No LICENSE found in Cargo.toml, skipping...");
         }
     };

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -40,6 +40,7 @@ struct CargoPackage {
     name: String,
     description: Option<String>,
     license: Option<String>,
+    license_file: Option<String>,
     repository: Option<String>,
 
     #[serde(default)]
@@ -425,6 +426,15 @@ impl CrateData {
         }
     }
 
+    fn license(&self) -> Option<String> {
+        self.manifest.package.license.clone().or_else(|| {
+            self.manifest.package.license_file.clone().map(|file| {
+                // When license is written in file: https://docs.npmjs.com/files/package.json#license
+                format!("SEE LICENSE IN {}", file)
+            })
+        })
+    }
+
     fn to_commonjs(&self, scope: &Option<String>, disable_dts: bool) -> NpmPackage {
         let data = self.npm_data(scope, true, disable_dts);
         let pkg = &self.data.packages[self.current_idx];
@@ -436,7 +446,7 @@ impl CrateData {
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
             version: pkg.version.clone(),
-            license: self.manifest.package.license.clone(),
+            license: self.license(),
             repository: self
                 .manifest
                 .package
@@ -463,7 +473,7 @@ impl CrateData {
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
             version: pkg.version.clone(),
-            license: self.manifest.package.license.clone(),
+            license: self.license(),
             repository: self
                 .manifest
                 .package
@@ -491,7 +501,7 @@ impl CrateData {
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
             version: pkg.version.clone(),
-            license: self.manifest.package.license.clone(),
+            license: self.license(),
             repository: self
                 .manifest
                 .package

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -350,6 +350,11 @@ impl CrateData {
         &self.manifest.package.license
     }
 
+    /// Get the license file path for the crate at the given path.
+    pub fn crate_license_file(&self) -> &Option<String> {
+        &self.manifest.package.license_file
+    }
+
     /// Returns the path to this project's target directory where artifacts are
     /// located after a cargo build.
     pub fn target_directory(&self) -> &Path {

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -40,6 +40,7 @@ struct CargoPackage {
     name: String,
     description: Option<String>,
     license: Option<String>,
+    #[serde(rename = "license-file")]
     license_file: Option<String>,
     repository: Option<String>,
 

--- a/tests/all/license.rs
+++ b/tests/all/license.rs
@@ -34,7 +34,7 @@ fn it_copies_a_license_default_path() {
 }
 
 #[test]
-fn it_copies_a_license_provied_path() {
+fn it_copies_a_license_provided_path() {
     let fixture = fixture::single_license();
     let out_dir = fixture.path.join("pkg");
     fs::create_dir(&out_dir).expect("should create pkg directory OK");
@@ -127,4 +127,31 @@ fn it_copies_all_licenses_provided_path() {
     let crate_license_2 = utils::file::read_file(&crate_license_path_2).unwrap();
     let pkg_license_2 = utils::file::read_file(&pkg_license_path_2).unwrap();
     assert_eq!(crate_license_2, pkg_license_2);
+}
+
+#[test]
+fn it_copies_a_non_standard_license_provided_path() {
+    let license_file = "NON-STANDARD-LICENSE";
+    let fixture = fixture::non_standard_license(license_file);
+    let out_dir = fixture.path.join("pkg");
+    fs::create_dir(&out_dir).expect("should create pkg directory OK");
+    let crate_data = CrateData::new(&fixture.path);
+
+    let step = wasm_pack::progressbar::Step::new(1);
+    assert!(license::copy_from_crate(&crate_data.unwrap(), &fixture.path, &out_dir, &step).is_ok());
+
+    let crate_license_path = fixture.path.join(license_file);
+    let pkg_license_path = out_dir.join(license_file);
+    println!(
+        "wasm-pack: should have copied LICENSE from '{}' to '{}'",
+        crate_license_path.display(),
+        pkg_license_path.display()
+    );
+    assert!(fs::metadata(&crate_license_path).is_ok());
+
+    assert!(fs::metadata(&pkg_license_path).is_ok());
+
+    let crate_license = utils::file::read_file(&crate_license_path).unwrap();
+    let pkg_license = utils::file::read_file(&pkg_license_path).unwrap();
+    assert_eq!(crate_license, pkg_license);
 }

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -137,6 +137,39 @@ impl Fixture {
         )
     }
 
+    /// Add a `Cargo.toml` with a correctly configured `wasm-bindgen`
+    /// dependency, `wasm-bindgen-test` dev-dependency, and `crate-type =
+    /// ["cdylib"]`.
+    ///
+    /// `name` is the crate's name.
+    /// `license_file` is license file path
+    pub fn cargo_toml_with_license_file(&self, name: &str, license_file: &str) -> &Self {
+        self.file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    authors = ["The wasm-pack developers"]
+                    description = "so awesome rust+wasm package"
+                    name = "{}"
+                    license-file = "{}"
+                    repository = "https://github.com/rustwasm/wasm-pack.git"
+                    version = "0.1.0"
+
+                    [lib]
+                    crate-type = ["cdylib"]
+
+                    [dependencies]
+                    wasm-bindgen = "=0.2.21"
+
+                    [dev-dependencies]
+                    wasm-bindgen-test = "=0.2.21"
+                "#,
+                name, license_file
+            ),
+        )
+    }
+
     /// Add a `src/lib.rs` file that contains a "hello world" program.
     pub fn hello_world_src_lib(&self) -> &Self {
         self.file(
@@ -658,6 +691,16 @@ pub fn dual_license() -> Fixture {
         .cargo_toml("dual_license")
         .wtfpl_license()
         .mit_license()
+        .hello_world_src_lib();
+    fixture
+}
+
+pub fn non_standard_license(license_file: &str) -> Fixture {
+    let fixture = Fixture::new();
+    fixture
+        .readme()
+        .cargo_toml_with_license_file("dual_license", license_file)
+        .file(license_file, "license file for test")
         .hello_world_src_lib();
     fixture
 }


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
  - I checked issues list. No issue was found.

In my package, no `license` field is provided in `Cargo.toml`, but `license-file` is provided. I noticed `wasm-pack` does not copy license file specified in `license-file` field.

https://doc.rust-lang.org/cargo/reference/manifest.html

This patch supports `license-file` field by following two additions:

- `wasm-pack` copies file specified in `license-file` in `Cargo.toml` into `pkg` directory
- Set `"SEE LICENSE IN <filename>"` to `license` field of `package.json`. This is standard way documented in official npm document: https://docs.npmjs.com/files/package.json#license

I added one new test case to check my implementation works fine.

> ✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

:+1:
