### PR TITLE
Support chromedriver on Apple Silicon.

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -13,3 +13,5 @@ pub const WINDOWS: bool = cfg!(target_os = "windows");
 pub const x86_64: bool = cfg!(target_arch = "x86_64");
 #[allow(non_upper_case_globals)]
 pub const x86: bool = cfg!(target_arch = "x86");
+#[allow(non_upper_case_globals)]
+pub const aarch64: bool = cfg!(target_arch = "aarch64");

--- a/src/test/webdriver/chromedriver.rs
+++ b/src/test/webdriver/chromedriver.rs
@@ -9,7 +9,7 @@ use target;
 
 // Keep it up to date with each `wasm-pack` release.
 // https://chromedriver.storage.googleapis.com/LATEST_RELEASE
-const DEFAULT_CHROMEDRIVER_VERSION: &str = "79.0.3945.36";
+const DEFAULT_CHROMEDRIVER_VERSION: &str = "88.0.4324.96";
 
 const CHROMEDRIVER_LAST_UPDATED_STAMP: &str = "chromedriver_last_updated";
 const CHROMEDRIVER_VERSION_STAMP: &str = "chromedriver_version";
@@ -35,6 +35,8 @@ pub fn install_chromedriver(
         "linux64"
     } else if target::MACOS && target::x86_64 {
         "mac64"
+    } else if target::MACOS && target::aarch64 {
+        "mac64_m1"
     } else if target::WINDOWS {
         "win32"
     } else {


### PR DESCRIPTION
~~From local testing this works fine and native binaries aren't yet
available: https://bugs.chromium.org/p/chromedriver/issues/detail?id=3688.~~

Uses the newly-available `_m1` releases of chromedriver.

Resolves #954.

(checked the boxes!)
