### PR TITLE
fix: Check for "rustup" rather than ".rustup" when checking for wasm32

### DIFF
--- a/src/build/wasm_target.rs
+++ b/src/build/wasm_target.rs
@@ -20,7 +20,7 @@ impl fmt::Display for Wasm32Check {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let target = "wasm32-unknown-unknown";
 
-        if self.found {
+        if !self.found {
             let rustup_string = if self.is_rustup {
                 "It looks like Rustup is being used.".to_owned()
             } else {

--- a/src/build/wasm_target.rs
+++ b/src/build/wasm_target.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Wasm32Check {
             let rustup_string = if self.is_rustup {
                 "It looks like Rustup is being used.".to_owned()
             } else {
-                format!("It looks like Rustup is not being used. For non-Rustup setups, the {} target needs to be installed manually. See https://rustwasm.github.io/wasm-pack/book/prerequisites/index.html#target-wasm32-unknown-unknown on how to do this.", target)
+                format!("It looks like Rustup is not being used. For non-Rustup setups, the {} target needs to be installed manually. See https://rustwasm.github.io/wasm-pack/book/prerequisites/non-rustup-setups.html on how to do this.", target)
             };
 
             writeln!(
@@ -111,9 +111,9 @@ fn check_wasm32_target() -> Result<Wasm32Check, Error> {
         })
     // If it doesn't exist, then we need to check if we're using rustup.
     } else {
-        // If sysroot contains .rustup, then we can assume we're using rustup
+        // If sysroot contains "rustup", then we can assume we're using rustup
         // and use rustup to add the wasm32-unknown-unknown target.
-        if sysroot.to_string_lossy().contains(".rustup") {
+        if sysroot.to_string_lossy().contains("rustup") {
             rustup_add_wasm_target().map(|()| Wasm32Check {
                 rustc_path,
                 sysroot,


### PR DESCRIPTION
When checking for wasm32 target we did check if the sysroot contained ".rustup". While this covered the most common cases it didn't work when using Docker. So checking for "rustup" instead covers both
cases.

I also noticed another bug where if the target was found we printed the helpful information and not the way around so I fixed that as well. Also, the code linked to the wrong docs section since the last docs update so I corrected that.

This will fix #613