### PR TITLE
Introduce an `All` target for outputting all supported module types by wasm-pack

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -55,7 +55,7 @@ pub fn wasm_bindgen_build(
                 Target::Web,
                 profile
                 )?;
-        
+
             // Nodejs
             let mut out_name_for_nodejs = Some(format!("{}.cjs.js", data.crate_name()));
             if let Some(value) = out_name {

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -115,6 +115,7 @@ fn build_target_arg_legacy(target: Target, cli_path: &PathBuf) -> Result<String,
             }
         }
         Target::Bundler => "--browser",
+        Target::All => "--all",
     };
     Ok(target_arg.to_string())
 }

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -21,7 +21,6 @@ pub fn wasm_bindgen_build(
     target: Target,
     profile: BuildProfile,
 ) -> Result<(), failure::Error> {
-
     match target {
         Target::All => {
             // Bundler
@@ -29,7 +28,7 @@ pub fn wasm_bindgen_build(
             let mut out_name_for_bundler = Some(format!("{}_esm", data.crate_name()));
             if let Some(value) = out_name {
                 out_name_for_bundler = Some(format!("{}_esm", value));
-            }   
+            }
             run_wasm_bindgen(
                 data,
                 bindgen,
@@ -37,14 +36,14 @@ pub fn wasm_bindgen_build(
                 &out_name_for_bundler,
                 disable_dts,
                 Target::Bundler,
-                profile
-                )?;
+                profile,
+            )?;
 
             // Web
             let mut out_name_for_web = Some(format!("{}_web", data.crate_name()));
             if let Some(value) = out_name {
                 out_name_for_web = Some(format!("{}_web", value));
-            }            
+            }
             run_wasm_bindgen(
                 data,
                 bindgen,
@@ -52,14 +51,14 @@ pub fn wasm_bindgen_build(
                 &out_name_for_web,
                 disable_dts,
                 Target::Web,
-                profile
-                )?;
+                profile,
+            )?;
 
             // Nodejs
             let mut out_name_for_nodejs = Some(format!("{}_cjs", data.crate_name()));
             if let Some(value) = out_name {
                 out_name_for_nodejs = Some(format!("{}_cjs", value));
-            }            
+            }
             run_wasm_bindgen(
                 data,
                 bindgen,
@@ -67,14 +66,14 @@ pub fn wasm_bindgen_build(
                 &out_name_for_nodejs,
                 true,
                 Target::Nodejs,
-                profile
-                )?;
+                profile,
+            )?;
 
             // NoModules
             let mut out_name_for_nomodules = Some(format!("{}_browser", data.crate_name()));
             if let Some(value) = out_name {
                 out_name_for_nomodules = Some(format!("{}_browser", value));
-            }            
+            }
             run_wasm_bindgen(
                 data,
                 bindgen,
@@ -82,19 +81,19 @@ pub fn wasm_bindgen_build(
                 &out_name_for_nomodules,
                 disable_dts,
                 Target::NoModules,
-                profile
-                )?;
-        },
+                profile,
+            )?;
+        }
         _ => {
             run_wasm_bindgen(
-                    data,
-                    bindgen,
-                    out_dir,
-                    out_name,
-                    disable_dts,
-                    target,
-                    profile
-                )?;
+                data,
+                bindgen,
+                out_dir,
+                out_name,
+                disable_dts,
+                target,
+                profile,
+            )?;
         }
     }
     Ok(())
@@ -108,8 +107,7 @@ fn run_wasm_bindgen(
     disable_dts: bool,
     target: Target,
     profile: BuildProfile,
-    ) -> Result<(), failure::Error> {
-
+) -> Result<(), failure::Error> {
     let release_or_debug = match profile {
         BuildProfile::Release | BuildProfile::Profiling => "release",
         BuildProfile::Dev => "debug",
@@ -204,7 +202,7 @@ fn build_target_arg_legacy(target: Target, cli_path: &PathBuf) -> Result<String,
             }
         }
         Target::Bundler => "--browser",
-        _ => bail!(format!("The passed target, {}, is not supported", target))
+        _ => bail!(format!("The passed target, {}, is not supported", target)),
     };
     Ok(target_arg.to_string())
 }

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -10,9 +10,6 @@ use semver;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-// torch2424 TODO Remove this
-use PBAR;
-
 /// Run the `wasm-bindgen` CLI to generate bindings for the current crate's
 /// `.wasm`.
 pub fn wasm_bindgen_build(
@@ -24,20 +21,15 @@ pub fn wasm_bindgen_build(
     target: Target,
     profile: BuildProfile,
 ) -> Result<(), failure::Error> {
-    // torch2424 
-    PBAR.info(" ");
-    PBAR.info(&format!("torch2424: wasm_bindgen target {}", target));
-    PBAR.info(" ");
 
     match target {
         Target::All => {
-            PBAR.info("TODO Target all!"); 
-
 
             // Bundler
-            let mut out_name_for_bundler = Some(format!("{}.cjs", data.crate_name()));
+            // NOTE: We only generate our type definitions here if we want them
+            let mut out_name_for_bundler = Some(format!("{}.esm.js", data.crate_name()));
             if let Some(value) = out_name {
-                
+                out_name_for_bundler = Some(format!("{}.esm.js", value));
             }            
             run_wasm_bindgen(
                 data,
@@ -49,13 +41,50 @@ pub fn wasm_bindgen_build(
                 profile
                 )?;
 
-
             // Web
-            
+            let mut out_name_for_web = Some(format!("{}.web.js", data.crate_name()));
+            if let Some(value) = out_name {
+                out_name_for_web = Some(format!("{}.web.js", value));
+            }            
+            run_wasm_bindgen(
+                data,
+                bindgen,
+                out_dir,
+                &out_name_for_web,
+                false,
+                Target::Web,
+                profile
+                )?;
+        
             // Nodejs
+            let mut out_name_for_nodejs = Some(format!("{}.cjs.js", data.crate_name()));
+            if let Some(value) = out_name {
+                out_name_for_nodejs = Some(format!("{}.cjs.js", value));
+            }            
+            run_wasm_bindgen(
+                data,
+                bindgen,
+                out_dir,
+                &out_name_for_nodejs,
+                false,
+                Target::Nodejs,
+                profile
+                )?;
 
             // NoModules
-
+            let mut out_name_for_nomodules = Some(format!("{}.browser.js", data.crate_name()));
+            if let Some(value) = out_name {
+                out_name_for_nomodules = Some(format!("{}.browser.js", value));
+            }            
+            run_wasm_bindgen(
+                data,
+                bindgen,
+                out_dir,
+                &out_name_for_nomodules,
+                false,
+                Target::NoModules,
+                profile
+                )?;
         },
         _ => {
             run_wasm_bindgen(
@@ -88,12 +117,6 @@ fn run_wasm_bindgen(
     };
 
     let out_dir = out_dir.to_str().unwrap();
-
-    // torch2424 
-    PBAR.info(" ");
-    PBAR.info(&format!("torch2424: wasm_bindgen out_dir {}", out_dir));
-    PBAR.info(" ");
-
 
     let wasm_path = data
         .target_directory()

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -10,6 +10,9 @@ use semver;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+// torch2424 TODO Remove this
+use PBAR;
+
 /// Run the `wasm-bindgen` CLI to generate bindings for the current crate's
 /// `.wasm`.
 pub fn wasm_bindgen_build(
@@ -21,12 +24,76 @@ pub fn wasm_bindgen_build(
     target: Target,
     profile: BuildProfile,
 ) -> Result<(), failure::Error> {
+    // torch2424 
+    PBAR.info(" ");
+    PBAR.info(&format!("torch2424: wasm_bindgen target {}", target));
+    PBAR.info(" ");
+
+    match target {
+        Target::All => {
+            PBAR.info("TODO Target all!"); 
+
+
+            // Bundler
+            let mut out_name_for_bundler = Some(format!("{}.cjs", data.crate_name()));
+            if let Some(value) = out_name {
+                
+            }            
+            run_wasm_bindgen(
+                data,
+                bindgen,
+                out_dir,
+                &out_name_for_bundler,
+                disable_dts,
+                Target::Bundler,
+                profile
+                )?;
+
+
+            // Web
+            
+            // Nodejs
+
+            // NoModules
+
+        },
+        _ => {
+            run_wasm_bindgen(
+                    data,
+                    bindgen,
+                    out_dir,
+                    out_name,
+                    disable_dts,
+                    target,
+                    profile
+                )?;
+        }
+    }
+    Ok(())
+}
+
+fn run_wasm_bindgen(
+    data: &CrateData,
+    bindgen: &Download,
+    out_dir: &Path,
+    out_name: &Option<String>,
+    disable_dts: bool,
+    target: Target,
+    profile: BuildProfile,
+    ) -> Result<(), failure::Error> {
+
     let release_or_debug = match profile {
         BuildProfile::Release | BuildProfile::Profiling => "release",
         BuildProfile::Dev => "debug",
     };
 
     let out_dir = out_dir.to_str().unwrap();
+
+    // torch2424 
+    PBAR.info(" ");
+    PBAR.info(&format!("torch2424: wasm_bindgen out_dir {}", out_dir));
+    PBAR.info(" ");
+
 
     let wasm_path = data
         .target_directory()
@@ -115,7 +182,7 @@ fn build_target_arg_legacy(target: Target, cli_path: &PathBuf) -> Result<String,
             }
         }
         Target::Bundler => "--browser",
-        Target::All => "--all",
+        _ => bail!(format!("The passed target, {}, is not supported", target))
     };
     Ok(target_arg.to_string())
 }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -226,6 +226,8 @@ impl Build {
             process_step(self)?;
         }
 
+        info!("TODO Testing!");
+
         let duration = crate::command::utils::elapsed(started.elapsed());
         info!("Done in {}.", &duration);
         info!(
@@ -373,7 +375,7 @@ impl Build {
 
         match self.target {
             Target::All => {
-            
+                info!("TODO Target all!"); 
             },
             _ => {
                 bindgen::wasm_bindgen_build(

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -226,8 +226,6 @@ impl Build {
             process_step(self)?;
         }
 
-        PBAR.info("TODO Testing!");
-
         let duration = crate::command::utils::elapsed(started.elapsed());
         info!("Done in {}.", &duration);
         info!(
@@ -370,25 +368,15 @@ impl Build {
 
     fn step_run_wasm_bindgen(&mut self) -> Result<(), Error> {
         info!("Building the wasm bindings...");
-
-        info!("target {}", self.target);
-
-        match self.target {
-            Target::All => {
-                info!("TODO Target all!"); 
-            },
-            _ => {
-                bindgen::wasm_bindgen_build(
-                    &self.crate_data,
-                    self.bindgen.as_ref().unwrap(),
-                    &self.out_dir,
-                    &self.out_name,
-                    self.disable_dts,
-                    self.target,
-                    self.profile,
-                    )?;
-            }
-        }
+        bindgen::wasm_bindgen_build(
+            &self.crate_data,
+            self.bindgen.as_ref().unwrap(),
+            &self.out_dir,
+            &self.out_name,
+            self.disable_dts,
+            self.target,
+            self.profile,
+        )?;
         info!("wasm bindings were built at {:#?}.", &self.out_dir);
         Ok(())
     }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -54,6 +54,8 @@ pub enum Target {
     /// in a browser but pollutes the global namespace and must be manually
     /// instantiated.
     NoModules,
+    /// Correspond to `--target all` where the output is all other targets
+    All,
 }
 
 impl Default for Target {
@@ -69,6 +71,7 @@ impl fmt::Display for Target {
             Target::Web => "web",
             Target::Nodejs => "nodejs",
             Target::NoModules => "no-modules",
+            Target::All => "all",
         };
         write!(f, "{}", s)
     }
@@ -82,6 +85,7 @@ impl FromStr for Target {
             "web" => Ok(Target::Web),
             "nodejs" => Ok(Target::Nodejs),
             "no-modules" => Ok(Target::NoModules),
+            "all" => Ok(Target::All),
             _ => bail!("Unknown target: {}", s),
         }
     }
@@ -120,7 +124,7 @@ pub struct BuildOptions {
     pub disable_dts: bool,
 
     #[structopt(long = "target", short = "t", default_value = "bundler")]
-    /// Sets the target environment. [possible values: bundler, nodejs, web, no-modules]
+    /// Sets the target environment. [possible values: bundler, nodejs, web, no-modules, all]
     pub target: Target,
 
     #[structopt(long = "debug")]
@@ -364,15 +368,25 @@ impl Build {
 
     fn step_run_wasm_bindgen(&mut self) -> Result<(), Error> {
         info!("Building the wasm bindings...");
-        bindgen::wasm_bindgen_build(
-            &self.crate_data,
-            self.bindgen.as_ref().unwrap(),
-            &self.out_dir,
-            &self.out_name,
-            self.disable_dts,
-            self.target,
-            self.profile,
-        )?;
+
+        info!("target {}", self.target);
+
+        match self.target {
+            Target::All => {
+            
+            },
+            _ => {
+                bindgen::wasm_bindgen_build(
+                    &self.crate_data,
+                    self.bindgen.as_ref().unwrap(),
+                    &self.out_dir,
+                    &self.out_name,
+                    self.disable_dts,
+                    self.target,
+                    self.profile,
+                    )?;
+            }
+        }
         info!("wasm bindings were built at {:#?}.", &self.out_dir);
         Ok(())
     }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -226,7 +226,7 @@ impl Build {
             process_step(self)?;
         }
 
-        info!("TODO Testing!");
+        PBAR.info("TODO Testing!");
 
         let duration = crate::command::utils::elapsed(started.elapsed());
         info!("Done in {}.", &duration);

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -764,8 +764,8 @@ impl CrateData {
                 files: data.files,
                 main: data.main,
                 // TODO: The other formats
-                // module: data.main,
-                // browser: data.main,
+                module: "".to_string(),
+                browser: "".to_string(),
                 homepage: data.homepage,
                 types: data.dts_file,
                 side_effects: false,

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::path::Path;
 
 use self::npm::{
-    repository::Repository, CommonJSPackage, ESModulesPackage, NoModulesPackage, NpmPackage,
+    repository::Repository, CommonJSPackage, ESModulesPackage, NoModulesPackage, AllPackage, NpmPackage,
 };
 use cargo_metadata::Metadata;
 use chrono::offset;
@@ -540,6 +540,7 @@ impl CrateData {
             Target::NoModules => self.to_nomodules(scope, disable_dts, out_dir),
             Target::Bundler => self.to_esmodules(scope, disable_dts, out_dir),
             Target::Web => self.to_web(scope, disable_dts, out_dir),
+            Target::All => self.to_all(scope, disable_dts, out_dir),
         };
 
         let npm_json = serde_json::to_string_pretty(&npm_data)?;
@@ -731,6 +732,43 @@ impl CrateData {
             browser: data.main,
             homepage: data.homepage,
             types: data.dts_file,
+        })
+    }
+
+    fn to_all(
+        &self,
+        scope: &Option<String>,
+        disable_dts: bool,
+        out_dir: &Path,
+        ) -> NpmPackage {
+        let data = self.npm_data(scope, false, disable_dts, out_dir);
+        let pkg = &self.data.packages[self.current_idx];
+
+        self.check_optional_fields();
+
+        NpmPackage::AllPackage(AllPackage {
+            name: data.name,
+            collaborators: pkg.authors.clone(),
+            description: self.manifest.package.description.clone(),
+            version: pkg.version.to_string(),
+            license: self.license(),
+            repository: self
+                .manifest
+                .package
+                .repository
+                .clone()
+                .map(|repo_url| Repository {
+                    ty: "git".to_string(),
+                    url: repo_url,
+                }),
+                files: data.files,
+                main: data.main,
+                // TODO: The other formats
+                // module: data.main,
+                // browser: data.main,
+                homepage: data.homepage,
+                types: data.dts_file,
+                side_effects: false,
         })
     }
 

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -12,7 +12,8 @@ use std::fs;
 use std::path::Path;
 
 use self::npm::{
-    repository::Repository, CommonJSPackage, ESModulesPackage, NoModulesPackage, AllPackage, NpmPackage,
+    repository::Repository, AllPackage, CommonJSPackage, ESModulesPackage, NoModulesPackage,
+    NpmPackage,
 };
 use cargo_metadata::Metadata;
 use chrono::offset;
@@ -559,7 +560,6 @@ impl CrateData {
         disable_dts: bool,
         out_dir: &Path,
     ) -> NpmData {
-
         let pkg = &self.data.packages[self.current_idx];
         let npm_name = match scope {
             Some(s) => format!("@{}/{}", s, pkg.name),
@@ -592,7 +592,8 @@ impl CrateData {
                         let type_file = format!("{}{}.d.ts", name_prefix, module_type_prefix);
                         files.push(type_file.to_string());
                         if *module_type_prefix != "_cjs" {
-                            let type_bg_file = format!("{}{}_bg.d.ts", name_prefix, module_type_prefix);
+                            let type_bg_file =
+                                format!("{}{}_bg.d.ts", name_prefix, module_type_prefix);
                             files.push(type_bg_file.to_string());
                         }
                         Some(type_file)
@@ -600,7 +601,7 @@ impl CrateData {
                         None
                     };
                 }
-            },
+            }
             Target::Nodejs => {
                 let js_bg_file = format!("{}_bg.js", name_prefix);
                 files.push(js_bg_file);
@@ -798,12 +799,7 @@ impl CrateData {
         })
     }
 
-    fn to_all(
-        &self,
-        scope: &Option<String>,
-        disable_dts: bool,
-        out_dir: &Path,
-        ) -> NpmPackage {
+    fn to_all(&self, scope: &Option<String>, disable_dts: bool, out_dir: &Path) -> NpmPackage {
         let data = self.npm_data(Target::All, scope, disable_dts, out_dir);
         let pkg = &self.data.packages[self.current_idx];
 
@@ -830,14 +826,14 @@ impl CrateData {
                     ty: "git".to_string(),
                     url: repo_url,
                 }),
-                files: files,
-                main: data.main,
-                module: data.module,
-                browser: data.browser,
-                web: data.web,
-                homepage: data.homepage,
-                types: data.dts_file,
-                side_effects: false,
+            files: files,
+            main: data.main,
+            module: data.module,
+            browser: data.browser,
+            web: data.web,
+            homepage: data.homepage,
+            types: data.dts_file,
+            side_effects: false,
         })
     }
 

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -566,7 +566,7 @@ impl CrateData {
         // Target::Nodejs
         let cjs_js_file = format!("{}.cjs.js", name_prefix);
         // Target::NoModules
-        let nomodules_js_file = format!("{}.no-modules.js", name_prefix);
+        let nomodules_js_file = format!("{}.browser.js", name_prefix);
         // Target::Bundler
         let esm_js_file = format!("{}.esm.js", name_prefix);
         // Target::Web

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -564,13 +564,13 @@ impl CrateData {
 
 
         // Target::Nodejs
-        let cjs_js_file = format!("{}.cjs.js", name_prefix);
+        let cjs_js_file = format!("{}_cjs.js", name_prefix);
         // Target::NoModules
-        let nomodules_js_file = format!("{}.browser.js", name_prefix);
+        let nomodules_js_file = format!("{}_browser.js", name_prefix);
         // Target::Bundler
-        let esm_js_file = format!("{}.esm.js", name_prefix);
+        let esm_js_file = format!("{}_esm.js", name_prefix);
         // Target::Web
-        let web_js_file = format!("{}.web.js", name_prefix);
+        let web_js_file = format!("{}_web.js", name_prefix);
 
         let mut files = vec![wasm_file];
 

--- a/src/manifest/npm/all.rs
+++ b/src/manifest/npm/all.rs
@@ -17,6 +17,7 @@ pub struct AllPackage {
     pub main: String,
     pub module: String, 
     pub browser: String,
+    pub web: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub homepage: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/manifest/npm/all.rs
+++ b/src/manifest/npm/all.rs
@@ -15,7 +15,7 @@ pub struct AllPackage {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub files: Vec<String>,
     pub main: String,
-    pub module: String, 
+    pub module: String,
     pub browser: String,
     pub web: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/manifest/npm/all.rs
+++ b/src/manifest/npm/all.rs
@@ -1,0 +1,26 @@
+use manifest::npm::repository::Repository;
+
+#[derive(Serialize)]
+pub struct AllPackage {
+    pub name: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub collaborators: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<Repository>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
+    pub main: String,
+    pub module: String, 
+    pub browser: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub types: Option<String>,
+    #[serde(rename = "sideEffects")]
+    pub side_effects: bool,
+}

--- a/src/manifest/npm/mod.rs
+++ b/src/manifest/npm/mod.rs
@@ -1,13 +1,13 @@
+mod all;
 mod commonjs;
 mod esmodules;
 mod nomodules;
-mod all;
 pub mod repository;
 
+pub use self::all::AllPackage;
 pub use self::commonjs::CommonJSPackage;
 pub use self::esmodules::ESModulesPackage;
 pub use self::nomodules::NoModulesPackage;
-pub use self::all::AllPackage;
 
 #[derive(Serialize)]
 #[serde(untagged)]
@@ -15,5 +15,5 @@ pub enum NpmPackage {
     CommonJSPackage(CommonJSPackage),
     ESModulesPackage(ESModulesPackage),
     NoModulesPackage(NoModulesPackage),
-    AllPackage(AllPackage), 
+    AllPackage(AllPackage),
 }

--- a/src/manifest/npm/mod.rs
+++ b/src/manifest/npm/mod.rs
@@ -1,11 +1,13 @@
 mod commonjs;
 mod esmodules;
 mod nomodules;
+mod all;
 pub mod repository;
 
 pub use self::commonjs::CommonJSPackage;
 pub use self::esmodules::ESModulesPackage;
 pub use self::nomodules::NoModulesPackage;
+pub use self::all::AllPackage;
 
 #[derive(Serialize)]
 #[serde(untagged)]
@@ -13,4 +15,5 @@ pub enum NpmPackage {
     CommonJSPackage(CommonJSPackage),
     ESModulesPackage(ESModulesPackage),
     NoModulesPackage(NoModulesPackage),
+    AllPackage(AllPackage), 
 }


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ x ] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [ x ] You ran `cargo fmt` on the code base before submitting
- [ x ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

relates to #697 
closes #313
 
This introduces a `--target all` flag that will run wasm-bindgen for all of our supported outputs, prefixing them with a `_[MODULE TYPE HERE]`. And then adding all of the files to the resulting package.json.

# Things still to do

* Tests (Wanted to get some approval before writing them)
* Comments made in #313 regarding `.mjs` :smile: cc @stephanemagnenat

cc@alexcrichton @ashleygwilliams

P.S I wrote the last half of this at 2AM. So the code may be terrible, but I figured we could get through this together :joy: 
