### PR TITLE
Corrected files included in package.json for bundler / no target (#837)

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -578,7 +578,7 @@ impl CrateData {
     fn npm_data(
         &self,
         scope: &Option<String>,
-        include_commonjs_shim: bool,
+        add_js_bg_to_package_json: bool,
         disable_dts: bool,
         out_dir: &Path,
     ) -> NpmData {
@@ -588,10 +588,10 @@ impl CrateData {
         let mut files = vec![wasm_file];
 
         files.push(js_file.clone());
-        // if include_commonjs_shim {
+        if add_js_bg_to_package_json {
             let js_bg_file = format!("{}_bg.js", name_prefix);
             files.push(js_bg_file);
-        // }
+        }
 
         let pkg = &self.data.packages[self.current_idx];
         let npm_name = match scope {
@@ -671,7 +671,7 @@ impl CrateData {
         disable_dts: bool,
         out_dir: &Path,
     ) -> NpmPackage {
-        let data = self.npm_data(scope, false, disable_dts, out_dir);
+        let data = self.npm_data(scope, true, disable_dts, out_dir);
         let pkg = &self.data.packages[self.current_idx];
 
         self.check_optional_fields();

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -588,10 +588,10 @@ impl CrateData {
         let mut files = vec![wasm_file];
 
         files.push(js_file.clone());
-        if include_commonjs_shim {
+        // if include_commonjs_shim {
             let js_bg_file = format!("{}_bg.js", name_prefix);
             files.push(js_bg_file);
-        }
+        // }
 
         let pkg = &self.data.packages[self.current_idx];
         let npm_name = match scope {
@@ -734,7 +734,7 @@ impl CrateData {
         disable_dts: bool,
         out_dir: &Path,
     ) -> NpmPackage {
-        let data = self.npm_data(scope, false, disable_dts, out_dir);
+        let data = self.npm_data(scope, true, disable_dts, out_dir);
         let pkg = &self.data.packages[self.current_idx];
 
         self.check_optional_fields();

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -646,7 +646,7 @@ impl CrateData {
     }
 
     fn to_commonjs(&self, scope: &Option<String>, disable_dts: bool, out_dir: &Path) -> NpmPackage {
-        let data = self.npm_data(scope, true, disable_dts, out_dir);
+        let data = self.npm_data(scope, false, disable_dts, out_dir);
         let pkg = &self.data.packages[self.current_idx];
 
         self.check_optional_fields();
@@ -745,7 +745,7 @@ impl CrateData {
         disable_dts: bool,
         out_dir: &Path,
     ) -> NpmPackage {
-        let data = self.npm_data(scope, true, disable_dts, out_dir);
+        let data = self.npm_data(scope, false, disable_dts, out_dir);
         let pkg = &self.data.packages[self.current_idx];
 
         self.check_optional_fields();

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -260,10 +260,11 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     assert_eq!(pkg.side_effects, false);
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["index_bg.wasm", "index_bg.js", "index.d.ts", "index.js"]
-        .iter()
-        .map(|&s| String::from(s))
-        .collect();
+    let expected_files: HashSet<String> =
+        ["index_bg.wasm", "index_bg.js", "index.d.ts", "index.js"]
+            .iter()
+            .map(|&s| String::from(s))
+            .collect();
     assert_eq!(actual_files, expected_files);
 }
 
@@ -304,10 +305,14 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
     assert_eq!(pkg.module, "js_hello_world.js");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["js_hello_world_bg.wasm", "js_hello_world_bg.js", "js_hello_world.js"]
-        .iter()
-        .map(|&s| String::from(s))
-        .collect();
+    let expected_files: HashSet<String> = [
+        "js_hello_world_bg.wasm",
+        "js_hello_world_bg.js",
+        "js_hello_world.js",
+    ]
+    .iter()
+    .map(|&s| String::from(s))
+    .collect();
     assert_eq!(actual_files, expected_files);
 }
 

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -191,7 +191,6 @@ fn it_creates_a_pkg_json_with_correct_files_on_node() {
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
         "js_hello_world_bg.wasm",
-        "js_hello_world_bg.js",
         "js_hello_world.d.ts",
         "js_hello_world.js",
     ]
@@ -226,7 +225,6 @@ fn it_creates_a_pkg_json_with_correct_files_on_nomodules() {
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
         "js_hello_world.d.ts",
-        "js_hello_world_bg.js",
         "js_hello_world_bg.wasm",
         "js_hello_world.js",
     ]

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -97,8 +97,9 @@ fn it_creates_a_package_json_default_path() {
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
-        "js_hello_world_bg.wasm",
         "js_hello_world.d.ts",
+        "js_hello_world_bg.js",
+        "js_hello_world_bg.wasm",
         "js_hello_world.js",
     ]
     .iter()
@@ -125,8 +126,9 @@ fn it_creates_a_package_json_provided_path() {
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
-        "js_hello_world_bg.wasm",
         "js_hello_world.d.ts",
+        "js_hello_world_bg.js",
+        "js_hello_world_bg.wasm",
         "js_hello_world.js",
     ]
     .iter()
@@ -153,8 +155,9 @@ fn it_creates_a_package_json_provided_path_with_scope() {
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
-        "js_hello_world_bg.wasm",
         "js_hello_world.d.ts",
+        "js_hello_world_bg.js",
+        "js_hello_world_bg.wasm",
         "js_hello_world.js",
     ]
     .iter()
@@ -222,9 +225,10 @@ fn it_creates_a_pkg_json_with_correct_files_on_nomodules() {
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
+        "js_hello_world.d.ts",
+        "js_hello_world_bg.js",
         "js_hello_world_bg.wasm",
         "js_hello_world.js",
-        "js_hello_world.d.ts",
     ]
     .iter()
     .map(|&s| String::from(s))
@@ -256,7 +260,7 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     assert_eq!(pkg.side_effects, false);
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["index_bg.wasm", "index.d.ts", "index.js"]
+    let expected_files: HashSet<String> = ["index_bg.wasm", "index_bg.js", "index.d.ts", "index.js"]
         .iter()
         .map(|&s| String::from(s))
         .collect();
@@ -300,7 +304,7 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
     assert_eq!(pkg.module, "js_hello_world.js");
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> = ["js_hello_world_bg.wasm", "js_hello_world.js"]
+    let expected_files: HashSet<String> = ["js_hello_world_bg.wasm", "js_hello_world_bg.js", "js_hello_world.js"]
         .iter()
         .map(|&s| String::from(s))
         .collect();


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

Closes #837

`wasm-pack build` and `wasm-pack build --target bundler` generate a _bg.js file, but it is not added to the package.json. The file that is added, *.js will however reference the _bg.js, so when the package is distributed (both through `pack` or `publish`) it is not usable.

This change will fix that by passing the correct bool value to npm_data

As is the same for my other PR, there is some test failure that I locally also have on the master branch. Please let me know how to address this if possible