### PR TITLE
Updated help message for `build` and `publish` subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- ###  Fixes
+
+  - Updated help message for `build` and `publish` subcommands. Replaced `browser` with the `bundler`
+
 ## 🛠️ 0.8.1
 
 - ### 🤕 Fixes

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -135,8 +135,8 @@ pub struct BuildOptions {
     /// this flag will disable generating this TypeScript file.
     pub disable_dts: bool,
 
-    #[structopt(long = "target", short = "t", default_value = "browser")]
-    /// Sets the target environment. [possible values: browser, nodejs, web, no-modules]
+    #[structopt(long = "target", short = "t", default_value = "bundler")]
+    /// Sets the target environment. [possible values: bundler, nodejs, web, no-modules]
     pub target: Target,
 
     #[structopt(long = "debug")]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -36,8 +36,8 @@ pub enum Command {
     #[structopt(name = "publish")]
     /// 🎆  pack up your npm package and publish!
     Publish {
-        #[structopt(long = "target", short = "t", default_value = "browser")]
-        /// Sets the target environment. [possible values: browser, nodejs, no-modules]
+        #[structopt(long = "target", short = "t", default_value = "bundler")]
+        /// Sets the target environment. [possible values: bundler, nodejs, web, no-modules]
         target: String,
 
         /// The access level for the package to be published

--- a/src/command/publish/mod.rs
+++ b/src/command/publish/mod.rs
@@ -41,8 +41,8 @@ pub fn publish(
                     .interact()?;
                 let out_dir = format!("{}/pkg", out_dir);
                 let target = Select::new()
-                    .with_prompt("target[default: browser]")
-                    .items(&["browser", "nodejs", "no-modules"])
+                    .with_prompt("target[default: bundler]")
+                    .items(&["bundler", "nodejs", "web", "no-modules"])
                     .default(0)
                     .interact()?
                     .to_string();


### PR DESCRIPTION
Closes #636 

Should we also add a deprecation warning for those who still use `browser`?

There's also an interesting line here:
https://github.com/rustwasm/wasm-pack/blob/master/src/bindgen.rs#L204
Update it to `--bundler`?