### PR TITLE
Revert "0.9.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,5 @@
 # Changelog
 
-## ☁️  0.9.1
-
-- ### 🤕 Fixes
-
-  - **Bump binaryen to version_90 - [ashleygwilliams], [issue/781] [issue/782] [pull/687]**
-
-    Previously, wasm-pack was hardcoded to install and attempt to execute wasm-opt on every build
-    using binaryen version 78. This version had various issues on Unix/Linux and caused broken CI
-    builds for many folks (we're so sorry!).
-
-    This PR updates the binaryen version to 90, which should fix the issues folks were having. 
-
-    Long-term, we'd like to create an auto-updating mechanism so that we can install and use the
-    latest release of binaryen as we do for other binaries we orchestrate.
-
-    [ashleygwilliams]: https://github.com/ashleygwilliams
-    [pull/687]: https://github.com/rustwasm/wasm-pack/pull/687
-    [issue/782]: https://github.com/rustwasm/wasm-pack/issues/782
-    [issue/781]: https://github.com/rustwasm/wasm-pack/issues/781
-
-- ### 🛠️ Maintenance
-
-  - **Consolidate wasm-opt installation into existing binary install logic - [ashleygwilliams], [issue/685] [pull/687]**
-
-    [ashleygwilliams]: https://github.com/ashleygwilliams
-    [pull/687]: https://github.com/rustwasm/wasm-pack/pull/687
-    [issue/685]: https://github.com/rustwasm/wasm-pack/issues/685
-
 ## 🌥️ 0.9.0
 
 - ### ✨ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,7 +2063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-pack"
-version = "0.9.1"
+version = "0.9.0"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasm-pack"
 description = "📦✨ your favorite rust -> wasm workflow tool!"
-version = "0.9.1"
+version = "0.9.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 repository = "https://github.com/ashleygwilliams/wasm-pack.git"
 license = "MIT/Apache-2.0"

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,9 +42,9 @@
           <h2>📦✨ your favorite rust -> wasm workflow tool!</h2>
         </div>
         <div class="five columns" id="installer">
-          <a class="button button-primary" href="/wasm-pack/installer">✨ Install wasm-pack 0.9.1 ✨</a>
-          <p>7 Feb 2020 |
-            <a href="https://github.com/rustwasm/wasm-pack/releases/tag/v0.9.1">
+          <a class="button button-primary" href="/wasm-pack/installer">✨ Install wasm-pack 0.9.0 ✨</a>
+          <p>31 Jan 2020 |
+            <a href="https://github.com/rustwasm/wasm-pack/releases/tag/v0.9.0">
               Release Notes
             </a>
           </p>

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-pack",
-  "version": "0.9.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-pack",
-  "version": "0.9.1",
+  "version": "0.9.0",
   "description": "📦✨ your favorite rust -> wasm workflow tool!",
   "main": "binary.js",
   "scripts": {


### PR DESCRIPTION
Reverts rustwasm/wasm-pack#785

getting a local test failure on installing browser drivers. CI doesn't appear to catch it but have confirmed it on MacOS and windows.