### PR TITLE
Add --omit-imports flag

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -17,6 +17,7 @@ pub fn wasm_bindgen_build(
     out_dir: &Path,
     out_name: &Option<String>,
     disable_dts: bool,
+    omit_imports: bool,
     target: Target,
     profile: BuildProfile,
 ) -> Result<(), failure::Error> {
@@ -34,19 +35,21 @@ pub fn wasm_bindgen_build(
         .join(data.crate_name())
         .with_extension("wasm");
 
-    let dts_arg = if disable_dts {
-        "--no-typescript"
-    } else {
-        "--typescript"
-    };
     let bindgen_path = install::get_tool_path(install_status, Tool::WasmBindgen)?
         .binary(&Tool::WasmBindgen.to_string())?;
 
     let mut cmd = Command::new(&bindgen_path);
-    cmd.arg(&wasm_path)
-        .arg("--out-dir")
-        .arg(out_dir)
-        .arg(dts_arg);
+    cmd.arg(&wasm_path).arg("--out-dir").arg(out_dir);
+
+    if disable_dts {
+        cmd.arg("--no-typescript");
+    } else {
+        cmd.arg("--typescript");
+    };
+
+    if omit_imports {
+        cmd.arg("--omit-imports");
+    }
 
     let target_arg = build_target_arg(target, &bindgen_path)?;
     if supports_dash_dash_target(bindgen_path.to_path_buf())? {

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -27,6 +27,7 @@ pub struct Build {
     pub crate_data: manifest::CrateData,
     pub scope: Option<String>,
     pub disable_dts: bool,
+    pub omit_imports: bool,
     pub target: Target,
     pub profile: BuildProfile,
     pub mode: InstallMode,
@@ -119,6 +120,12 @@ pub struct BuildOptions {
     /// this flag will disable generating this TypeScript file.
     pub disable_dts: bool,
 
+    #[structopt(long = "omit-imports")]
+    /// When "module" is used in bindings to bring items into scope, the JS code
+    /// generator automatically creates corresponding import statements in the
+    /// output. This flag causes those import statements to be omitted.
+    pub omit_imports: bool,
+
     #[structopt(long = "target", short = "t", default_value = "bundler")]
     /// Sets the target environment. [possible values: bundler, nodejs, web, no-modules]
     pub target: Target,
@@ -160,6 +167,7 @@ impl Default for BuildOptions {
             scope: None,
             mode: InstallMode::default(),
             disable_dts: false,
+            omit_imports: false,
             target: Target::default(),
             debug: false,
             dev: false,
@@ -196,6 +204,7 @@ impl Build {
             crate_data,
             scope: build_opts.scope,
             disable_dts: build_opts.disable_dts,
+            omit_imports: build_opts.omit_imports,
             target: build_opts.target,
             profile,
             mode: build_opts.mode,
@@ -370,6 +379,7 @@ impl Build {
             &self.out_dir,
             &self.out_name,
             self.disable_dts,
+            self.omit_imports,
             self.target,
             self.profile,
         )?;


### PR DESCRIPTION
This PR adds an `--omit-imports` flag corresponding to the `wasm-bindgen-cli` flag added upstream in https://github.com/rustwasm/wasm-bindgen/pull/1958.

This flag is useful for some scenarios where imports must be controlled through separate preloads scripts where items are brought into the application scope by modifying `global` or `window` directly, instead of through the usual `import` or `require` mechanisms.

Examples of using this flag can be found in the `omit-imports` branch of [electron-sys](https://github.com/interfaces-rs/electron-sys/tree/omit-imports). See the [activity-monitor](https://github.com/interfaces-rs/electron-sys/tree/omit-imports/examples/activity-monitor) example (with [package.json](https://github.com/interfaces-rs/electron-sys/blob/10f467bae189a35c15e9206d42dfa952e697fb35/examples/activity-monitor/package.json#L9) and [preload.js](https://github.com/interfaces-rs/electron-sys/blob/omit-imports/examples/activity-monitor/preload.js)) and [hash](https://github.com/interfaces-rs/electron-sys/tree/omit-imports/examples/hash) example with (with [package.json](https://github.com/interfaces-rs/electron-sys/blob/10f467bae189a35c15e9206d42dfa952e697fb35/examples/hash/package.json#L9) and [preload.js](https://github.com/interfaces-rs/electron-sys/blob/omit-imports/examples/hash/preload.js)).