### PR TITLE
Update docs for the Rust-generated wasm function

### DIFF
--- a/docs/src/tutorials/hybrid-applications-with-webpack/using-your-library.md
+++ b/docs/src/tutorials/hybrid-applications-with-webpack/using-your-library.md
@@ -55,13 +55,15 @@ pub fn run() -> Result<(), JsValue> {
 }
 ```
 
-Now, open up the `js/index.js` file. We see our Rust-generated wasm `run` function being
+Now, open up the `js/index.js` file. We see our Rust-generated wasm `main_js` function being
 called inside our JS file.
 
 ```js
-import("../crate/pkg").then(module => {
-  module.run();
-});
+import("../pkg/index.js")
+  .then((module) => {
+    module.main_js();
+  })
+  .catch(console.error);
 ```
 
 ## Run The Project


### PR DESCRIPTION
The documentation is out of date. It says that there should be a `run()` function, but really a `main_js()` function should be there.
However, the `rust-webpack-template` doesn't add the `then()` statement to the import in the template.
I have created [a pull request](https://github.com/rustwasm/rust-webpack-template/pull/172) to add this to the template, and I have updated the docs for this newer version here.