### PR TITLE
manifest: var keyword; remove return, use is_empty

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -620,7 +620,7 @@ impl CrateData {
             None
         };
 
-        let keywords = if pkg.keywords.len() > 0 {
+        let keywords = if !pkg.keywords.is_empty() {
             Some(pkg.keywords.clone())
         } else {
             None
@@ -644,7 +644,7 @@ impl CrateData {
             files,
             main: js_file,
             homepage: self.manifest.package.homepage.clone(),
-            keywords: keywords,
+            keywords,
         }
     }
 


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ X] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [X ] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

Small changes
* use `!pkg.keywords.is_empty()` over `pkg.keywords.len() > 0`
* use 'keyword' instead of redundant 'keyword: keyword'