### PR TITLE
docs: Remove greenkeeper reference from readme, as it is being retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ This tool seeks to be a one-stop shop for building and working with rust-
 generated WebAssembly that you would like to interop with JavaScript, in the
 browser or with Node.js. `wasm-pack` helps you build rust-generated
 WebAssembly packages that you could publish to the npm registry, or otherwise use
-alongside any javascript packages in workflows that you already use, such as [webpack]
-or [greenkeeper].
+alongside any javascript packages in workflows that you already use, such as [webpack].
 
 [bundler-support]: https://github.com/rustwasm/team/blob/master/goals/bundler-integration.md#details
 [webpack]: https://webpack.js.org/
-[greenkeeper]: https://greenkeeper.io/
 
 This project is a part of the [rust-wasm] group. You can find more info by
 visiting that repo!


### PR DESCRIPTION
This is a very small change to the README, not an actual issue (not a bug or feature request) so I am not sure about how to handle it. In the [contributing guidelines](https://github.com/rustwasm/wasm-pack/blob/master/CONTRIBUTING.md) I could not find instructions. Maybe it would be a good addition (under docs category)?

Anyway, while checking the repository, I noticed you reference greenkeeper in the README, but it is going to be taken down in less than a month, so I think it is better to avoid stale links.