### PR TITLE
Correct out-dir argument behavior

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -179,7 +179,7 @@ impl Build {
     pub fn try_from_opts(build_opts: BuildOptions) -> Result<Self, Error> {
         let crate_path = get_crate_path(build_opts.path)?;
         let crate_data = manifest::CrateData::new(&crate_path, build_opts.out_name.clone())?;
-        let out_dir = crate_path.join(PathBuf::from(build_opts.out_dir));
+        let out_dir = PathBuf::from(build_opts.out_dir);
 
         let dev = build_opts.dev || build_opts.debug;
         let profile = match (dev, build_opts.release, build_opts.profiling) {


### PR DESCRIPTION
Fixes #704 
Correct the out-dir argument's behavior so that it behaves as documentation says it does.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
