### PR TITLE
Support --target-dir as extra-option in build cmd

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -12,6 +12,7 @@ use std::process::Command;
 /// Run the `wasm-bindgen` CLI to generate bindings for the current crate's
 /// `.wasm`.
 pub fn wasm_bindgen_build(
+    target_dir: &Path,
     data: &CrateData,
     install_status: &install::Status,
     out_dir: &Path,
@@ -27,8 +28,7 @@ pub fn wasm_bindgen_build(
 
     let out_dir = out_dir.to_str().unwrap();
 
-    let wasm_path = data
-        .target_directory()
+    let wasm_path = target_dir
         .join("wasm32-unknown-unknown")
         .join(release_or_debug)
         .join(data.crate_name())

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -364,7 +364,19 @@ impl Build {
 
     fn step_run_wasm_bindgen(&mut self) -> Result<(), Error> {
         info!("Building the wasm bindings...");
+        let target_dir = self
+            .extra_options
+            .iter()
+            .position(|x| *x == "--target-dir")
+            .and_then(|pos| self.extra_options.iter().nth(pos + 1));
+        let target_dir = if let Some(d) = target_dir {
+            self.crate_data.workspace_root().join(d)
+        } else {
+            self.crate_data.target_directory().to_path_buf()
+        };
+        log::debug!("Use target directory {}", target_dir.display());
         bindgen::wasm_bindgen_build(
+            &target_dir,
             &self.crate_data,
             &self.bindgen.as_ref().unwrap(),
             &self.out_dir,


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
