### PR TITLE
fix(docs): fix broken link and typo for "Commands"

### DIFF
--- a/docs/src/commands/index.md
+++ b/docs/src/commands/index.md
@@ -3,14 +3,15 @@
 `wasm-pack` has several commands to help you during the process of building
 a Rust-generated WebAssembly project.
 
-- `new`: This command generates a new project for you using a template. [Learn more][generate]
+- `new`: This command generates a new project for you using a template. [Learn more][new]
 - `build`: This command builds a `pkg` directory for you with compiled wasm and generated JS. [Learn more][build]
-- `pack` and `publish`: These command will create a tarball, and optionally publish it to a registry, such as npm. [Learn more][pack-pub]
-
+- `pack` and `publish`: These commands will create a tarball, and optionally publish it to a registry, such as npm. [Learn more][pack-pub]
 
 ### Deprecated Commands
+
 - `init`: This command has been deprecated in favor of `build`.
 
+[new]: ./new.html
 [build]: ./build.html
 [new]: ./new.html
 [pack-pub]: ./pack-and-publish.html

--- a/docs/src/commands/index.md
+++ b/docs/src/commands/index.md
@@ -13,5 +13,4 @@ a Rust-generated WebAssembly project.
 
 [new]: ./new.html
 [build]: ./build.html
-[new]: ./new.html
 [pack-pub]: ./pack-and-publish.html

--- a/docs/src/commands/new.md
+++ b/docs/src/commands/new.md
@@ -40,8 +40,8 @@ The `wasm-pack new` command can be given an optional mode argument, e.g.:
 wasm-pack new myproject --mode noinstall
 ```
 
-The mode pass can be either "normal", "noinstall", or "force". "normal is passed by
-degault.
+The mode passed can be either "normal", "noinstall", or "force". "normal" is passed by
+default.
 
 `noinstall` means that wasm-pack should not attempt to install any underlying tools.
 If a necessary tool cannot be found, the command will error.


### PR DESCRIPTION
refs #755

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
