### PR TITLE
Fix panics in `build --mode no-install`

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -259,38 +259,27 @@ impl Build {
                 };
             ($($name:ident,)*) => (steps![$($name),*])
         }
+        let mut steps = Vec::new();
         match &mode {
-            BuildMode::Normal => steps![
-                step_check_rustc_version,
-                step_check_crate_config,
-                step_check_for_wasm_target,
-                step_build_wasm,
-                step_create_dir,
-                step_copy_readme,
-                step_copy_license,
-                step_install_wasm_bindgen,
-                step_run_wasm_bindgen,
-                step_create_json,
-            ],
-            BuildMode::Noinstall => steps![
-                step_check_rustc_version,
-                step_check_crate_config,
-                step_build_wasm,
-                step_create_dir,
-                step_copy_readme,
-                step_copy_license,
-                step_run_wasm_bindgen,
-                step_create_json,
-            ],
-            BuildMode::Force => steps![
-                step_build_wasm,
-                step_create_dir,
-                step_copy_readme,
-                step_copy_license,
-                step_run_wasm_bindgen,
-                step_create_json,
-            ],
+            BuildMode::Force => {}
+            _ => {
+                steps.extend(steps![
+                    step_check_rustc_version,
+                    step_check_crate_config,
+                    step_check_for_wasm_target,
+                ]);
+            }
         }
+        steps.extend(steps![
+            step_build_wasm,
+            step_create_dir,
+            step_copy_readme,
+            step_copy_license,
+            step_install_wasm_bindgen,
+            step_run_wasm_bindgen,
+            step_create_json,
+        ]);
+        steps
     }
 
     fn step_check_rustc_version(&mut self) -> Result<(), Error> {

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -212,3 +212,29 @@ fn build_with_arbitrary_cargo_options() {
         .assert()
         .success();
 }
+
+#[test]
+fn build_no_install() {
+    let fixture = utils::fixture::js_hello_world();
+    fixture.install_local_wasm_bindgen();
+    fixture
+        .wasm_pack()
+        .arg("build")
+        .arg("--mode")
+        .arg("no-install")
+        .assert()
+        .success();
+}
+
+#[test]
+fn build_force() {
+    let fixture = utils::fixture::js_hello_world();
+    fixture.install_local_wasm_bindgen();
+    fixture
+        .wasm_pack()
+        .arg("build")
+        .arg("--mode")
+        .arg("force")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
This commit fixes the `wasm-pack build --mode no-install` command from
unconditionally panicking as well as `--mode force`. These steps were
calling an `unwrap()` on an internal `Option<T>` which was supposed to
be set during `step_install_wasm_bindgen`, but that step wasn't run in
these modes. The mode configuration of steps has been refactored
slightly to ensure that more steps are shared between these modes to
reduce duplication.
