### PR TITLE
Add license files and README file to 'files' field of package.json

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -239,29 +239,29 @@ impl Build {
                 step_add_wasm_target,
                 step_build_wasm,
                 step_create_dir,
-                step_create_json,
                 step_copy_readme,
                 step_copy_license,
                 step_install_wasm_bindgen,
                 step_run_wasm_bindgen,
+                step_create_json,
             ],
             BuildMode::Noinstall => steps![
                 step_check_rustc_version,
                 step_check_crate_config,
                 step_build_wasm,
                 step_create_dir,
-                step_create_json,
                 step_copy_readme,
                 step_copy_license,
-                step_run_wasm_bindgen
+                step_run_wasm_bindgen,
+                step_create_json,
             ],
             BuildMode::Force => steps![
                 step_build_wasm,
                 step_create_dir,
-                step_create_json,
                 step_copy_readme,
                 step_copy_license,
-                step_run_wasm_bindgen
+                step_run_wasm_bindgen,
+                step_create_json,
             ],
         }
     }


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

## Problems

Currently, `wasm-pack` copies `README.md` and license files into `pkg` directory. But they are not listed in `files` field of `package.json`. `npm publish` does not contain the copied files. This causes 2 problems:

- README.md is not reflected in npmjs.com's package page
- User cannot look the copyright notice of the license file in installed package directory in `node_modules`. Some famous license (e.g. MIT) requires to show copyright notice. So it's better to contain license file in the installed package directory.

## Solution this patch provides

Add `README.md` and detected license files to `files` field of generated `package.json`.

e.g.
```
{
  "name": "foo",
  // ...
  "files": [
    "foo_bg.wasm",
    "foo.js",
    "foo.d.ts",
    "README.md",
    "LICENSE.txt"
  ],
  // ...
}
```