### PR TITLE
cargo install fails because latest is not valid

### DIFF
--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -17,7 +17,9 @@ pub fn generate(
     let download = install::download_prebuilt_or_cargo_install(
         Tool::CargoGenerate,
         &cache::get_wasm_pack_cache()?,
-        "latest",
+        "^0.5.3", // This is a temporary fix for issue
+                  // [#907](https://github.com/rustwasm/wasm-pack/issues/907).
+                  // `latest` no longer works with cargo.
         install_permitted,
     )?;
     generate::generate(&template, &name, &download)?;


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨


## Description
cargo install X --version **latest** does not work and results in a failure. I tracked down the code that causes this issue and set the version to `^0.5.3`. This pull request should hopefully suppress that error.

Fixes #907

## Testing
[x] cargo install works with that specified version

## Additional context
This might not be a good fix, a better fix for this may be completely removing the version argument and providing an empty string as cargo will default to the latest version.