### PR TITLE
feat(publish): dist tag option

### DIFF
--- a/docs/src/commands/pack-and-publish.md
+++ b/docs/src/commands/pack-and-publish.md
@@ -3,7 +3,7 @@
 The `publish` and `pack` commands interact with the pkg directory that's
 created when you run `wasm-pack build`. The `pack` command creates a tarball
 from the pkg directory and the `publish` command creates a tarball from the
-pkg directory __and__ publishes it to the NPM registry.
+pkg directory **and** publishes it to the NPM registry.
 
 Underneath, these commands use `npm pack` and `npm publish`. You can read
 more about these in the NPM documentation:
@@ -30,3 +30,16 @@ Unable to find the pkg directory at path 'myproject/src/', or in a child directo
 ```
 
 If you don't set a path, they use the current directory as the path.
+
+## Publishing tagged releases
+
+You can also publish tagged releases with the optional `--tag` argument, e.g.
+
+```
+wasm-pack publish --tag next
+```
+
+By default, the `latest` tag is used to identify the current version of a package,
+and npm install \<pkg\> (without any @\<version\> or @\<tag\> specifier) installs the latest tag.
+
+You can read more about [distribution tags](https://docs.npmjs.com/cli/dist-tag) on NPM.

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -65,6 +65,11 @@ pub enum Command {
         #[structopt(long = "access", short = "a")]
         access: Option<Access>,
 
+        /// The distribution tag being used for publishing.
+        /// See https://docs.npmjs.com/cli/dist-tag
+        #[structopt(long = "tag")]
+        tag: Option<String>,
+
         /// The path to the Rust crate. If not set, searches up the path from the current dirctory.
         #[structopt(parse(from_os_str))]
         path: Option<PathBuf>,
@@ -135,10 +140,11 @@ pub fn run_wasm_pack(command: Command) -> result::Result<(), Error> {
             target,
             path,
             access,
+            tag,
         } => {
             info!("Running publish command...");
             info!("Path: {:?}", &path);
-            publish(&target, path, access)
+            publish(&target, path, access, tag)
         }
         Command::Login {
             registry,

--- a/src/command/publish/mod.rs
+++ b/src/command/publish/mod.rs
@@ -19,6 +19,7 @@ pub fn publish(
     _target: &str,
     path: Option<PathBuf>,
     access: Option<Access>,
+    tag: Option<String>,
 ) -> result::Result<(), Error> {
     let crate_path = get_crate_path(path)?;
 
@@ -74,7 +75,7 @@ pub fn publish(
             }
         }
     }?;
-    npm::npm_publish(&pkg_directory.to_string_lossy(), access)?;
+    npm::npm_publish(&pkg_directory.to_string_lossy(), access, tag)?;
     info!("Published your package!");
 
     PBAR.info("💥  published your package!");

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -17,11 +17,18 @@ pub fn npm_pack(path: &str) -> Result<(), failure::Error> {
 }
 
 /// Run the `npm publish` command.
-pub fn npm_publish(path: &str, access: Option<Access>) -> Result<(), failure::Error> {
+pub fn npm_publish(
+    path: &str,
+    access: Option<Access>,
+    tag: Option<String>,
+) -> Result<(), failure::Error> {
     let mut cmd = child::new_command("npm");
     match access {
         Some(a) => cmd.current_dir(path).arg("publish").arg(&a.to_string()),
         None => cmd.current_dir(path).arg("publish"),
+    };
+    if let Some(tag) = tag {
+        cmd.arg("--tag").arg(&tag.to_string());
     };
 
     child::run(cmd, "npm publish").context("Publishing to npm failed")?;


### PR DESCRIPTION
I haven't created a ticket and couldn't find any. I hope it is still ok to submit this small PR, which fits my needs.

This PR adds a new option to `wasm-pack publish` for publishing tagged releases.

See [dist-tags](https://docs.npmjs.com/cli/dist-tag) on NPM for further explanation of distribution tags.