### PR TITLE
fix(manifest): LICENSE and README don't need to be whitelisted

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -430,17 +430,13 @@ impl CrateData {
             None
         };
 
-        let readme_file = out_dir.join("README.md");
-        if readme_file.is_file() {
-            files.push("README.md".to_string());
-        }
-
         if let Ok(entries) = fs::read_dir(out_dir) {
             let file_names = entries
                 .filter_map(|e| e.ok())
                 .filter(|e| e.metadata().map(|m| m.is_file()).unwrap_or(false))
                 .filter_map(|e| e.file_name().into_string().ok())
-                .filter(|f| f.starts_with("LICENSE"));
+                .filter(|f| f.starts_with("LICENSE"))
+                .filter(|f| f != "LICENSE");
             for file_name in file_names {
                 files.push(file_name);
             }

--- a/tests/all/license.rs
+++ b/tests/all/license.rs
@@ -17,8 +17,8 @@ fn it_copies_a_license_default_path() {
     let step = wasm_pack::progressbar::Step::new(1);
     assert!(license::copy_from_crate(&crate_data.unwrap(), &fixture.path, &out_dir, &step).is_ok());
 
-    let crate_license_path = fixture.path.join("LICENSE-WTFPL");
-    let pkg_license_path = out_dir.join("LICENSE-WTFPL");
+    let crate_license_path = fixture.path.join("LICENSE");
+    let pkg_license_path = out_dir.join("LICENSE");
     println!(
         "wasm-pack: should have copied LICENSE from '{}' to '{}'",
         crate_license_path.display(),
@@ -42,10 +42,10 @@ fn it_copies_a_license_provided_path() {
 
     let step = wasm_pack::progressbar::Step::new(1);
     assert!(license::copy_from_crate(&crate_data.unwrap(), &fixture.path, &out_dir, &step).is_ok());
-    let crate_license_path = fixture.path.join("LICENSE-WTFPL");
-    let pkg_license_path = out_dir.join("LICENSE-WTFPL");
+    let crate_license_path = fixture.path.join("LICENSE");
+    let pkg_license_path = out_dir.join("LICENSE");
     println!(
-        "wasm-pack: should have copied LICENSE-WTFPL from '{}' to '{}'",
+        "wasm-pack: should have copied LICENSE from '{}' to '{}'",
         crate_license_path.display(),
         pkg_license_path.display()
     );

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use utils::{self, fixture};
-use wasm_pack::{self, license, manifest, readme};
+use wasm_pack::{self, license, manifest};
 
 #[test]
 fn it_gets_the_crate_name_default_path() {
@@ -446,36 +446,6 @@ fn it_lists_license_files_in_files_field_of_package_json() {
     assert!(
         pkg.files.contains(&"LICENSE-MIT".to_string()),
         "LICENSE-MIT is not in files: {:?}",
-        pkg.files,
-    );
-}
-
-#[test]
-fn it_lists_readme_in_files_field_of_package_json() {
-    let fixture = utils::fixture::Fixture::new();
-    fixture
-        .readme()
-        .hello_world_src_lib()
-        .cargo_toml("readme-test-for-package-json");
-
-    let out_dir = fixture.path.join("pkg");
-
-    let crate_data = manifest::CrateData::new(&fixture.path).unwrap();
-
-    let step = wasm_pack::progressbar::Step::new(3);
-    wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
-    readme::copy_from_crate(&fixture.path, &out_dir, &step).unwrap();
-    crate_data
-        .write_package_json(&out_dir, &None, false, "", &step)
-        .unwrap();
-
-    let package_json_path = &fixture.path.join("pkg").join("package.json");
-    fs::metadata(package_json_path).unwrap();
-    let pkg = utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
-
-    assert!(
-        pkg.files.contains(&"README.md".to_string()),
-        "README.md is not in files: {:?}",
         pkg.files,
     );
 }

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -67,6 +67,16 @@ impl Fixture {
         )
     }
 
+    /// Add `LICENSE` file to the fixture.
+    pub fn license(&self) -> &Self {
+        self.file(
+            "LICENSE",
+            r#"
+                I'm a license!
+            "#,
+        )
+    }
+
     /// Add `WTFPL LICENSE` file to the fixture.
     pub fn wtfpl_license(&self) -> &Self {
         self.file(
@@ -662,7 +672,7 @@ pub fn single_license() -> Fixture {
     fixture
         .readme()
         .cargo_toml("single_license")
-        .wtfpl_license()
+        .license()
         .hello_world_src_lib();
     fixture
 }


### PR DESCRIPTION
fixes #551 