### PR TITLE
fix installer to allow for custom install locations

### DIFF
--- a/docs/_installer/index.html
+++ b/docs/_installer/index.html
@@ -51,7 +51,7 @@
           <code>curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh</code>
           <p>
             You appear to be running a *nix system (Unix, Linux, MacOS). If not,
-            <a class="default-platform-button" href="#">display all supported installers</a>.
+            <a class="default-platform-button" href="#">display all supported installers</a>. The default location will be $CARGO_HOME/bin or the location of rustup if CARGO_HOME is not set.
           </p>
         </div>
       </div>

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -56,6 +56,7 @@ fn do_install() -> Result<(), failure::Error> {
     match cargo_home {
         Ok(path) => {
             installation_dir.push(path);
+            installation_dir.push("bin");
         }
         Err(_) => {
             println!("$CARGO_HOME not set, default to rustup location for install");


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ X ] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [ X ] You ran `cargo fmt` on the code base before submitting
- [ X ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

This fixes #470 and install wasm-pack to the `CARGO_HOME` environmental variable if it is set.  I guess one minor note is that I've made it so that the environmental variable is checked before check for `rustup`.  This has the advantage that users who installed rust without `rustup` can still install `wasm-pack` as `rustup` is not an actual requirement.  
