### PR TITLE
Update cargo_metadata to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,10 +171,10 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.6.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1971,7 +1971,7 @@ dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "binary-install 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2113,7 +2113,7 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
-"checksum cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1b4d380e1bab994591a24c2bdd1b054f64b60bef483a8c598c7c345bc3bbe"
+"checksum cargo_metadata 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "929766d993a2fde7a0ae962ee82429069cd7b68839cd9375b98efd719df65d3a"
 "checksum cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "c9ce8bb087aacff865633f0bd5aeaed910fe2fe55b55f4739527f2e023a2e53d"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://rustwasm.github.io/wasm-pack/"
 
 [dependencies]
 atty = "0.2.11"
-cargo_metadata = "0.6.0"
+cargo_metadata = "0.8.0"
 console = "0.6.1"
 dialoguer = "0.3.0"
 curl = "0.4.13"

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -1,6 +1,10 @@
 //! Reading and writing Cargo.toml and package.json manifests.
 
-#![allow(clippy::new_ret_no_self, clippy::needless_pass_by_value, clippy::redundant_closure)]
+#![allow(
+    clippy::new_ret_no_self,
+    clippy::needless_pass_by_value,
+    clippy::redundant_closure
+)]
 
 mod npm;
 
@@ -350,8 +354,9 @@ impl CrateData {
             )
         }
 
-        let data =
-            cargo_metadata::metadata(Some(&manifest_path)).map_err(error_chain_to_failure)?;
+        let data = cargo_metadata::MetadataCommand::new()
+            .manifest_path(&manifest_path)
+            .exec()?;
 
         let manifest_and_keys = CrateData::parse_crate_data(&manifest_path)?;
         CrateData::warn_for_unused_keys(&manifest_and_keys);
@@ -369,18 +374,6 @@ impl CrateData {
             current_idx,
             out_name,
         });
-
-        fn error_chain_to_failure(err: cargo_metadata::Error) -> Error {
-            let errors = err.iter().collect::<Vec<_>>();
-            let mut err: Error = match errors.last() {
-                Some(e) => format_err!("{}", e),
-                None => return format_err!("{}", err),
-            };
-            for e in errors[..errors.len() - 1].iter().rev() {
-                err = err.context(e.to_string()).into();
-            }
-            err
-        }
     }
 
     /// Read the `manifest_path` file and deserializes it using the toml Deserializer.
@@ -596,7 +589,7 @@ impl CrateData {
             name: data.name,
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
-            version: pkg.version.clone(),
+            version: pkg.version.to_string(),
             license: self.license(),
             repository: self
                 .manifest
@@ -629,7 +622,7 @@ impl CrateData {
             name: data.name,
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
-            version: pkg.version.clone(),
+            version: pkg.version.to_string(),
             license: self.license(),
             repository: self
                 .manifest
@@ -658,7 +651,7 @@ impl CrateData {
             name: data.name,
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
-            version: pkg.version.clone(),
+            version: pkg.version.to_string(),
             license: self.license(),
             repository: self
                 .manifest
@@ -692,7 +685,7 @@ impl CrateData {
             name: data.name,
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
-            version: pkg.version.clone(),
+            version: pkg.version.to_string(),
             license: self.license(),
             repository: self
                 .manifest


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

This updates `cargo_metadata` to 0.8.0. The semantics slightly changed, but other than that there's not a lot of difference. The error type is simplified, which means a conversion function is no longer needed.

I was hoping this would fix (it doesn't) #637, but unfortunately not.
