### PR TITLE
Added keywords (#707)

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -390,7 +390,8 @@ struct NpmData {
     files: Vec<String>,
     dts_file: Option<String>,
     main: String,
-    homepage: Option<String>, // https://docs.npmjs.com/files/package.json#homepage
+    homepage: Option<String>, // https://docs.npmjs.com/files/package.json#homepage,
+    keywords: Option<Vec<String>>, // https://docs.npmjs.com/files/package.json#keywords
 }
 
 #[doc(hidden)]
@@ -607,6 +608,12 @@ impl CrateData {
             None
         };
 
+        let keywords = if pkg.keywords.len() > 0 {
+            Some(pkg.keywords.clone())
+        } else {
+            None
+        };
+
         if let Ok(entries) = fs::read_dir(out_dir) {
             let file_names = entries
                 .filter_map(|e| e.ok())
@@ -625,6 +632,7 @@ impl CrateData {
             files,
             main: js_file,
             homepage: self.manifest.package.homepage.clone(),
+            keywords: keywords,
         }
     }
 
@@ -662,6 +670,7 @@ impl CrateData {
             main: data.main,
             homepage: data.homepage,
             types: data.dts_file,
+            keywords: data.keywords,
         })
     }
 
@@ -696,6 +705,7 @@ impl CrateData {
             homepage: data.homepage,
             types: data.dts_file,
             side_effects: false,
+            keywords: data.keywords,
         })
     }
 
@@ -725,6 +735,7 @@ impl CrateData {
             homepage: data.homepage,
             types: data.dts_file,
             side_effects: false,
+            keywords: data.keywords,
         })
     }
 
@@ -758,6 +769,7 @@ impl CrateData {
             browser: data.main,
             homepage: data.homepage,
             types: data.dts_file,
+            keywords: data.keywords,
         })
     }
 

--- a/src/manifest/npm/commonjs.rs
+++ b/src/manifest/npm/commonjs.rs
@@ -19,4 +19,6 @@ pub struct CommonJSPackage {
     pub homepage: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub types: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keywords: Option<Vec<String>>,
 }

--- a/src/manifest/npm/esmodules.rs
+++ b/src/manifest/npm/esmodules.rs
@@ -21,4 +21,6 @@ pub struct ESModulesPackage {
     pub types: Option<String>,
     #[serde(rename = "sideEffects")]
     pub side_effects: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keywords: Option<Vec<String>>,
 }

--- a/src/manifest/npm/nomodules.rs
+++ b/src/manifest/npm/nomodules.rs
@@ -19,4 +19,6 @@ pub struct NoModulesPackage {
     pub homepage: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub types: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keywords: Option<Vec<String>>,
 }

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -370,6 +370,63 @@ fn it_sets_homepage_field_if_available_in_cargo_toml() {
 }
 
 #[test]
+fn it_sets_keywords_field_if_available_in_cargo_toml() {
+    // When 'homepage' is available
+    let fixture = utils::fixture::Fixture::new();
+    fixture.hello_world_src_lib().file(
+        "Cargo.toml",
+        r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "homepage-field-test"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+            keywords = ["wasm"]
+
+            [lib]
+            crate-type = ["cdylib"]
+
+            [dependencies]
+            wasm-bindgen = "=0.2"
+
+            [dev-dependencies]
+            wasm-bindgen-test = "=0.2"
+        "#,
+    );
+
+    let out_dir = fixture.path.join("pkg");
+    let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
+
+    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    crate_data
+        .write_package_json(&out_dir, &None, true, Target::Bundler)
+        .unwrap();
+
+    let pkg = utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
+    let keywords = pkg.keywords.clone().unwrap();
+    assert!(
+        keywords.contains(&"wasm".to_string()),
+        "keywords is not in files: {:?}",
+        keywords,
+    );
+
+    // When 'keywords' is unavailable
+    let fixture = fixture::js_hello_world();
+    let out_dir = fixture.path.join("pkg");
+    let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
+
+    wasm_pack::command::utils::create_pkg_dir(&out_dir).unwrap();
+    crate_data
+        .write_package_json(&out_dir, &None, true, Target::Bundler)
+        .unwrap();
+
+    let pkg = utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
+    assert_eq!(pkg.keywords, None);
+}
+
+#[test]
 fn it_does_not_error_when_wasm_bindgen_is_declared() {
     let fixture = fixture::js_hello_world();
     // Ensure that there is a `Cargo.lock`.

--- a/tests/all/utils/manifest.rs
+++ b/tests/all/utils/manifest.rs
@@ -24,6 +24,7 @@ pub struct NpmPackage {
     #[serde(default = "default_false", rename = "sideEffects")]
     pub side_effects: bool,
     pub homepage: Option<String>,
+    pub keywords: Option<Vec<String>>,
 }
 
 fn default_none() -> String {


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

Closes #707 

package.json files usually contain a `keywords` array so that npm can make searching easier. Currently the keywords from the Cargo.toml are not exported to the package.json, meaning they have to be done manually before a package is published to npm, or be difficult to find on npm.

This is my first edit, so please let me know if I have made some junior mistakes
