### PR TITLE
Control wasm-opt via environment variable

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -141,3 +141,16 @@ wasm-pack build examples/js-hello-world --mode no-install -- --offline
 <sup id="footnote-0">0</sup> If you need to include additional assets in the pkg
 directory and your NPM package, we intend to have a solution for your use case
 soon. [↩](#wasm-pack-build)
+
+## Environment Variables read by `wasm-pack build`
+
+> WARNING! Configuration via environment variables is new in wasm-pack so expect some churn as the right patterns are
+> discovered.
+
+You can override these environment variables to change `wasm-pack` build's behavior.
+
+Environment variables take precedence over `Cargo.toml` configuration.
+
+For example, if `WASM_PACK_WASM_OPT=false` is set as an environment variable, wasm-opt will not run under any circumstance.
+
+- `WASM_PACK_WASM_OPT` -- Enable/disable whether wasm-opt will be used to optimize the .wasm binary. Can be `true` or `false`.


### PR DESCRIPTION
I'm working on a WebAssembly application that I have to build in different ways in different situations.

Because of this, needing to configure things via `Cargo.toml` would mean that I'd need to either:

1. Manually flip settings when I needed to build slightly differently in a different scenario.
2. Write code to generate `Cargo.toml` files with the settings that I need.

---

For my own use case, configuring via an environment variable is simpler than both of the above `Cargo.toml` based options.

This was discussed briefly in https://github.com/rustwasm/wasm-pack/pull/805#issuecomment-633622479 and _seems_ to have some support from the maintainers.

In this PR I only introduce one environment variable in an attempt to scratch an immediate itch (a case where I want to prevent debug info from being stripped from my release builds).

As such, I'd imagine that the future of environment variables would look different than this first stab.

For example, `WASM_PACK_WASM_OPT=true wasm-pack build` works but `WASM_PACK_WASM_OPT=on wasm-pack build` does not.

Contrast this with `cargo`'s acceptable boolean values.

```
$ RUSTFLAGS="-C lto=oijefoijw" cargo build
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names -C lto=oijefoijw --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit code: 1)
--- stderr
error: incorrect value `oijefoijw` for codegen option `lto` - either a boolean (`yes`, `no`, `on`, `off`, etc), `thin`, `fat`, or omitted was expected
```

Whether or not that is desirable is a separate discussion (I personally don't mind only accepting true/false, for example). My main point is that there are discussions/decisions like that that I'd imagine should/would happen at some point.

To respect that process - I added some documentation that mentions that environment variables are young and unstable at this time.

Let me know if there's anything to improve about this PR!

## Example Usage

```
WASM_PACK_WASM_OPT=false wasm-pack build --release
WASM_PACK_WASM_OPT=true wasm-pack build --dev
```