### PR TITLE
specifically check the crate-type of the specified Cargo target when building

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -19,6 +19,7 @@ pub fn wasm_bindgen_build(
     disable_dts: bool,
     target: Target,
     profile: BuildProfile,
+    artifact_name: &Path,
 ) -> Result<(), failure::Error> {
     let release_or_debug = match profile {
         BuildProfile::Release | BuildProfile::Profiling => "release",
@@ -31,7 +32,7 @@ pub fn wasm_bindgen_build(
         .target_directory()
         .join("wasm32-unknown-unknown")
         .join(release_or_debug)
-        .join(data.crate_name())
+        .join(artifact_name)
         .with_extension("wasm");
 
     let dts_arg = if disable_dts {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,7 +1,7 @@
 //! Building a Rust crate into a `.wasm` binary.
 
 use child;
-use command::build::BuildProfile;
+use command::build::{BuildProfile, CargoTarget};
 use emoji;
 use failure::{Error, ResultExt};
 use manifest::Crate;
@@ -76,13 +76,14 @@ fn wasm_pack_local_version() -> Option<String> {
 pub fn cargo_build_wasm(
     path: &Path,
     profile: BuildProfile,
+    target: &CargoTarget,
     extra_options: &[String],
 ) -> Result<(), Error> {
     let msg = format!("{}Compiling to Wasm...", emoji::CYCLONE);
     PBAR.info(&msg);
 
     let mut cmd = Command::new("cargo");
-    cmd.current_dir(path).arg("build").arg("--lib");
+    cmd.current_dir(path).arg("build").args(target.as_args());
 
     if PBAR.quiet() {
         cmd.arg("--quiet");

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -121,7 +121,7 @@ pub enum CargoTarget {
 impl CargoTarget {
     pub(crate) fn matches(&self, target: &cargo_metadata::Target) -> bool {
         match self {
-            Self::Library => target.kind.iter().any(|k| k == "lib"),
+            Self::Library => target.kind.iter().any(|k| k.ends_with("lib")),
             Self::Binary(b) => target.kind.iter().any(|k| k == "bin") && &target.name == b,
             Self::Example(e) => target.kind.iter().any(|k| k == "example") && &target.name == e,
             Self::Test(t) => target.kind.iter().any(|k| k == "test") && &target.name == t,

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -514,6 +514,15 @@ impl Build {
 
     fn step_run_wasm_bindgen(&mut self) -> Result<(), Error> {
         info!("Building the wasm bindings...");
+
+        let artifact_name = match &self.cargo_target {
+            CargoTarget::Library => self.crate_data.crate_name().into(),
+            CargoTarget::Binary(b) => b.into(),
+            CargoTarget::Example(e) => PathBuf::from("examples").join(e),
+            CargoTarget::Test(t) => t.into(),
+            CargoTarget::Benchmark(b) => b.into(),
+        };
+
         bindgen::wasm_bindgen_build(
             &self.crate_data,
             &self.bindgen.as_ref().unwrap(),
@@ -522,6 +531,7 @@ impl Build {
             self.disable_dts,
             self.target,
             self.profile,
+            &artifact_name,
         )?;
         info!("wasm bindings were built at {:#?}.", &self.out_dir);
         Ok(())

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -497,19 +497,19 @@ impl CrateData {
     fn check_crate_type(&self, target: &CargoTarget) -> Result<(), Error> {
         let pkg = &self.data.packages[self.current_idx];
 
-        if let Some(selected_target) = pkg.targets.iter().find(|t| target.matches(t)) {
-            if !selected_target.crate_types.iter().any(|c| c == "cdylib") {
-                bail!(
-                    "crate-type must be cdylib to compile to wasm32-unknown-unknown. \
-                    Add the following to your Cargo.toml file:\n\n\
-                    {}\n\
-                    crate-type = [\"cdylib\", \"rlib\"]",
-                    target.as_manifest()
-                )
+        for selected_target in pkg.targets.iter().filter(|t| target.matches(t)) {
+            if selected_target.crate_types.iter().any(|c| c == "cdylib") {
+                return Ok(());
             }
         }
 
-        Ok(())
+        bail!(
+            "crate-type must be cdylib to compile to wasm32-unknown-unknown. \
+            Add the following to your Cargo.toml file:\n\n\
+            {}\n\
+            crate-type = [\"cdylib\", \"rlib\"]",
+            target.as_manifest()
+        )
     }
 
     /// Get the crate name for the crate at the given path.

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -50,7 +50,7 @@ fn it_checks_has_cdylib_default_path() {
 }
 
 #[test]
-fn it_checks_specified_target_has_cdylib_default_path() {
+fn it_checks_example_target_has_cdylib_fail() {
     let fixture = fixture::cdylib_on_wrong_target();
     // Ensure that there is a `Cargo.lock`.
     fixture.cargo_check();
@@ -58,6 +58,17 @@ fn it_checks_specified_target_has_cdylib_default_path() {
     assert!(crate_data
         .check_crate_config(&CargoTarget::Example("my-example".into()))
         .is_err());
+}
+
+#[test]
+fn it_checks_example_target_has_cdylib_success() {
+    let fixture = fixture::cdylib_on_correct_example_target();
+    // Ensure that there is a `Cargo.lock`.
+    fixture.cargo_check();
+    let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
+    assert!(crate_data
+        .check_crate_config(&CargoTarget::Example("my-example".into()))
+        .is_ok());
 }
 
 #[test]

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use utils::{self, fixture};
-use wasm_pack::command::build::Target;
+use wasm_pack::command::build::{CargoTarget, Target};
 use wasm_pack::command::utils::get_crate_path;
 use wasm_pack::{self, license, manifest};
 
@@ -44,7 +44,20 @@ fn it_checks_has_cdylib_default_path() {
     // Ensure that there is a `Cargo.lock`.
     fixture.cargo_check();
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    assert!(crate_data.check_crate_config().is_err());
+    assert!(crate_data
+        .check_crate_config(&CargoTarget::Library)
+        .is_err());
+}
+
+#[test]
+fn it_checks_specified_target_has_cdylib_default_path() {
+    let fixture = fixture::cdylib_on_wrong_target();
+    // Ensure that there is a `Cargo.lock`.
+    fixture.cargo_check();
+    let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
+    assert!(crate_data
+        .check_crate_config(&CargoTarget::Example("my-example".into()))
+        .is_err());
 }
 
 #[test]
@@ -53,14 +66,18 @@ fn it_checks_has_cdylib_provided_path() {
     // Ensure that there is a `Cargo.lock`.
     fixture.cargo_check();
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    crate_data.check_crate_config().unwrap();
+    crate_data
+        .check_crate_config(&CargoTarget::Library)
+        .unwrap();
 }
 
 #[test]
 fn it_checks_has_cdylib_wrong_crate_type() {
     let fixture = fixture::bad_cargo_toml();
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    assert!(crate_data.check_crate_config().is_err());
+    assert!(crate_data
+        .check_crate_config(&CargoTarget::Library)
+        .is_err());
 }
 
 #[test]
@@ -69,7 +86,9 @@ fn it_recognizes_a_map_during_depcheck() {
     // Ensure that there is a `Cargo.lock`.
     fixture.cargo_check();
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    crate_data.check_crate_config().unwrap();
+    crate_data
+        .check_crate_config(&CargoTarget::Library)
+        .unwrap();
 }
 
 #[test]
@@ -318,7 +337,9 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
 fn it_errors_when_wasm_bindgen_is_not_declared() {
     let fixture = fixture::bad_cargo_toml();
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    assert!(crate_data.check_crate_config().is_err());
+    assert!(crate_data
+        .check_crate_config(&CargoTarget::Library)
+        .is_err());
 }
 
 #[test]
@@ -439,7 +460,9 @@ fn it_does_not_error_when_wasm_bindgen_is_declared() {
     // Ensure that there is a `Cargo.lock`.
     fixture.cargo_check();
     let crate_data = manifest::CrateData::new(&fixture.path, None).unwrap();
-    crate_data.check_crate_config().unwrap();
+    crate_data
+        .check_crate_config(&CargoTarget::Library)
+        .unwrap();
 }
 
 #[test]

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -210,6 +210,26 @@ impl Fixture {
         )
     }
 
+    pub fn example_src_lib(&self, name: &str) -> &Self {
+        self.file(
+            "examples/my-example.rs",
+            &format!(
+                r#"
+                extern crate wasm_bindgen;
+                use wasm_bindgen::prelude::*;
+
+                use {}::greet;
+
+                #[wasm_bindgen]
+                pub fn greet_ferris() {{
+                    greet("ferris");
+                }}
+                "#,
+                name
+            ),
+        )
+    }
+
     /// Install a local wasm-bindgen for this fixture.
     ///
     /// Takes care not to re-install for every fixture, but only the one time
@@ -425,9 +445,13 @@ pub fn no_cdylib() -> Fixture {
 
 pub fn cdylib_on_wrong_target() -> Fixture {
     let fixture = Fixture::new();
-    fixture.readme().hello_world_src_lib().file(
-        "Cargo.toml",
-        r#"
+    fixture
+        .readme()
+        .hello_world_src_lib()
+        .example_src_lib("foo")
+        .file(
+            "Cargo.toml",
+            r#"
             [package]
             authors = ["The wasm-pack developers"]
             description = "so awesome rust+wasm package"
@@ -449,7 +473,41 @@ pub fn cdylib_on_wrong_target() -> Fixture {
             [dev-dependencies]
             wasm-bindgen-test = "0.2"
         "#,
-    );
+        );
+    fixture
+}
+
+pub fn cdylib_on_correct_example_target() -> Fixture {
+    let fixture = Fixture::new();
+    fixture
+        .readme()
+        .hello_world_src_lib()
+        .example_src_lib("foo")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "foo"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["lib"]
+
+            [[example]]
+            name = "my-example"
+            crate-type = ["cdylib"]
+
+            [dependencies]
+            wasm-bindgen = "0.2"
+
+            [dev-dependencies]
+            wasm-bindgen-test = "0.2"
+        "#,
+        );
     fixture
 }
 

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -423,6 +423,36 @@ pub fn no_cdylib() -> Fixture {
     fixture
 }
 
+pub fn cdylib_on_wrong_target() -> Fixture {
+    let fixture = Fixture::new();
+    fixture.readme().hello_world_src_lib().file(
+        "Cargo.toml",
+        r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "foo"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["cdylib"]
+
+            [[example]]
+            name = "my-example"
+            crate-type = ["lib"]
+
+            [dependencies]
+            wasm-bindgen = "0.2"
+
+            [dev-dependencies]
+            wasm-bindgen-test = "0.2"
+        "#,
+    );
+    fixture
+}
+
 pub fn not_a_crate() -> Fixture {
     let fixture = Fixture::new();
     fixture.file("README.md", "This is not a Rust crate!");


### PR DESCRIPTION
fixes #848

Please let me know if you can think of a more concise way to achieve this (specifically WRT the `TryFrom` implementation). Aside from that, I think this is fairly straightforward.

### Notes

- The rationale for only touching the `build` subcommand here is that no such check is performed when executing the `test` subcommand.
- All possible Cargo target types are accounted for here, but [on further inspection it looks like](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field) only `lib` and `example` are able to be compiled as any `crate-type` other than `bin`. Does that mean we can/should remove references to the other three types, or should we leave them in for possible future development?