### PR TITLE
Colorize output from cargo on non-Windows OSes

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -134,6 +134,9 @@ pub fn cargo_install_wasm_bindgen(
         .context("failed to create temp dir for `cargo install wasm-bindgen`")?;
 
     let mut cmd = Command::new("cargo");
+    if cfg!(not(windows)) {
+        cmd.arg("--color").arg("always");
+    }
     cmd.arg("install")
         .arg("--force")
         .arg("wasm-bindgen-cli")

--- a/src/build.rs
+++ b/src/build.rs
@@ -70,6 +70,9 @@ pub fn cargo_build_wasm(
     let msg = format!("{}Compiling to WASM...", emoji::CYCLONE);
     PBAR.step(step, &msg);
     let mut cmd = Command::new("cargo");
+    if cfg!(not(windows)) {
+        cmd.arg("--color").arg("always");
+    }
     cmd.current_dir(path).arg("build").arg("--lib");
     match profile {
         BuildProfile::Profiling => {
@@ -97,6 +100,9 @@ pub fn cargo_build_wasm(
 /// Run `cargo build --tests` targetting `wasm32-unknown-unknown`.
 pub fn cargo_build_wasm_tests(path: &Path, debug: bool) -> Result<(), Error> {
     let mut cmd = Command::new("cargo");
+    if cfg!(not(windows)) {
+        cmd.arg("--color").arg("always");
+    }
     cmd.current_dir(path).arg("build").arg("--tests");
     if !debug {
         cmd.arg("--release");


### PR DESCRIPTION
related: #298

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

I found previous attempts at #293 #423. I understood that enabling colors causes a problem on Windows, but I still want to colorize output from cargo because it's much easier to read compilation errors from `cargo build`.

By this patch, I want to suggest to enable colors on non-Windows OSes. I read #298 and it seems to solve the Windows issue, but there is no update on the issue from Nov. If it would still take time to complete, I want to enable colors at least on non-Windows OSes.
