### PR TITLE
Re-enable looking in the path Wasm-opt for binaries first.

### DIFF
--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -64,7 +64,7 @@ pub fn find_wasm_opt(
 
         match path.as_path().parent() {
             Some(path) => return Ok(install::Status::Found(Download::at(path))),
-            _ => {}
+            None => {}
         }
     }
 

--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -3,7 +3,7 @@
 use crate::child;
 use crate::install::{self, Tool};
 use crate::PBAR;
-use binary_install::Cache;
+use binary_install::{Cache, Download};
 use std::path::Path;
 use std::process::Command;
 
@@ -58,6 +58,16 @@ pub fn find_wasm_opt(
     cache: &Cache,
     install_permitted: bool,
 ) -> Result<install::Status, failure::Error> {
+    // First attempt to look up in PATH. If found assume it works.
+    if let Ok(path) = which::which("wasm-opt") {
+        PBAR.info(&format!("found wasm-opt at {:?}", path));
+
+        match path.as_path().parent() {
+            Some(path) => return Ok(install::Status::Found(Download::at(path))),
+            _ => {}
+        }
+    }
+
     let version = "version_78";
     Ok(install::download_prebuilt(
         &install::Tool::WasmOpt,


### PR DESCRIPTION
First look in the local path for the wasm-opt binary. Use whatever binary is found and assume it works.

I'm specifically working on an ARM Mac and was able to build wasm-opt locally but wasm-pack wasn't picking it up. I found that the code used to support this so I copied it back https://github.com/rustwasm/wasm-pack/commit/9b74e43d2de3c0c1eccdc3752c870925b68fb27a#diff-d9cd988699c3224bc78800edb64a7cb60d3cae9833460f79ce2d586b9555cd83R70

Referenced in this issue https://github.com/rustwasm/wasm-pack/issues/913

I'm kinda new at this so I'm willing to accept whatever guidance is necessary for this. Thanks for creating this project!

Make sure these boxes are checked! 📦✅

- [✅] You have the latest version of `rustfmt` installed
```bash
  $ rustup component add rustfmt
```
- [✅] You ran `cargo fmt` on the code base before submitting
- [✅] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
