### PR TITLE
Unstable versions of cargo-generate on crates.io breaks prebuilt binaries and previously installed version checks.

### DIFF
--- a/docs/src/commands/new.md
+++ b/docs/src/commands/new.md
@@ -30,7 +30,7 @@ wasm-pack new myproject --template https://github.com/rustwasm/wasm-pack-templat
 The template can be an address to a git repo that contains a [`cargo-generate`]
 template.
 
-[`cargo-generate`]: https://github.com/ashleygwilliams/cargo-generate
+[`cargo-generate`]: https://github.com/cargo-generate/cargo-generate
 
 ## Mode
 

--- a/src/install/krate.rs
+++ b/src/install/krate.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct Krate {
-    pub max_version: String,
+    pub max_stable_version: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -198,7 +198,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
         },
         Tool::CargoGenerate => {
             Ok(format!(
-                "https://github.com/ashleygwilliams/cargo-generate/releases/download/v{0}/cargo-generate-v{0}-{1}.tar.gz",
+                "https://github.com/cargo-generate/cargo-generate/releases/download/v{0}/cargo-generate-v{0}-{1}.tar.gz",
                 Krate::new(&Tool::CargoGenerate)?.max_version,
                 target
             ))

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -93,7 +93,7 @@ pub fn check_version(
 ) -> Result<bool, failure::Error> {
     let expected_version = if expected_version == "latest" {
         let krate = Krate::new(tool)?;
-        krate.max_version
+        krate.max_stable_version
     } else {
         expected_version.to_string()
     };
@@ -199,7 +199,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
         Tool::CargoGenerate => {
             Ok(format!(
                 "https://github.com/cargo-generate/cargo-generate/releases/download/v{0}/cargo-generate-v{0}-{1}.tar.gz",
-                Krate::new(&Tool::CargoGenerate)?.max_version,
+                Krate::new(&Tool::CargoGenerate)?.max_stable_version,
                 target
             ))
         },


### PR DESCRIPTION
This PR fixes #976.

Recently there was a version of `cargo-generate` published to `crates.io`, `0.6.0-alpha.1`. This caused an issue because the previous API for `Krate` to check the latest version used `max_version` instead of `max_stable_version`, and there were no prebuilt binary for `0.6.0-alpha.1`. This PR fixes this issue and therefore fixes prebuilt binaries as well as the checks for previously installed versions of cargo-generate. I also changed the GitHub address to use `cargo-generate/cargo-generate` instead of `ashleygwilliams/cargo-generate`. While it still works without it, it's still just generally helpful as it saves one level of redirection which on some connections may be kind of slow.