### PR TITLE
no `latest` version argument specified.

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -260,10 +260,13 @@ pub fn cargo_install(
     cmd.arg("install")
         .arg("--force")
         .arg(crate_name)
-        .arg("--version")
-        .arg(version)
         .arg("--root")
         .arg(&tmp);
+
+    if version != "latest" {
+        cmd.arg("--version")
+           .arg(version);
+    }
 
     let context = format!("Installing {} with cargo", tool);
     child::run(cmd, "cargo install").context(context)?;


### PR DESCRIPTION
`cargo install` doesn't seem to specify the` latest` version.

Closes #907

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
