### PR TITLE
feat(build): multiple build targets per package

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -125,6 +125,23 @@ wasm-pack build examples/js-hello-world --mode no-install
 | `no-install`  | `wasm-pack init` implicitly and create wasm binding  without installing `wasm-bindgen`.  |
 | `normal`      | do all the stuffs of `no-install` with installed `wasm-bindgen`.                         |
 
+## Multiple build targets per package
+
+The `build` command accepts an optional `--is-child` argument.
+```
+wasm-pack build examples/js-hello-world --is-child --out-name child
+```
+
+This command will extend a previously generated package, which makes it possible to have multiple build targets per package.
+For example it would be feasible to have an optimized build for web and Node.
+
+Following is an example which will use the wee_alloc feature for web, because size is more crucial whereas Node should be optimized for speed.
+
+```
+wasm-pack build examples/js-hello-world --out-dir pkg -- --features "wee_alloc"
+wasm-pack build examples/js-hello-world --out-dir pkg --out-name js-hello-node --is-child
+```
+
 ## Extra options
 
 The `build` command can pass extra options straight to `cargo build` even if they are not

--- a/src/manifest/npm/commonjs.rs
+++ b/src/manifest/npm/commonjs.rs
@@ -1,6 +1,6 @@
 use manifest::npm::repository::Repository;
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct CommonJSPackage {
     pub name: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/src/manifest/npm/esmodules.rs
+++ b/src/manifest/npm/esmodules.rs
@@ -1,6 +1,6 @@
 use manifest::npm::repository::Repository;
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct ESModulesPackage {
     pub name: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/src/manifest/npm/mod.rs
+++ b/src/manifest/npm/mod.rs
@@ -7,10 +7,20 @@ pub use self::commonjs::CommonJSPackage;
 pub use self::esmodules::ESModulesPackage;
 pub use self::nomodules::NoModulesPackage;
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum NpmPackage {
     CommonJSPackage(CommonJSPackage),
     ESModulesPackage(ESModulesPackage),
     NoModulesPackage(NoModulesPackage),
+}
+
+impl NpmPackage {
+    pub fn add_file(&mut self, file: String) {
+        match self {
+            Self::CommonJSPackage(pkg) => pkg.files.push(file),
+            Self::ESModulesPackage(pkg) => pkg.files.push(file),
+            Self::NoModulesPackage(pkg) => pkg.files.push(file),
+        }
+    }
 }

--- a/src/manifest/npm/nomodules.rs
+++ b/src/manifest/npm/nomodules.rs
@@ -1,6 +1,6 @@
 use manifest::npm::repository::Repository;
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct NoModulesPackage {
     pub name: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/src/manifest/npm/repository.rs
+++ b/src/manifest/npm/repository.rs
@@ -1,4 +1,4 @@
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Repository {
     #[serde(rename = "type")]
     pub ty: String,


### PR DESCRIPTION
Hey there,

I haven't created an issue for this before submitting this PR, but I think it's a nice addition.

EDIT: I've just seen this PR: https://github.com/rustwasm/wasm-pack/pull/695
It is somewhat similar. Let me know what you think! This PR will also extend the files section of the already existing package.json. Otherwise you would have to do this manually. Maybe the use cases of both PRs differ enough?

Edit2: I've just seen #606.
This PR indeed directly refers to the problem explained there, but we need to discuss whether this should be behind an argument just like I did or whether it should be the default behavior.

What I would propose is that wasm-pack automatically detects whether a package.json exists. If the package.json has been generated with the same --out-name it should be overwritten, otherwise it should extend it. When extending, it should also check whether changes have already been done to extend it so that multiple recompilations of a transitive dependency don't generate a bad package.json.

Here is what I wrote in the docs. Let me know if the use case is clear enough:

## Multiple build targets per package

The `build` command accepts an optional `--is-child` argument.
```
wasm-pack build examples/js-hello-world --is-child --out-name child
```

This command will extend a previously generated package, which makes it possible to have multiple build targets per package.
For example it would be feasible to have an optimized build for web and Node.

Following is an example which will use the wee_alloc feature for web, because size is more crucial whereas Node should be optimized for speed.

```
wasm-pack build examples/js-hello-world --out-dir pkg -- --features "wee_alloc"
wasm-pack build examples/js-hello-world --out-dir pkg --out-name js-hello-node --is-child
```