### PR TITLE
Adds end to end test for building a generated project

### DIFF
--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -295,3 +295,17 @@ fn build_force() {
         .assert()
         .success();
 }
+
+#[test]
+fn build_from_new() {
+    let fixture = utils::fixture::not_a_crate();
+    let name = "generated-project";
+    fixture.wasm_pack().arg("new").arg(name).assert().success();
+    let project_location = fixture.path.join(&name);
+    fixture
+        .wasm_pack()
+        .arg("build")
+        .arg(&project_location)
+        .assert()
+        .success();
+}


### PR DESCRIPTION
This PR adds an end to end integration test that assures that a user can run successfully run the following commands:

```console
$ wasm-pack new my-project
$ cd my-project
$ wasm-pack build
```