### PR TITLE
Recurse up the path looking for the Cargo.toml

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -4,7 +4,7 @@ use binary_install::{Cache, Download};
 use bindgen;
 use build;
 use cache;
-use command::utils::{create_pkg_dir, set_crate_path};
+use command::utils::{create_pkg_dir, get_crate_path};
 use emoji;
 use failure::Error;
 use license;
@@ -118,7 +118,7 @@ pub enum BuildProfile {
 /// Everything required to configure and run the `wasm-pack build` command.
 #[derive(Debug, StructOpt)]
 pub struct BuildOptions {
-    /// The path to the Rust crate.
+    /// The path to the Rust crate. If not set, searches up the path from the current directory.
     #[structopt(parse(from_os_str))]
     pub path: Option<PathBuf>,
 
@@ -193,7 +193,7 @@ type BuildStep = fn(&mut Build) -> Result<(), Error>;
 impl Build {
     /// Construct a build command from the given options.
     pub fn try_from_opts(build_opts: BuildOptions) -> Result<Self, Error> {
-        let crate_path = set_crate_path(build_opts.path)?;
+        let crate_path = get_crate_path(build_opts.path)?;
         let crate_data = manifest::CrateData::new(&crate_path, build_opts.out_name.clone())?;
         let out_dir = crate_path.join(PathBuf::from(build_opts.out_dir));
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -28,7 +28,7 @@ pub enum Command {
     #[structopt(name = "pack")]
     /// 🍱  create a tar of your npm package but don't publish!
     Pack {
-        /// The path to the Rust crate.
+        /// The path to the Rust crate. If not set, searches up the path from the current dirctory.
         #[structopt(parse(from_os_str))]
         path: Option<PathBuf>,
     },
@@ -44,7 +44,7 @@ pub enum Command {
         #[structopt(long = "access", short = "a")]
         access: Option<Access>,
 
-        /// The path to the Rust crate.
+        /// The path to the Rust crate. If not set, searches up the path from the current dirctory.
         #[structopt(parse(from_os_str))]
         path: Option<PathBuf>,
     },

--- a/src/command/pack.rs
+++ b/src/command/pack.rs
@@ -1,4 +1,4 @@
-use command::utils::{find_pkg_directory, set_crate_path};
+use command::utils::{find_pkg_directory, get_crate_path};
 use failure::Error;
 use log::info;
 use npm;
@@ -9,7 +9,7 @@ use PBAR;
 /// Executes the 'npm pack' command on the 'pkg' directory
 /// which creates a tarball that can be published to the NPM registry
 pub fn pack(path: Option<PathBuf>) -> result::Result<(), Error> {
-    let crate_path = set_crate_path(path)?;
+    let crate_path = get_crate_path(path)?;
 
     info!("Packing up the npm package...");
     let pkg_directory = find_pkg_directory(&crate_path).ok_or_else(|| {

--- a/src/command/publish/mod.rs
+++ b/src/command/publish/mod.rs
@@ -3,7 +3,7 @@ pub mod access;
 
 use self::access::Access;
 use command::build::{Build, BuildOptions, Target};
-use command::utils::{find_pkg_directory, set_crate_path};
+use command::utils::{find_pkg_directory, get_crate_path};
 use dialoguer::{Confirmation, Input, Select};
 use failure::Error;
 use log::info;
@@ -20,7 +20,7 @@ pub fn publish(
     path: Option<PathBuf>,
     access: Option<Access>,
 ) -> result::Result<(), Error> {
-    let crate_path = set_crate_path(path)?;
+    let crate_path = get_crate_path(path)?;
 
     info!("Publishing the npm package...");
     info!("npm info located in the npm debug log");

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -5,7 +5,7 @@ use binary_install::Cache;
 use bindgen;
 use build;
 use cache;
-use command::utils::set_crate_path;
+use command::utils::get_crate_path;
 use console::style;
 use failure::Error;
 use lockfile::Lockfile;
@@ -19,7 +19,7 @@ use test::{self, webdriver};
 /// Everything required to configure the `wasm-pack test` command.
 pub struct TestOptions {
     #[structopt(parse(from_os_str))]
-    /// The path to the Rust crate.
+    /// The path to the Rust crate. If not set, searches up the path from the current dirctory.
     pub path: Option<PathBuf>,
 
     #[structopt(long = "node")]
@@ -119,7 +119,7 @@ impl Test {
             extra_options,
         } = test_opts;
 
-        let crate_path = set_crate_path(path)?;
+        let crate_path = get_crate_path(path)?;
         let crate_data = manifest::CrateData::new(&crate_path, None)?;
         let any_browser = chrome || firefox || safari;
 

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -8,8 +8,30 @@ use walkdir::WalkDir;
 
 /// If an explicit path is given, then use it, otherwise assume the current
 /// directory is the crate path.
-pub fn set_crate_path(path: Option<PathBuf>) -> Result<PathBuf, failure::Error> {
-    Ok(path.unwrap_or_else(|| PathBuf::from(".")))
+pub fn get_crate_path(path: Option<PathBuf>) -> Result<PathBuf, failure::Error> {
+    match path {
+        Some(p) => Ok(p),
+        None => find_manifest_from_cwd(),
+    }
+}
+
+/// Search up the path for the manifest file from the current working directory
+/// If we don't find the manifest file then return back the current working directory
+/// to provide the appropriate error
+fn find_manifest_from_cwd() -> Result<PathBuf, failure::Error> {
+    let mut parent_path = std::env::current_dir()?;
+    let mut manifest_path = parent_path.join("Cargo.toml");
+    loop {
+        if !manifest_path.is_file() {
+            if parent_path.pop() {
+                manifest_path = parent_path.join("Cargo.toml");
+            } else {
+                return Ok(PathBuf::from("."));
+            }
+        } else {
+            return Ok(parent_path.to_owned());
+        }
+    }
 }
 
 /// Construct our `pkg` directory in the crate.

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -9,6 +9,7 @@ fn build_in_non_crate_directory_doesnt_panic() {
     fixture
         .wasm_pack()
         .arg("build")
+        .arg(".")
         .assert()
         .failure()
         .stderr(predicates::str::contains("missing a `Cargo.toml`"));


### PR DESCRIPTION
PR for #620 Walk up parent directories to find the current crate

When setting the crate path, if the default path of the current working directory is defined pass back a flag indicating the default was used
If the default is used, and a path is not specified, then walk up the path to find the Cargo.toml file

I'm relatively new to Rust and figured this was a good first step to getting to know the project and wet my feet, but I'm not sure I'm doing things the idiomatic way - so I'm happy to have all and any feedback!

