### PR TITLE
Create npm installer

### DIFF
--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,94 @@
+<div align="center">
+
+  <h1>📦✨  wasm-pack</h1>
+
+  <p>
+    <strong>Your favorite Rust → Wasm workflow tool!</strong>
+  </p>
+
+  <p>
+    <a href="https://travis-ci.com/rustwasm/wasm-pack"><img alt="Build Status" src="https://travis-ci.com/rustwasm/wasm-pack.svg?branch=master"/></a>
+    <a href="https://ci.appveyor.com/project/ashleygwilliams/wasm-pack-071k0"><img alt="Build status" src="https://ci.appveyor.com/api/projects/status/iv1qtnqtv168ef8h?svg=true"/></a>
+    <a href="https://crates.io/crates/wasm-pack"><img alt="crates.io" src="https://meritbadge.herokuapp.com/wasm-pack"/></a>
+  </p>
+
+  <h3>
+    <a href="https://rustwasm.github.io/docs/wasm-pack/">Docs</a>
+    <span> | </span>
+    <a href="https://github.com/rustwasm/wasm-pack/blob/master/CONTRIBUTING.md">Contributing</a>
+    <span> | </span>
+    <a href="https://discordapp.com/channels/442252698964721669/443151097398296587">Chat</a>
+  </h3>
+
+  <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
+</div>
+
+## About
+
+This tool seeks to be a one-stop shop for building and working with rust-
+generated WebAssembly that you would like to interop with JavaScript, in the
+browser or with Node.js. `wasm-pack` helps you build rust-generated
+WebAssembly packages that you could publish to the npm registry, or otherwise use
+alongside any javascript packages in workflows that you already use, such as [webpack]
+or [greenkeeper].
+
+[bundler-support]: https://github.com/rustwasm/team/blob/master/goals/bundler-integration.md#details
+[webpack]: https://webpack.js.org/
+[greenkeeper]: https://greenkeeper.io/
+
+This project is a part of the [rust-wasm] group. You can find more info by
+visiting that repo!
+
+[rust-wasm]: https://github.com/rustwasm/team
+
+![demo](demo.gif)
+
+## 🔮 Prerequisities
+
+This project requires Rust 1.30.0 or later.
+
+- [Development Environment](https://rustwasm.github.io/wasm-pack/book/prerequisites/index.html)
+- [Installation](https://rustwasm.github.io/wasm-pack/installer)
+
+## ⚡ Quickstart Guide
+
+Visit the [quickstart quide] in our documentation.
+
+[quickstart guide]: https://rustwasm.github.io/wasm-pack/book/quickstart.html
+
+## 🎙️ Commands
+
+- [`new`](https://rustwasm.github.io/wasm-pack/book/commands/new.html): Generate a new RustWasm project using a template
+- [`build`](https://rustwasm.github.io/wasm-pack/book/commands/build.html): Generate an npm wasm pkg from a rustwasm crate
+- [`test`](https://rustwasm.github.io/wasm-pack/book/commands/test.html): Run browser tests
+- [`pack` and `publish`](https://rustwasm.github.io/wasm-pack/book/commands/pack-and-publish.html): Create a tarball of your rustwasm pkg and/or publish to a registry
+
+## 📝 Logging
+
+`wasm-pack` uses [`env_logger`] to produce logs when `wasm-pack` runs.
+
+To configure your log level, use the `RUST_LOG` environment variable. For example:
+
+```
+RUST_LOG=info wasm-pack build
+```
+
+[`env_logger`]: https://crates.io/crates/env_logger
+
+## 👯 Contributing
+
+Read our [guide] on getting up and running for developing `wasm-pack`, and
+check out our [contribution policy].
+
+[guide]: https://rustwasm.github.io/wasm-pack/book/contributing.html
+[contribution policy]: CONTRIBUTING.md
+
+## 🤹‍♀️ Governance
+
+This project is part of the [rustwasm Working Group].
+
+This project was started by [ashleygwilliams] and is co-maintained by [ashleygwilliams], [drager] and the Rust Wasm Working Group Core Team.
+
+[ashleygwilliams]: https://github.com/ashleygwilliams
+[drager]: https://github.com/drager
+[rustwasm Working Group]: https://github.com/rustwasm/team

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,29 +1,10 @@
-<div align="center">
+# 📦✨  wasm-pack
+> Your favorite rust -> wasm workflow tool!
 
-  <h1>📦✨  wasm-pack</h1>
+[![Build Status](https://travis-ci.com/rustwasm/wasm-pack.svg?branch=master)](https://travis-ci.com/rustwasm/wasm-pack)
+[![Build status](https://ci.appveyor.com/api/projects/status/iv1qtnqtv168ef8h?svg=true)](https://ci.appveyor.com/project/ashleygwilliams/wasm-pack-071k0)
+[![crates.io](https://meritbadge.herokuapp.com/wasm-pack)](https://crates.io/crates/wasm-pack)
 
-  <p>
-    <strong>Your favorite Rust → Wasm workflow tool!</strong>
-  </p>
-
-  <p>
-    <a href="https://travis-ci.com/rustwasm/wasm-pack"><img alt="Build Status" src="https://travis-ci.com/rustwasm/wasm-pack.svg?branch=master"/></a>
-    <a href="https://ci.appveyor.com/project/ashleygwilliams/wasm-pack-071k0"><img alt="Build status" src="https://ci.appveyor.com/api/projects/status/iv1qtnqtv168ef8h?svg=true"/></a>
-    <a href="https://crates.io/crates/wasm-pack"><img alt="crates.io" src="https://meritbadge.herokuapp.com/wasm-pack"/></a>
-  </p>
-
-  <h3>
-    <a href="https://rustwasm.github.io/docs/wasm-pack/">Docs</a>
-    <span> | </span>
-    <a href="https://github.com/rustwasm/wasm-pack/blob/master/CONTRIBUTING.md">Contributing</a>
-    <span> | </span>
-    <a href="https://discordapp.com/channels/442252698964721669/443151097398296587">Chat</a>
-  </h3>
-
-  <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
-</div>
-
-## About
 
 This tool seeks to be a one-stop shop for building and working with rust-
 generated WebAssembly that you would like to interop with JavaScript, in the
@@ -49,23 +30,17 @@ This project requires Rust 1.30.0 or later.
 
 - [Development Environment](https://rustwasm.github.io/wasm-pack/book/prerequisites/index.html)
 - [Installation](https://rustwasm.github.io/wasm-pack/installer)
-
-## ⚡ Quickstart Guide
-
-Visit the [quickstart quide] in our documentation.
-
-[quickstart guide]: https://rustwasm.github.io/wasm-pack/book/quickstart.html
+- [Project Setup](https://rustwasm.github.io/wasm-pack/book/project-setup/index.html)
 
 ## 🎙️ Commands
 
-- [`new`](https://rustwasm.github.io/wasm-pack/book/commands/new.html): Generate a new RustWasm project using a template
 - [`build`](https://rustwasm.github.io/wasm-pack/book/commands/build.html): Generate an npm wasm pkg from a rustwasm crate
 - [`test`](https://rustwasm.github.io/wasm-pack/book/commands/test.html): Run browser tests
 - [`pack` and `publish`](https://rustwasm.github.io/wasm-pack/book/commands/pack-and-publish.html): Create a tarball of your rustwasm pkg and/or publish to a registry
 
 ## 📝 Logging
 
-`wasm-pack` uses [`env_logger`] to produce logs when `wasm-pack` runs.
+`wasm-pack` uses [`env_logger`] to produces logs when `wasm-pack` runs.
 
 To configure your log level, use the `RUST_LOG` environment variable. For example:
 
@@ -89,6 +64,40 @@ This project is part of the [rustwasm Working Group].
 
 This project was started by [ashleygwilliams] and is co-maintained by [ashleygwilliams], [drager] and the Rust Wasm Working Group Core Team.
 
-[ashleygwilliams]: https://github.com/ashleygwilliams
-[drager]: https://github.com/drager
-[rustwasm Working Group]: https://github.com/rustwasm/team
+## ⚡ Quickstart Guide
+
+1. Write a crate in Rust.
+2. Add `wasm-bindgen` to your `Cargo.toml`:
+
+  ```toml
+  [lib]
+  crate-type = ["cdylib"]
+
+  [dependencies]
+  wasm-bindgen = "0.2"
+  ```
+3. Add this to the top of your `src/lib.rs`:
+
+  ```rust
+  use wasm_bindgen::prelude::*;
+  ```
+
+4. Annotate your public functions with `#[wasm_bindgen]`, for example:
+
+  ```rust
+  #[wasm_bindgen]
+  extern {
+      pub fn alert(s: &str);
+  }
+
+  #[wasm_bindgen]
+  pub fn greet(name: &str) {
+      alert(&format!("Hello, {}!", name));
+  }
+  ```
+
+5. Install this tool: `cargo install wasm-pack`
+6. Run `wasm-pack build`, optionally, pass a path to a dir or a scope (see above for details)
+7. This tool generates files in a `pkg` dir
+8. To publish to npm, run `wasm-pack publish`. You may need to login to the
+   registry you want to publish to. You can login using `wasm-pack login`.

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -1,0 +1,50 @@
+const { Binary } = require("binary-install");
+const os = require("os");
+const { join } = require("path");
+
+const getPlatform = () => {
+  const type = os.type();
+  const arch = os.arch();
+
+  if (type === "Windows_NT" && arch === "x64") {
+    return "x86_64-pc-windows-msvc";
+  }
+  if (type === "Linux" && arch === "x64") {
+    return "x86_64-unknown-linux-musl";
+  }
+  if (type === "Darwin" && arch === "x64") {
+    return "x86_64-apple-darwin";
+  }
+
+  throw new Error(`Unsupported platform: ${type} ${arch}`);
+};
+
+const getBinary = () => {
+  const platform = getPlatform();
+  const version = require("./package.json").version;
+  const author = "rustwasm";
+  const name = "wasm-pack";
+  const url = `https://github.com/${author}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
+  return new Binary(url, { name });
+};
+
+const run = () => {
+  const binary = getBinary();
+  binary.run();
+};
+
+const install = () => {
+  const binary = getBinary();
+  binary.install();
+};
+
+const uninstall = () => {
+  const binary = getBinary();
+  binary.uninstall();
+};
+
+module.exports = {
+  install,
+  run,
+  uninstall
+};

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,0 +1,252 @@
+{
+  "name": "wasm-pack",
+  "version": "0.8.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "binary-install": {
+      "version": "github:EverlastingBugstopper/binary-install#422b936acee289853f791a463df52454179ded5a",
+      "from": "github:EverlastingBugstopper/binary-install#master",
+      "requires": {
+        "axios": "^0.19.0",
+        "env-paths": "^2.2.0",
+        "rimraf": "^3.0.0",
+        "tar": "^5.0.5",
+        "universal-url": "^2.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chownr": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "env-paths": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.0.0.tgz",
+      "integrity": "sha512-40Qz+LFXmd9tzYVnnBmZvFfvAADfUA14TXPK1s7IfElJTIZ97rA8w4Kin7Wt5JBrC3ShnnFJO/5vPjPEeJIq9A==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "hasurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hasurl/-/hasurl-1.0.0.tgz",
+      "integrity": "sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
+      "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "rimraf": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "tar": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
+      "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
+      "requires": {
+        "chownr": "^1.1.3",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.0",
+        "mkdirp": "^0.5.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "universal-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universal-url/-/universal-url-2.0.0.tgz",
+      "integrity": "sha512-3DLtXdm/G1LQMCnPj+Aw7uDoleQttNHp2g5FnNQKR6cP6taNWS1b/Ehjjx4PVyvejKi3TJyu8iBraKM4q3JQPg==",
+      "requires": {
+        "hasurl": "^1.0.0",
+        "whatwg-url": "^7.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+    },
+    "whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "wasm-pack",
+  "version": "0.8.1",
+  "description": "📦✨ your favorite rust -> wasm workflow tool!",
+  "main": "binary.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "node -e 'require(\"./binary.js\").install()'",
+    "preuninstall": "node -e 'require(\"./binary.js\").uninstall()'"
+  },
+  "bin": {
+    "wasm-pack": "./run.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rustwasm/wasm-pack.git"
+  },
+  "keywords": [
+    "wasm",
+    "rust-wasm",
+    "registry",
+    "cli",
+    "rust",
+    "npm",
+    "package"
+  ],
+  "author": "ashley666ashley@gmail.com",
+  "license": "MIT OR Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/rustwasm/wasm-pack/issues"
+  },
+  "homepage": "https://github.com/rustwasm/wasm-pack#readme",
+  "dependencies": {
+    "binary-install": "github:EverlastingBugstopper/binary-install#master"
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -4,7 +4,6 @@
   "description": "📦✨ your favorite rust -> wasm workflow tool!",
   "main": "binary.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "node -e 'require(\"./binary.js\").install()'",
     "preuninstall": "node -e 'require(\"./binary.js\").uninstall()'"
   },
@@ -24,13 +23,13 @@
     "npm",
     "package"
   ],
-  "author": "ashley666ashley@gmail.com",
+  "author": "Ashley Williams <ashley666ashley@gmail.com>",
   "license": "MIT OR Apache-2.0",
   "bugs": {
     "url": "https://github.com/rustwasm/wasm-pack/issues"
   },
   "homepage": "https://github.com/rustwasm/wasm-pack#readme",
   "dependencies": {
-    "binary-install": "github:EverlastingBugstopper/binary-install#master"
+    "binary-install": "0.0.0"
   }
 }

--- a/npm/run.js
+++ b/npm/run.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+const { run } = require("./binary");
+run()


### PR DESCRIPTION
This PR creates an npm installer for `wasm-pack` that downloads and installs a binary. It uses this unpublished package for installing binaries https://github.com/everlastingbugstopper/binary-install. 

It currently downloads from a workers.cloudflare endpoint that we'd likely want to change to something that the rustwasm working group has control over.

We also probably want some more keywords before this would be published - currently I've just copied the same tags from the repository.

Proof that it works
```console
$ cd ./wasm-pack/npm
$ npm i -g

> wasm-pack@0.8.1 postinstall 
> node -e 'require("./binary.js").install()'

Downloading release https://workers.cloudflare.com/get-binary/rustwasm/wasm-pack/v0.8.1/x86_64-apple-darwin.tar.gz
wasm-pack has been installed!
+ wasm-pack@0.8.1
updated 1 package in 1.317s                                                                                                                                                        
$ which wasm-pack
~/.nvm/versions/node/v13.1.0/bin/wasm-pack                                                                                                                                                         
$ wasm-pack
wasm-pack 0.8.1
Ashley Williams <ashley666ashley@gmail.com>
📦 ✨  pack and publish your wasm!

USAGE:
    wasm-pack [FLAGS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
    -v, --verbose    Log verbosity is based off the number of v used

SUBCOMMANDS:
    build      🏗️  build your npm package!
    help       Prints this message or the help of the given subcommand(s)
    login      👤  Add an npm registry user account! (aliases: adduser, add-user)
    pack       🍱  create a tar of your npm package but don't publish!
    publish    🎆  pack up your npm package and publish!
    test       👩‍🔬  test your wasm!
```

Uninstalling will remove the downloaded binary, and installing a new version will overwrite the old downloaded binary.

Some caveats:

The README will need to be updated on every wasm-pack release, and the version number in package.json will also need to be bumped on every release.

Fixes #321 
