### PR TITLE
feat: added possibility to add a version for gecko driver to install

### DIFF
--- a/src/test/webdriver/geckodriver.rs
+++ b/src/test/webdriver/geckodriver.rs
@@ -4,6 +4,7 @@ use chrono::DateTime;
 use failure::{self, ResultExt};
 use install::InstallMode;
 use stamps;
+use std::env::VarError;
 use std::path::PathBuf;
 use target;
 
@@ -88,13 +89,21 @@ fn get_geckodriver_url(target: &str, ext: &str) -> String {
             .and_then(get_version_from_json)
             .and_then(save_geckodriver_version)
     };
-
+    let specified_geckodriver_version: Result<String, VarError> =
+        std::env::var("SPECIFIED_GECKO_DRIVER_VERSION");
     let geckodriver_version = if target::WINDOWS {
         log::info!(
             "[geckodriver] Windows detected, holding geckodriver version to {}",
             DEFAULT_WINDOWS_GECKODRIVER_VERSION
         );
         DEFAULT_WINDOWS_GECKODRIVER_VERSION.to_owned()
+    } else if specified_geckodriver_version.is_ok() {
+        let version = specified_geckodriver_version.unwrap();
+        log::info!(
+            "[geckodriver] Looking up specified version of geckodriver : {}",
+            version
+        );
+        version
     } else {
         log::info!("[geckodriver] Looking up latest version of geckodriver...");
         match stamps::read_stamps_file_to_json() {

--- a/tests/all/webdriver.rs
+++ b/tests/all/webdriver.rs
@@ -28,3 +28,19 @@ fn can_install_geckodriver() {
     let cache = Cache::at(&fixture.path);
     assert!(webdriver::install_geckodriver(&cache, true).is_ok());
 }
+
+#[test]
+#[cfg(any(
+    all(target_os = "linux", target_arch = "x86"),
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "macos", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86"),
+    all(target_os = "windows", target_arch = "x86_64")
+))]
+fn can_install_geckodriver_with_specified_version() {
+    std::env::set_var("SPECIFIED_GECKO_DRIVER_VERSION", "0.25");
+    let fixture = fixture::js_hello_world();
+    let cache = Cache::at(&fixture.path);
+
+    assert!(webdriver::install_geckodriver(&cache, true).is_ok());
+}


### PR DESCRIPTION
Hello guys !!! 

I checked! 📦✅

- [x] I have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt 
->  info: component 'rustfmt' for target 'x86_64-unknown-linux-gnu' is up to date

```
- [x] I ran `cargo fmt` on the code base before submitting 
- [x] I reference which issue is being closed in the PR text
->  https://github.com/rustwasm/wasm-bindgen/issues/2261#issuecomment-670961373


Since the 27th of July there is a bug with headless mode for firefox on the latest **geckodriver**.
So, it could be nice to give us the opportunity to choose which version we want to install.

This PR is draft, because I am not pro and maybe we can find a good solution together 😄

My first reflex is that we could use environment variable to do that, but maybe we can use `feature` or something else.

Thank you for your inputs.

By the way, the test I made is failing, and even with debugging in my IDE, I do not know where it is failing. Can somebody give me a hand on this ? 

✨ Thank you for your inputs ✨

Issue : https://github.com/rustwasm/wasm-bindgen/issues/2261#issuecomment-670961373
