### PR TITLE
feat: Print unexpected panics to standard error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,13 @@ extern crate atty;
 extern crate env_logger;
 #[macro_use]
 extern crate failure;
-#[macro_use]
 extern crate human_panic;
 extern crate structopt;
 extern crate wasm_pack;
 extern crate which;
 
 use std::env;
+use std::panic;
 use structopt::StructOpt;
 use wasm_pack::{command::run_wasm_pack, Cli};
 
@@ -16,7 +16,9 @@ mod installer;
 
 fn main() {
     env_logger::init();
-    setup_panic!();
+
+    setup_panic_hooks();
+
     if let Err(e) = run() {
         eprintln!("Error: {}", e);
         for cause in e.iter_causes() {
@@ -48,4 +50,30 @@ fn run() -> Result<(), failure::Error> {
     let args = Cli::from_args();
     run_wasm_pack(args.cmd)?;
     Ok(())
+}
+
+fn setup_panic_hooks() {
+    let meta = human_panic::Metadata {
+        version: env!("CARGO_PKG_VERSION").into(),
+        name: env!("CARGO_PKG_NAME").into(),
+        authors: env!("CARGO_PKG_AUTHORS").replace(":", ", ").into(),
+        homepage: env!("CARGO_PKG_HOMEPAGE").into(),
+    };
+
+    let default_hook = panic::take_hook();
+
+    match env::var("RUST_BACKTRACE") {
+        Err(_) => {
+            panic::set_hook(Box::new(move |info: &panic::PanicInfo| {
+                // First call the default hook that prints to standard error.
+                default_hook(info);
+
+                // Then call human_panic.
+                let file_path = human_panic::handle_dump(&meta, info);
+                human_panic::print_msg(file_path, &meta)
+                    .expect("human-panic: printing error message to console failed");
+            }));
+        }
+        Ok(_) => {}
+    }
 }


### PR DESCRIPTION
This will print to standard error for unexpected panics and then let `human_panic` handle panics, just like before.

This will fix #562.