### PR TITLE
doc(readme): Remove obsolete link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ This project requires Rust 1.30.0 or later.
 
 - [Development Environment](https://rustwasm.github.io/wasm-pack/book/prerequisites/index.html)
 - [Installation](https://rustwasm.github.io/wasm-pack/installer)
-- [Project Setup](https://rustwasm.github.io/wasm-pack/book/project-setup/index.html)
 
 ## 🎙️ Commands
 


### PR DESCRIPTION
The docs have changed a bit and this link no longer exists, so let's remove it.
