### PR TITLE
Fix ignored wasm-opt version param

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -206,7 +206,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
         Tool::WasmOpt => {
             Ok(format!(
         "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_90",
+        vers = version,
         target = target,
             ))
         }

--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -58,7 +58,7 @@ pub fn find_wasm_opt(
     cache: &Cache,
     install_permitted: bool,
 ) -> Result<install::Status, failure::Error> {
-    let version = "version_78";
+    let version = "version_90";
     Ok(install::download_prebuilt(
         &install::Tool::WasmOpt,
         cache,


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ ] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [ ] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
