### PR TITLE
Flag gh-pages docs as unpublished

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
     - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.2" mdbook)
     - cargo install-update -a
     script:
-    - (cd docs && mdbook build)
+    - (cd docs && mv _theme theme && mdbook build)
     - rustc ./docs/_installer/build-installer.rs
     - ./build-installer
     deploy:

--- a/docs/_theme/header.hbs
+++ b/docs/_theme/header.hbs
@@ -1,0 +1,44 @@
+<style>
+  header.warning {
+    background-color: rgb(242, 222, 222);
+    border-bottom-color: rgb(238, 211, 215);
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-bottom-style: solid;
+    border-bottom-width: 0.666667px;
+    border-image-outset: 0 0 0 0;
+    border-image-repeat: stretch stretch;
+    border-image-slice: 100% 100% 100% 100%;
+    border-image-source: none;
+    border-image-width: 1 1 1 1;
+    border-left-color: rgb(238, 211, 215);
+    border-left-style: solid;
+    border-left-width: 0.666667px;
+    border-right-color: rgb(238, 211, 215);
+    border-right-style: solid;
+    border-right-width: 0.666667px;
+    border-top-color: rgb(238, 211, 215);
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-top-style: solid;
+    border-top-width: 0.666667px;
+    color: rgb(185, 74, 72);
+    margin-bottom: 0px;
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-top: 30px;
+    padding-bottom: 8px;
+    padding-left: 14px;
+    padding-right: 35px;
+    padding-top: 8px;
+    text-align: center;
+  }
+</style>
+<header class='warning'>
+  This is the <strong>unpublished</strong> documentation of
+  <code>wasm-pack</code>, the published documentation is available
+  <a href="https://rustwasm.github.io/docs/wasm-pack/">
+    on the main Rust and WebAssembly documentation site
+  </a>. Features documented here may not be available in released versions of
+  <code>wasm-pack</code>.
+</header>


### PR DESCRIPTION
This commit adds a header dialog to the gh-pages mdbook documentation of
this repository to indicate that it represents unpublished documentation
that may not reflect the currently published version of `wasm-pack`. The
header redirects users to https://rustwasm.github.io/docs/wasm-pack/
which has the documentation for the latest published version of
`wasm-pack`.
