### PR TITLE
"Wasm" is a contraction, not an acronym

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -180,7 +180,7 @@ pub fn wasm_bindgen_build(
     profile: BuildProfile,
     step: &Step,
 ) -> Result<(), failure::Error> {
-    let msg = format!("{}Running WASM-bindgen...", emoji::RUNNER);
+    let msg = format!("{}Running wasm-bindgen...", emoji::RUNNER);
     PBAR.step(step, &msg);
 
     let release_or_debug = match profile {

--- a/src/build.rs
+++ b/src/build.rs
@@ -52,7 +52,7 @@ fn rustc_minor_version() -> Option<u32> {
 /// Ensure that `rustup` has the `wasm32-unknown-unknown` target installed for
 /// current toolchain
 pub fn rustup_add_wasm_target(step: &Step) -> Result<(), Error> {
-    let msg = format!("{}Adding WASM target...", emoji::TARGET);
+    let msg = format!("{}Adding the Wasm target...", emoji::TARGET);
     PBAR.step(step, &msg);
     let mut cmd = Command::new("rustup");
     cmd.arg("target").arg("add").arg("wasm32-unknown-unknown");
@@ -67,7 +67,7 @@ pub fn cargo_build_wasm(
     step: &Step,
     extra_options: &Vec<String>,
 ) -> Result<(), Error> {
-    let msg = format!("{}Compiling to WASM...", emoji::CYCLONE);
+    let msg = format!("{}Compiling to Wasm...", emoji::CYCLONE);
     PBAR.step(step, &msg);
     let mut cmd = Command::new("cargo");
     cmd.current_dir(path).arg("build").arg("--lib");

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -250,7 +250,7 @@ impl Test {
     fn step_build_tests(&mut self, step: &Step) -> Result<(), Error> {
         info!("Compiling tests to wasm...");
 
-        let msg = format!("{}Compiling tests to WASM...", emoji::CYCLONE);
+        let msg = format!("{}Compiling tests to Wasm...", emoji::CYCLONE);
         PBAR.step(step, &msg);
 
         build::cargo_build_wasm_tests(&self.crate_path, !self.release)?;


### PR DESCRIPTION
And therefore should not be all caps.

https://webassembly.github.io/spec/core/intro/introduction.html#wasm

v important
