### PR TITLE
Support 'homepage' field of Cargo.toml and package.json

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -41,6 +41,7 @@ struct CargoPackage {
     description: Option<String>,
     license: Option<String>,
     repository: Option<String>,
+    homepage: Option<String>,
 
     #[serde(default)]
     metadata: CargoMetadata,
@@ -199,6 +200,7 @@ struct NpmData {
     files: Vec<String>,
     dts_file: Option<String>,
     main: String,
+    homepage: Option<String>, // https://docs.npmjs.com/files/package.json#homepage
 }
 
 #[doc(hidden)]
@@ -422,6 +424,7 @@ impl CrateData {
             dts_file,
             files,
             main: js_file,
+            homepage: self.manifest.package.homepage.clone(),
         }
     }
 
@@ -448,6 +451,7 @@ impl CrateData {
                 }),
             files: data.files,
             main: data.main,
+            homepage: data.homepage,
             types: data.dts_file,
         })
     }
@@ -475,6 +479,7 @@ impl CrateData {
                 }),
             files: data.files,
             module: data.main,
+            homepage: data.homepage,
             types: data.dts_file,
             side_effects: "false".to_string(),
         })
@@ -503,6 +508,7 @@ impl CrateData {
                 }),
             files: data.files,
             browser: data.main,
+            homepage: data.homepage,
             types: data.dts_file,
         })
     }

--- a/src/manifest/npm/commonjs.rs
+++ b/src/manifest/npm/commonjs.rs
@@ -16,5 +16,7 @@ pub struct CommonJSPackage {
     pub files: Vec<String>,
     pub main: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub types: Option<String>,
 }

--- a/src/manifest/npm/esmodules.rs
+++ b/src/manifest/npm/esmodules.rs
@@ -16,6 +16,8 @@ pub struct ESModulesPackage {
     pub files: Vec<String>,
     pub module: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub types: Option<String>,
     #[serde(rename = "sideEffects")]
     pub side_effects: String,

--- a/src/manifest/npm/nomodules.rs
+++ b/src/manifest/npm/nomodules.rs
@@ -16,5 +16,7 @@ pub struct NoModulesPackage {
     pub files: Vec<String>,
     pub browser: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub types: Option<String>,
 }

--- a/tests/all/utils/manifest.rs
+++ b/tests/all/utils/manifest.rs
@@ -23,6 +23,7 @@ pub struct NpmPackage {
     pub types: String,
     #[serde(default = "default_none", rename = "sideEffects")]
     pub side_effects: String,
+    pub homepage: Option<String>,
 }
 
 fn default_none() -> String {


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
  - I searched 'homepage' word but no open issue was found

Both `Cargo.toml` and `package.json` have `homepage` field. They are meaning the same so I thought `homepage` field should be copied from `Cargo.toml` into `package.json`. This patch implements the feature.

- Cargo.toml
  - https://doc.rust-lang.org/cargo/reference/manifest.html
- package.json
  - https://docs.npmjs.com/files/package.json#homepage

