### PR TITLE
feat: adds support for M1 macbooks to curl installer

### DIFF
--- a/docs/_installer/init.sh
+++ b/docs/_installer/init.sh
@@ -92,6 +92,13 @@ get_architecture() {
         fi
     fi
 
+    if [ "$_ostype" = Darwin -a "$_cputype" = arm64 ]; then
+        # Darwin `uname -s` doesn't seem to lie on Big Sur
+        # but we want to serve x86_64 binaries anyway that they can
+        # then run in x86_64 emulation mode on their arm64 devices
+        local _cputype=x86_64
+    fi
+
     case "$_ostype" in
         Linux)
             local _ostype=unknown-linux-musl

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -12,7 +12,7 @@ const getPlatform = () => {
   if (type === "Linux" && arch === "x64") {
     return "x86_64-unknown-linux-musl";
   }
-  if (type === "Darwin" && arch === "x64") {
+  if (type === "Darwin" && (arch === "x64" || arch === "arm64")) {
     return "x86_64-apple-darwin";
   }
 


### PR DESCRIPTION
M1 macbooks can run x86_64 code in emulation mode! this PR adds support for detecting if a machine is an M1 macbook, and then directs them towards the x86_64-apple-darwin binary in both the curl installer and the npm installer :)