### PR TITLE
Bump binary-install version to fix Windows installs

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+const { install } = require("./binary");
+install();

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -19,11 +19,13 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "binary-install": {
-      "version": "github:EverlastingBugstopper/binary-install#422b936acee289853f791a463df52454179ded5a",
-      "from": "github:EverlastingBugstopper/binary-install#master",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.0.1.tgz",
+      "integrity": "sha512-axr6lqB4ec/pkEOb/JMnZpfcroWv1zT48pVz1oQHG7XmGkS77vmdxmP1btuH79lWQdy9e2MVw/uW0D8siopkRg==",
       "requires": {
         "axios": "^0.19.0",
         "env-paths": "^2.2.0",
+        "mkdirp": "^0.5.1",
         "rimraf": "^3.0.0",
         "tar": "^5.0.5",
         "universal-url": "^2.0.0"

--- a/npm/package.json
+++ b/npm/package.json
@@ -4,8 +4,8 @@
   "description": "📦✨ your favorite rust -> wasm workflow tool!",
   "main": "binary.js",
   "scripts": {
-    "postinstall": "node -e 'require(\"./binary.js\").install()'",
-    "preuninstall": "node -e 'require(\"./binary.js\").uninstall()'"
+    "postinstall": "node ./install.js",
+    "preuninstall": "node ./uninstall.js"
   },
   "bin": {
     "wasm-pack": "./run.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -30,6 +30,6 @@
   },
   "homepage": "https://github.com/rustwasm/wasm-pack#readme",
   "dependencies": {
-    "binary-install": "0.0.0"
+    "binary-install": "0.0.1"
   }
 }

--- a/npm/run.js
+++ b/npm/run.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 const { run } = require("./binary");
-run()
+run();

--- a/npm/uninstall.js
+++ b/npm/uninstall.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+const { uninstall } = require("./binary");
+uninstall();


### PR DESCRIPTION
Fixes #757 

Not sure how we'll actually release this given that our npm installer version number is tied to the version of wasm-pack. Might need to do a point release of wasm-pack that does nothing? Alternatively we can do a release of everything that's been merged to master since April, not sure if that's the direction we want to go though.

cc @ashleygwilliams 