### PR TITLE
Use win32 chromedriver binary on win64, update chromedriver version and fix error message

### DIFF
--- a/src/test/webdriver.rs
+++ b/src/test/webdriver.rs
@@ -31,14 +31,14 @@ pub fn install_chromedriver(
         "linux64"
     } else if target::MACOS && target::x86_64 {
         "mac64"
-    } else if target::WINDOWS && target::x86 {
+    } else if target::WINDOWS {
         "win32"
     } else {
-        bail!("geckodriver binaries are unavailable for this target")
+        bail!("chromedriver binaries are unavailable for this target")
     };
 
     let url = format!(
-        "https://chromedriver.storage.googleapis.com/2.41/chromedriver_{}.zip",
+        "https://chromedriver.storage.googleapis.com/2.45/chromedriver_{}.zip",
         target
     );
     match cache.download(

--- a/src/test/webdriver.rs
+++ b/src/test/webdriver.rs
@@ -38,7 +38,7 @@ pub fn install_chromedriver(
     };
 
     let url = format!(
-        "https://chromedriver.storage.googleapis.com/2.45/chromedriver_{}.zip",
+        "https://chromedriver.storage.googleapis.com/2.46/chromedriver_{}.zip",
         target
     );
     match cache.download(
@@ -92,7 +92,7 @@ pub fn install_geckodriver(
     };
 
     let url = format!(
-        "https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-{}.{}",
+        "https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-{}.{}",
         target,
         ext,
     );

--- a/tests/all/webdriver.rs
+++ b/tests/all/webdriver.rs
@@ -6,7 +6,8 @@ use wasm_pack::test::webdriver;
 #[cfg(any(
     all(target_os = "linux", target_arch = "x86_64"),
     all(target_os = "macos", target_arch = "x86_64"),
-    all(target_os = "windows", target_arch = "x86")
+    all(target_os = "windows", target_arch = "x86"),
+    all(target_os = "windows", target_arch = "x86_64")
 ))]
 fn can_install_chromedriver() {
     let fixture = fixture::js_hello_world();


### PR DESCRIPTION
This solves #535.

Changes:
* use win32 chromedriver binary on win64 systems
* update chromedriver version to 2.45
* fix error message