### PR TITLE
Export the Binary from npm module

### DIFF
--- a/npm/binary.js
+++ b/npm/binary.js
@@ -28,23 +28,4 @@ const getBinary = () => {
   return new Binary(url, { name });
 };
 
-const run = () => {
-  const binary = getBinary();
-  binary.run();
-};
-
-const install = () => {
-  const binary = getBinary();
-  binary.install();
-};
-
-const uninstall = () => {
-  const binary = getBinary();
-  binary.uninstall();
-};
-
-module.exports = {
-  install,
-  run,
-  uninstall
-};
+module.exports = getBinary();


### PR DESCRIPTION
This is not done as an optimization, but to intentionally leak other things about `Binary`.
For example, it enables me to do a cheeky
```js
child_process.spawn(require('wasm-pack')._getBinaryPath(), args)
```
in a consuming module, without spawning an extra node process.
This allows spawning the binary in a transient dependency, something that was rather awkward before: https://github.com/wasm-tool/rollup-plugin-rust/commit/9027e61e6426c2cae59f6eb7b71449efb07fca7c

An alternative  would be to export it manually, as `getBinaryPath` (no underscore) or something, but  whichever can be maintained if the implementation switches from `binary-installer` or if `binary-installer` changes this "private" method.