### PR TITLE
Fix sideEffects value in generated package.json should be boolean

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -639,7 +639,7 @@ impl CrateData {
             module: data.main,
             homepage: data.homepage,
             types: data.dts_file,
-            side_effects: "false".to_string(),
+            side_effects: false,
         })
     }
 
@@ -668,7 +668,7 @@ impl CrateData {
             module: data.main,
             homepage: data.homepage,
             types: data.dts_file,
-            side_effects: "false".to_string(),
+            side_effects: false,
         })
     }
 

--- a/src/manifest/npm/esmodules.rs
+++ b/src/manifest/npm/esmodules.rs
@@ -20,5 +20,5 @@ pub struct ESModulesPackage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub types: Option<String>,
     #[serde(rename = "sideEffects")]
-    pub side_effects: String,
+    pub side_effects: bool,
 }

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -28,17 +28,17 @@ fn it_should_build_crates_in_a_workspace() {
             "Cargo.toml",
             r#"
                 [workspace]
-                members = ["blah"]
+                members = ["it_should_build_crates_in_a_workspace"]
             "#,
         )
         .file(
-            Path::new("blah").join("Cargo.toml"),
+            Path::new("it_should_build_crates_in_a_workspace").join("Cargo.toml"),
             r#"
                 [package]
                 authors = ["The wasm-pack developers"]
                 description = "so awesome rust+wasm package"
                 license = "WTFPL"
-                name = "blah"
+                name = "it_should_build_crates_in_a_workspace"
                 repository = "https://github.com/rustwasm/wasm-pack.git"
                 version = "0.1.0"
 
@@ -50,7 +50,9 @@ fn it_should_build_crates_in_a_workspace() {
             "#,
         )
         .file(
-            Path::new("blah").join("src").join("lib.rs"),
+            Path::new("it_should_build_crates_in_a_workspace")
+                .join("src")
+                .join("lib.rs"),
             r#"
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -62,7 +64,7 @@ fn it_should_build_crates_in_a_workspace() {
         .install_local_wasm_bindgen();
     fixture
         .wasm_pack()
-        .current_dir(&fixture.path.join("blah"))
+        .current_dir(&fixture.path.join("it_should_build_crates_in_a_workspace"))
         .arg("build")
         .assert()
         .success();

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -92,7 +92,7 @@ fn it_creates_a_package_json_default_path() {
     );
     assert_eq!(pkg.module, "js_hello_world.js");
     assert_eq!(pkg.types, "js_hello_world.d.ts");
-    assert_eq!(pkg.side_effects, "false");
+    assert_eq!(pkg.side_effects, false);
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
@@ -252,7 +252,7 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     );
     assert_eq!(pkg.module, "index.js");
     assert_eq!(pkg.types, "index.d.ts");
-    assert_eq!(pkg.side_effects, "false");
+    assert_eq!(pkg.side_effects, false);
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = ["index_bg.wasm", "index.d.ts", "index.js"]

--- a/tests/all/utils/manifest.rs
+++ b/tests/all/utils/manifest.rs
@@ -21,13 +21,17 @@ pub struct NpmPackage {
     pub browser: String,
     #[serde(default = "default_none")]
     pub types: String,
-    #[serde(default = "default_none", rename = "sideEffects")]
-    pub side_effects: String,
+    #[serde(default = "default_false", rename = "sideEffects")]
+    pub side_effects: bool,
     pub homepage: Option<String>,
 }
 
 fn default_none() -> String {
     "".to_string()
+}
+
+fn default_false() -> bool {
+    false
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt-preview --toolchain nightly
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text: There is no issue related to this fix

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

I'm not heavy user of webpack but `sideEffects` field of `package.json` seems boolean or array value.

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

But current wasm-pack sets `"false"` string value to the field. This patch fixes the point.