### PR TITLE
Add support for `--target web`

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -47,20 +47,26 @@ The exact meaning of the profile flags may evolve as the platform matures.
 
 ## Target
 
-The `build` command accepts a `--target` argument. This will customize the output files
-to align with a particular type of JS module. This allows wasm-pack to generate either
-ES6 modules or CommonJS modules for use in browser and in NodeJS. Defaults to `browser`.
-The options are:
+The `build` command accepts a `--target` argument. This will customize the JS
+that is emitted and how the WebAssembly files are instantiated and loaded. For
+more documentation on the various strategies here, see the [documentation on
+using the compiled output][deploy].
 
 ```
 wasm-pack build --target nodejs
 ```
 
-| Option    | Description                                                                                                     |
-|-----------|-----------------------------------------------------------------------------------------------------------------|
-| `nodejs`  | Outputs JS that uses CommonJS modules, for use with a `require` statement. `main` key in `package.json`. |
-| `no-modules`  | Outputs JS that use no modules. `browser` key in `package.json`. |
-| `browser` | Outputs JS that uses ES6 modules, primarily for use with `import` statements and/or bundlers such as `webpack`. `module` key in `package.json`. `sideEffects: false` by default. |
+| Option    | Usage | Description                                                                                                     |
+|-----------|------------|-----------------------------------------------------------------------------------------------------|
+| *not specified* or `bundler` | [Bundler][bundlers] | Outputs JS that is suitable for interoperation with a Bundler like Webpack. You'll `import` the JS and the `module` key is specified in `package.json`. `sideEffects: false` is by default. |
+| `nodejs`  | [Node.js][deploy-nodejs] | Outputs JS that uses CommonJS modules, for use with a `require` statement. `main` key in `package.json`. |
+| `web` | [Native in browser][deploy-web] | Outputs JS that can be natively imported as an ES module in a browser, but the WebAssembly must be manually instantiated and loaded. |
+| `no-modules` | [Native in browser][deploy-web] | Same as `web`, except the JS is included on a page and modifies global state, and doesn't support as many `wasm-bindgen` features as `web` |
+
+[deploy]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html
+[bundlers]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#bundlers
+[deploy-nodejs]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#nodejs
+[deploy-web]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#without-a-bundler
 
 ## Scope
 

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -2,7 +2,7 @@
 
 use binary_install::{Cache, Download};
 use child;
-use command::build::BuildProfile;
+use command::build::{BuildProfile, Target};
 use emoji;
 use failure::{self, ResultExt};
 use log::debug;
@@ -176,7 +176,7 @@ pub fn wasm_bindgen_build(
     bindgen: &Download,
     out_dir: &Path,
     disable_dts: bool,
-    target: &str,
+    target: &Target,
     profile: BuildProfile,
     step: &Step,
 ) -> Result<(), failure::Error> {
@@ -203,9 +203,10 @@ pub fn wasm_bindgen_build(
         "--typescript"
     };
     let target_arg = match target {
-        "nodejs" => "--nodejs",
-        "no-modules" => "--no-modules",
-        _ => "--browser",
+        Target::Nodejs => "--nodejs",
+        Target::NoModules => "--no-modules",
+        Target::Web => "--web",
+        Target::Bundler => "--browser",
     };
     let bindgen_path = bindgen.binary("wasm-bindgen")?;
     let mut cmd = Command::new(bindgen_path);

--- a/src/command/publish/mod.rs
+++ b/src/command/publish/mod.rs
@@ -2,7 +2,7 @@
 pub mod access;
 
 use self::access::Access;
-use command::build::{Build, BuildOptions};
+use command::build::{Build, BuildOptions, Target};
 use command::utils::{find_pkg_directory, set_crate_path};
 use dialoguer::{Confirmation, Input, Select};
 use failure::Error;
@@ -10,6 +10,7 @@ use log::info;
 use npm;
 use std::path::PathBuf;
 use std::result;
+use std::str::FromStr;
 use PBAR;
 
 /// Creates a tarball from a 'pkg' directory
@@ -45,6 +46,7 @@ pub fn publish(
                     .default(0)
                     .interact()?
                     .to_string();
+                let target = Target::from_str(&target)?;
                 let build_opts = BuildOptions {
                     path: Some(crate_path.clone()),
                     target,

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use utils::{self, fixture};
+use wasm_pack::command::build::Target;
 use wasm_pack::{self, license, manifest};
 
 #[test]
@@ -66,7 +67,7 @@ fn it_creates_a_package_json_default_path() {
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     assert!(crate_data
-        .write_package_json(&out_dir, &None, false, "", &step)
+        .write_package_json(&out_dir, &None, false, &Target::Bundler, &step)
         .is_ok());
     let package_json_path = &fixture.path.join("pkg").join("package.json");
     fs::metadata(package_json_path).unwrap();
@@ -102,7 +103,7 @@ fn it_creates_a_package_json_provided_path() {
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     assert!(crate_data
-        .write_package_json(&out_dir, &None, false, "", &step)
+        .write_package_json(&out_dir, &None, false, &Target::Bundler, &step)
         .is_ok());
     let package_json_path = &fixture.path.join("pkg").join("package.json");
     fs::metadata(package_json_path).unwrap();
@@ -131,7 +132,13 @@ fn it_creates_a_package_json_provided_path_with_scope() {
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     assert!(crate_data
-        .write_package_json(&out_dir, &Some("test".to_string()), false, "", &step)
+        .write_package_json(
+            &out_dir,
+            &Some("test".to_string()),
+            false,
+            &Target::Bundler,
+            &step
+        )
         .is_ok());
     let package_json_path = &fixture.path.join("pkg").join("package.json");
     fs::metadata(package_json_path).unwrap();
@@ -160,7 +167,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_node() {
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     assert!(crate_data
-        .write_package_json(&out_dir, &None, false, "nodejs", &step)
+        .write_package_json(&out_dir, &None, false, &Target::Nodejs, &step)
         .is_ok());
     let package_json_path = &out_dir.join("package.json");
     fs::metadata(package_json_path).unwrap();
@@ -196,7 +203,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_nomodules() {
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     assert!(crate_data
-        .write_package_json(&out_dir, &None, false, "no-modules", &step)
+        .write_package_json(&out_dir, &None, false, &Target::NoModules, &step)
         .is_ok());
     let package_json_path = &out_dir.join("package.json");
     fs::metadata(package_json_path).unwrap();
@@ -231,7 +238,7 @@ fn it_creates_a_pkg_json_in_out_dir() {
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     assert!(crate_data
-        .write_package_json(&out_dir, &None, false, "", &step)
+        .write_package_json(&out_dir, &None, false, &Target::Bundler, &step)
         .is_ok());
 
     let package_json_path = &fixture.path.join(&out_dir).join("package.json");
@@ -247,7 +254,7 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
     let step = wasm_pack::progressbar::Step::new(1);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     assert!(crate_data
-        .write_package_json(&out_dir, &None, true, "", &step)
+        .write_package_json(&out_dir, &None, true, &Target::Bundler, &step)
         .is_ok());
     let package_json_path = &out_dir.join("package.json");
     fs::metadata(package_json_path).unwrap();
@@ -310,7 +317,7 @@ fn it_sets_homepage_field_if_available_in_cargo_toml() {
     let step = wasm_pack::progressbar::Step::new(2);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     crate_data
-        .write_package_json(&out_dir, &None, true, "", &step)
+        .write_package_json(&out_dir, &None, true, &Target::Bundler, &step)
         .unwrap();
 
     let pkg = utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
@@ -327,7 +334,7 @@ fn it_sets_homepage_field_if_available_in_cargo_toml() {
     let step = wasm_pack::progressbar::Step::new(2);
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     crate_data
-        .write_package_json(&out_dir, &None, true, "", &step)
+        .write_package_json(&out_dir, &None, true, &Target::Bundler, &step)
         .unwrap();
 
     let pkg = utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
@@ -430,7 +437,7 @@ fn it_lists_license_files_in_files_field_of_package_json() {
     wasm_pack::command::utils::create_pkg_dir(&out_dir, &step).unwrap();
     license::copy_from_crate(&crate_data, &fixture.path, &out_dir, &step).unwrap();
     crate_data
-        .write_package_json(&out_dir, &None, false, "", &step)
+        .write_package_json(&out_dir, &None, false, &Target::Bundler, &step)
         .unwrap();
 
     let package_json_path = &fixture.path.join("pkg").join("package.json");


### PR DESCRIPTION
This commit adds support for the new `--web` flag in `wasm-bindgen`
under the flag name `--target web`. To ensure that it was plubmed around
the stringly-typed `target` type was switched to an `enum Target` to
ensure that all cases it's looked at are handled appropriately for the
new `web` target.
