### PR TITLE
feat(build): add first-class support for binary crates

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -81,7 +81,7 @@ pub fn cargo_build_wasm(
     let msg = format!("{}Compiling to Wasm...", emoji::CYCLONE);
     PBAR.info(&msg);
     let mut cmd = Command::new("cargo");
-    cmd.current_dir(path).arg("build").arg("--lib");
+    cmd.current_dir(path).arg("build");
     match profile {
         BuildProfile::Profiling => {
             // Once there are DWARF debug info consumers, force enable debug

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -295,3 +295,43 @@ fn build_force() {
         .assert()
         .success();
 }
+
+#[test]
+fn bin_crate_behavior_identical() {
+    let fixture = utils::fixture::bin_crate();
+    fixture.install_local_wasm_bindgen();
+    fixture
+        .wasm_pack()
+        .arg("build")
+        .arg("--target")
+        .arg("nodejs")
+        .assert()
+        .success();
+    let native_output = fixture.command("cargo").arg("run").output().unwrap();
+    assert!(native_output.status.success());
+    assert_eq!(native_output.stdout, b"Hello, World\n");
+    let wasm_output = fixture.command("node").arg("pkg/foo.js").output().unwrap();
+    assert!(wasm_output.status.success());
+    assert_eq!(wasm_output.stdout, b"Hello, World\n");
+}
+
+#[test]
+fn multi_bin_crate_procs_all() {
+    let fixture = utils::fixture::multi_bin_crate();
+    fixture.install_local_wasm_bindgen();
+    fixture
+        .wasm_pack()
+        .arg("build")
+        .arg("--target")
+        .arg("nodejs")
+        .assert()
+        .success();
+    let pkg_path = |x: &str| {
+        let mut path = fixture.path.clone();
+        path.push("pkg");
+        path.push(x);
+        path
+    };
+    assert!(pkg_path("foo.js").exists());
+    assert!(pkg_path("sample.js").exists());
+}

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -64,6 +64,13 @@ fn it_checks_has_cdylib_wrong_crate_type() {
 }
 
 #[test]
+fn it_accepts_binary_crates_without_cdylib() {
+    let fixture = fixture::bin_crate();
+    let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
+    crate_data.check_crate_config().unwrap();
+}
+
+#[test]
 fn it_recognizes_a_map_during_depcheck() {
     let fixture = fixture::serde_feature();
     // Ensure that there is a `Cargo.lock`.

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -1,5 +1,6 @@
 use binary_install::Cache;
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::mem::ManuallyDrop;
 use std::path::{Path, PathBuf};
@@ -210,6 +211,41 @@ impl Fixture {
         )
     }
 
+    /// Add a `src/main.rs` file that contains a "hello world" program.
+    pub fn hello_world_src_main(&self) -> &Self {
+        self.file(
+            "src/main.rs",
+            r#"
+                extern crate wasm_bindgen;
+                use wasm_bindgen::prelude::*;
+
+                // Import the `console.log` function from the Web.
+                #[wasm_bindgen]
+                extern {
+                    #[wasm_bindgen(js_namespace = console, js_name = log)]
+                    fn console_log(s: &str);
+                }
+
+                // On wasm, print() should forward to console.log.
+                #[cfg(target_arch = "wasm32")]
+                fn print(text: &str) {
+                    console_log(text);
+                }
+
+                // On not-wasm, print() should forward to println!().
+                #[cfg(not(target_arch = "wasm32"))]
+                fn print(text: &str) {
+                    println!("{}", text);
+                }
+
+                // Write a main() that will print some text.
+                fn main() {
+                    print("Hello, World");
+                }
+            "#,
+        )
+    }
+
     /// Install a local wasm-bindgen for this fixture.
     ///
     /// Takes care not to re-install for every fixture, but only the one time
@@ -221,7 +257,7 @@ impl Fixture {
 
         static INSTALL_WASM_BINDGEN: Once = ONCE_INIT;
         let cache = self.cache();
-        let version = "0.2.37";
+        let version = "0.2.54";
 
         let download = || {
             if let Ok(download) =
@@ -314,6 +350,12 @@ impl Fixture {
 
     pub fn cache(&self) -> Cache {
         Cache::at(&self.cache_dir())
+    }
+
+    pub fn command<S: AsRef<OsStr>>(&self, program: S) -> Command {
+        let mut result = Command::new(program);
+        result.current_dir(&self.path);
+        result
     }
 
     /// The `step_install_wasm_bindgen` and `step_run_wasm_bindgen` steps only
@@ -412,6 +454,86 @@ pub fn no_cdylib() -> Fixture {
             wasm-bindgen-test = "0.2"
         "#,
     );
+    fixture
+}
+
+pub fn bin_crate() -> Fixture {
+    let fixture = Fixture::new();
+    fixture.readme().hello_world_src_main().file(
+        "Cargo.toml",
+        r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "foo"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [dependencies]
+            wasm-bindgen = "0.2"
+
+            [dev-dependencies]
+            wasm-bindgen-test = "0.2"
+        "#,
+    );
+    fixture
+}
+
+pub fn multi_bin_crate() -> Fixture {
+    let fixture = Fixture::new();
+    fixture
+        .readme()
+        .hello_world_src_main()
+        .file(
+            "src/bin/sample.rs",
+            r#"
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+
+            // Import the `console.log` function from the Web.
+            #[wasm_bindgen]
+            extern {
+                #[wasm_bindgen(js_namespace = console, js_name = log)]
+                fn console_log(s: &str);
+            }
+
+            // On wasm, print() should forward to console.log.
+            #[cfg(target_arch = "wasm32")]
+            fn print(text: &str) {
+                console_log(text);
+            }
+
+            // On not-wasm, print() should forward to println!().
+            #[cfg(not(target_arch = "wasm32"))]
+            fn print(text: &str) {
+                println!("{}", text);
+            }
+
+            // Write a main() that will print slightly different text.
+            fn main() {
+                print("Sample Text");
+            }
+        "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "foo"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [dependencies]
+            wasm-bindgen = "0.2"
+
+            [dev-dependencies]
+            wasm-bindgen-test = "0.2"
+        "#,
+        );
     fixture
 }
 


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [X] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [X] You ran `cargo fmt` on the code base before submitting
- [X] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

---

fixes #734 

Now that https://github.com/rustwasm/wasm-bindgen/issues/1630 has been implemented, I think it's good to have the same support in `wasm-pack`.

This implementation currently doesn't add `bin` entries in `package.json`, partially because [the docs on that field](https://docs.npmjs.com/files/package.json.html#bin) say that targets must be prefixed with `#!/usr/bin/env node` and I'm not sure how or where to ensure that all and only binaries get that prefix. I don't think that feature is vital, but if other people think it's a must-have then I can take a look at adding it.