### PR TITLE
bump: wasm_opt, chromedriver & geckodriver version

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -165,7 +165,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
     let target = if target::LINUX && target::x86_64 {
         match tool {
             Tool::WasmOpt => "x86_64-linux",
-            _ => "x86_64-unknown-linux-musl",
+            _ => bail!("Unrecognized target!"),
         }
     } else if target::LINUX && target::x86 {
         match tool {
@@ -173,11 +173,11 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
             _ => bail!("Unrecognized target!"),
         }
     } else if target::MACOS && target::x86_64 {
-        "x86_64-apple-darwin"
+        "x86_64-macos"
     } else if target::WINDOWS && target::x86_64 {
         match tool {
-            Tool::WasmOpt => "x86-windows",
-            _ => "x86_64-pc-windows-msvc",
+            Tool::WasmOpt => "x86_64-windows",
+            _ => bail!("Unrecognized target!"),
         }
     } else if target::WINDOWS && target::x86 {
         match tool {

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -164,7 +164,7 @@ pub fn download_prebuilt(
 fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
     let target = if target::LINUX && target::x86_64 {
         match tool {
-            Tool::WasmOpt => "x86-linux",
+            Tool::WasmOpt => "x86_64-linux",
             _ => "x86_64-unknown-linux-musl",
         }
     } else if target::LINUX && target::x86 {
@@ -206,7 +206,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
         Tool::WasmOpt => {
             Ok(format!(
         "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_90",
+        vers = "version_97",
         target = target,
             ))
         }

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -165,7 +165,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
     let target = if target::LINUX && target::x86_64 {
         match tool {
             Tool::WasmOpt => "x86_64-linux",
-            _ => bail!("Unrecognized target!"),
+            _ => "x86_64-unknown-linux-musl",
         }
     } else if target::LINUX && target::x86 {
         match tool {
@@ -177,7 +177,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
     } else if target::WINDOWS && target::x86_64 {
         match tool {
             Tool::WasmOpt => "x86_64-windows",
-            _ => bail!("Unrecognized target!"),
+            _ => "x86_64-pc-windows-msvc",
         }
     } else if target::WINDOWS && target::x86 {
         match tool {

--- a/src/test/webdriver/chromedriver.rs
+++ b/src/test/webdriver/chromedriver.rs
@@ -9,7 +9,7 @@ use target;
 
 // Keep it up to date with each `wasm-pack` release.
 // https://chromedriver.storage.googleapis.com/LATEST_RELEASE
-const DEFAULT_CHROMEDRIVER_VERSION: &str = "79.0.3945.36";
+const DEFAULT_CHROMEDRIVER_VERSION: &str = "86.0.4240.22";
 
 const CHROMEDRIVER_LAST_UPDATED_STAMP: &str = "chromedriver_last_updated";
 const CHROMEDRIVER_VERSION_STAMP: &str = "chromedriver_version";

--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -58,7 +58,7 @@ pub fn find_wasm_opt(
     cache: &Cache,
     install_permitted: bool,
 ) -> Result<install::Status, failure::Error> {
-    let version = "version_78";
+    let version = "version_97";
     Ok(install::download_prebuilt(
         &install::Tool::WasmOpt,
         cache,


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅
- [x] You have the latest version of `rustfmt` installed
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

### Description
Fixes the issue reported in #919 
