### PR TITLE
Pass through --weak-refs --reference-types flags to bindgen

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -17,6 +17,8 @@ pub fn wasm_bindgen_build(
     out_dir: &Path,
     out_name: &Option<String>,
     disable_dts: bool,
+    weak_refs: bool,
+    reference_types: bool,
     target: Target,
     profile: BuildProfile,
 ) -> Result<(), failure::Error> {
@@ -47,6 +49,14 @@ pub fn wasm_bindgen_build(
         .arg("--out-dir")
         .arg(out_dir)
         .arg(dts_arg);
+
+    if weak_refs {
+        cmd.arg("--weak-refs");
+    }
+
+    if reference_types {
+        cmd.arg("--reference-types");
+    }
 
     let target_arg = build_target_arg(target, &bindgen_path)?;
     if supports_dash_dash_target(&bindgen_path)? {

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -28,6 +28,8 @@ pub struct Build {
     pub crate_data: manifest::CrateData,
     pub scope: Option<String>,
     pub disable_dts: bool,
+    pub weak_refs: bool,
+    pub reference_types: bool,
     pub target: Target,
     pub profile: BuildProfile,
     pub mode: InstallMode,
@@ -132,6 +134,14 @@ pub struct BuildOptions {
     /// this flag will disable generating this TypeScript file.
     pub disable_dts: bool,
 
+    #[structopt(long = "weak-refs")]
+    /// Enable usage of the JS weak references proposal.
+    pub weak_refs: bool,
+
+    #[structopt(long = "reference-types")]
+    /// Enable usage of WebAssembly reference types.
+    pub reference_types: bool,
+
     #[structopt(long = "target", short = "t", default_value = "bundler")]
     /// Sets the target environment. [possible values: bundler, nodejs, web, no-modules]
     pub target: Target,
@@ -173,6 +183,8 @@ impl Default for BuildOptions {
             scope: None,
             mode: InstallMode::default(),
             disable_dts: false,
+            weak_refs: false,
+            reference_types: false,
             target: Target::default(),
             debug: false,
             dev: false,
@@ -217,6 +229,8 @@ impl Build {
             crate_data,
             scope: build_opts.scope,
             disable_dts: build_opts.disable_dts,
+            weak_refs: build_opts.weak_refs,
+            reference_types: build_opts.reference_types,
             target: build_opts.target,
             profile,
             mode: build_opts.mode,
@@ -391,6 +405,8 @@ impl Build {
             &self.out_dir,
             &self.out_name,
             self.disable_dts,
+            self.weak_refs,
+            self.reference_types,
             self.target,
             self.profile,
         )?;

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -415,7 +415,7 @@ impl Build {
     }
 
     fn step_run_wasm_opt(&mut self) -> Result<(), Error> {
-        let args = match self
+        let mut args = match self
             .crate_data
             .configured_profile(self.profile)
             .wasm_opt_args()
@@ -423,6 +423,9 @@ impl Build {
             Some(args) => args,
             None => return Ok(()),
         };
+        if self.reference_types {
+            args.push("--enable-reference-types".into());
+        }
         info!("executing wasm-opt with {:?}", args);
         wasm_opt::run(
             &self.cache,


### PR DESCRIPTION
Fixes #930 
Closes #888 

I'm wondering if it'd make sense to have a --bind-gen-opts flag which allows the user to manually specify args to pass through