### PR TITLE
custom error message when wasm-bindgen fails because --web isn't available

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -204,7 +204,7 @@ pub fn wasm_bindgen_build(
         Target::Bundler => "--browser",
     };
     let bindgen_path = bindgen.binary("wasm-bindgen")?;
-    let mut cmd = Command::new(bindgen_path);
+    let mut cmd = Command::new(&bindgen_path);
     cmd.arg(&wasm_path)
         .arg("--out-dir")
         .arg(out_dir)
@@ -229,42 +229,47 @@ pub fn wasm_bindgen_build(
     let result = child::run(cmd, "wasm-bindgen");
     let result: Result<(), failure::Error> = match result {
         Ok(r) => Ok(r),
-        Err(e) => process_error(e),
+        Err(e) => process_error(&bindgen_path, e),
     };
     result.context("Running the wasm-bindgen CLI")?;
     Ok(())
 }
 
-fn process_error(e: child::CommandError) -> Result<(), failure::Error> {
+fn process_error(bindgen_path: &PathBuf, e: child::CommandError) -> Result<(), failure::Error> {
     match &e.stderr {
-        Some(err) if err.trim().starts_with("Unknown flag: '--web'") =>
-            bail!("Failed to execute `wasm-bindgen`: --web is not supported. Upgrade wasm-bindgen to a more recent version."),
+        Some(err) if err.trim().starts_with("Unknown flag: '--web'") => {
+            let v = wasm_bindgen_get_version(bindgen_path).unwrap_or(String::from("unknown"));
+            bail!("Failed to execute `wasm-bindgen`: --web is not supported in version '{}'. Upgrade the wasm-bindgen dependency in Cargo.toml to version 0.2.39 or later.", v)
+        }
         Some(err) => {
             eprintln!("{}", err);
             bail!("{}", e.to_string())
-        },
+        }
         _ => bail!("{}", e.to_string()),
     }
 }
 
 /// Check if the `wasm-bindgen` dependency is locally satisfied.
 fn wasm_bindgen_version_check(bindgen_path: &PathBuf, dep_version: &str) -> bool {
+    wasm_bindgen_get_version(bindgen_path)
+        .map(|v| {
+            info!(
+                "Checking installed `wasm-bindgen` version == expected version: {} == {}",
+                v, dep_version
+            );
+            v == dep_version
+        })
+        .unwrap_or(false)
+}
+
+/// Get the `wasm-bindgen` version
+fn wasm_bindgen_get_version(bindgen_path: &PathBuf) -> Option<String> {
     let mut cmd = Command::new(bindgen_path);
     cmd.arg("--version");
     child::run_capture_stdout(cmd, "wasm-bindgen")
-        .map(|stdout| {
-            stdout
-                .trim()
-                .split_whitespace()
-                .nth(1)
-                .map(|v| {
-                    info!(
-                        "Checking installed `wasm-bindgen` version == expected version: {} == {}",
-                        v, dep_version
-                    );
-                    v == dep_version
-                })
-                .unwrap_or(false)
+        .map(|stdout| match stdout.trim().split_whitespace().nth(1) {
+            Some(v) => return Some(v.to_owned()),
+            None => return None,
         })
-        .unwrap_or(false)
+        .unwrap_or(None)
 }

--- a/src/child.rs
+++ b/src/child.rs
@@ -3,9 +3,9 @@
 //! This module helps us ensure that all child processes that we spawn get
 //! properly logged and their output is logged as well.
 
-use failure::Error;
 use log::info;
-use std::process::{Command, Stdio};
+use std::io::Error as StdError;
+use std::process::{Command, ExitStatus, Stdio};
 
 /// Return a new Command object
 pub fn new_command(program: &str) -> Command {
@@ -23,39 +23,79 @@ pub fn new_command(program: &str) -> Command {
     }
 }
 
-/// Run the given command and return its stdout.
-pub fn run(mut command: Command, command_name: &str) -> Result<(), Error> {
+/// Error from running Command processes
+/// This captures the standard error output
+#[derive(Fail, Debug)]
+#[fail(display = "failed to execute `{}`: {}", command_name, fail_reason)]
+pub struct CommandError {
+    command_name: String,
+    fail_reason: String,
+    /// the output printed to stderr, if any
+    pub stderr: Option<String>,
+}
+
+impl CommandError {
+    fn from_status(command_name: &str, status: ExitStatus, stderr: Option<String>) -> CommandError {
+        CommandError {
+            command_name: command_name.to_string(),
+            fail_reason: format!("exited with {}", status),
+            stderr: stderr,
+        }
+    }
+
+    fn from_error(command_name: &str, err: StdError) -> CommandError {
+        CommandError {
+            command_name: command_name.to_string(),
+            fail_reason: err.to_string(),
+            stderr: None,
+        }
+    }
+}
+
+/// Run the given command and return on success.
+pub fn run(mut command: Command, command_name: &str) -> Result<(), CommandError> {
     info!("Running {:?}", command);
 
-    let status = command.status()?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        bail!(
-            "failed to execute `{}`: exited with {}",
-            command_name,
-            status
-        )
+    let cmd_output = command
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .output();
+    match cmd_output {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(())
+            } else {
+                Err(CommandError::from_status(
+                    command_name,
+                    output.status,
+                    Some(String::from_utf8_lossy(&output.stderr).into_owned()),
+                ))
+            }
+        }
+        Err(e) => Err(CommandError::from_error(command_name, e)),
     }
 }
 
 /// Run the given command and return its stdout.
-pub fn run_capture_stdout(mut command: Command, command_name: &str) -> Result<String, Error> {
+pub fn run_capture_stdout(
+    mut command: Command,
+    command_name: &str,
+) -> Result<String, CommandError> {
     info!("Running {:?}", command);
 
-    let output = command
-        .stderr(Stdio::inherit())
-        .stdin(Stdio::inherit())
-        .output()?;
-
-    if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-    } else {
-        bail!(
-            "failed to execute `{}`: exited with {}",
-            command_name,
-            output.status
-        )
+    let cmd_output = command.stdin(Stdio::inherit()).output();
+    match cmd_output {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+            } else {
+                Err(CommandError::from_status(
+                    command_name,
+                    output.status,
+                    Some(String::from_utf8_lossy(&output.stderr).into_owned()),
+                ))
+            }
+        }
+        Err(e) => Err(CommandError::from_error(command_name, e)),
     }
 }


### PR DESCRIPTION
PR for #627 - check wasm-bindgen version if target = web is passed

create a custom error message when wasm-bindgen fails because --web isn't available

Change the return type of the child run commands so it can return a CommandError that also captures the stderr if the process fails.
See if the returned output contains the 'Unknown flag: --web' error message and if so provide an alternative error that suggests upgrading
