### PR TITLE
Bump cargo_metadata to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://rustwasm.github.io/wasm-pack/"
 
 [dependencies]
 atty = "0.2.11"
-cargo_metadata = "0.8.0"
+cargo_metadata = "0.9.1"
 console = "0.6.1"
 dialoguer = "0.3.0"
 curl = "0.4.13"


### PR DESCRIPTION
Bumping the cargo_metadata dependency to version `0.9.1` (or even up to `0.10.0`) fixes issue #803. This is related to this pull request as well #804, but is smaller in scope.

All below boxes are checked, but I just bumped a dependency version.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
