### PR TITLE
Clarify what kind of account `login` adds

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -50,7 +50,7 @@ pub enum Command {
     },
 
     #[structopt(name = "login", alias = "adduser", alias = "add-user")]
-    /// 👤  Add a registry user account! (aliases: adduser, add-user)
+    /// 👤  Add a npm registry user account! (aliases: adduser, add-user)
     Login {
         #[structopt(long = "registry", short = "r")]
         /// Default: 'https://registry.npmjs.org/'.

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -50,7 +50,7 @@ pub enum Command {
     },
 
     #[structopt(name = "login", alias = "adduser", alias = "add-user")]
-    /// 👤  Add a npm registry user account! (aliases: adduser, add-user)
+    /// 👤  Add an npm registry user account! (aliases: adduser, add-user)
     Login {
         #[structopt(long = "registry", short = "r")]
         /// Default: 'https://registry.npmjs.org/'.


### PR DESCRIPTION
Was confused for a sec when I saw this in `--help`.