### PR TITLE
Update `chromedriver` download version

### DIFF
--- a/src/test/webdriver.rs
+++ b/src/test/webdriver.rs
@@ -53,7 +53,7 @@ pub fn install_chromedriver(
     };
 
     let url = format!(
-        "https://chromedriver.storage.googleapis.com/2.46/chromedriver_{}.zip",
+        "https://chromedriver.storage.googleapis.com/76.0.3809.68/chromedriver_{}.zip",
         target
     );
     match get_and_notify(cache, installation_allowed, "chromedriver", &url)? {


### PR DESCRIPTION
Looks like a lot of updates have happened since we first added this!
Let's download the most recent stable version.

Closes #611
