### PR TITLE
fix "no pre-built binaries" error for aarch64, use x86_64 via rosetta

### DIFF
--- a/docs/_installer/init.sh
+++ b/docs/_installer/init.sh
@@ -99,6 +99,11 @@ get_architecture() {
 
         Darwin)
             local _ostype=apple-darwin
+            # override for case where target machine is using Apple Silicon CPU, 
+            # use x86_64 binary via rosetta
+            if [ $_cputype == arm64 ]; then
+                local _cputype=x86_64
+            fi
             ;;
 
         MINGW* | MSYS* | CYGWIN*)

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -12,7 +12,8 @@ const getPlatform = () => {
   if (type === "Linux" && arch === "x64") {
     return "x86_64-unknown-linux-musl";
   }
-  if (type === "Darwin" && arch === "x64") {
+  if (type === "Darwin" && (arch === "x64" || arch === "arm64")) {
+    // use x86_64 binary on aarch64 target using rosetta
     return "x86_64-apple-darwin";
   }
 

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -172,7 +172,8 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
             Tool::WasmOpt => "x86-linux",
             _ => bail!("Unrecognized target!"),
         }
-    } else if target::MACOS && target::x86_64 {
+    } else if target::MACOS && (target::x86_64 || target::aarch64) {
+        // use x86_64 binary on aarch64 target using rosetta
         "x86_64-apple-darwin"
     } else if target::WINDOWS && target::x86_64 {
         match tool {

--- a/src/target.rs
+++ b/src/target.rs
@@ -13,3 +13,5 @@ pub const WINDOWS: bool = cfg!(target_os = "windows");
 pub const x86_64: bool = cfg!(target_arch = "x86_64");
 #[allow(non_upper_case_globals)]
 pub const x86: bool = cfg!(target_arch = "x86");
+#[allow(non_upper_case_globals)]
+pub const aarch64: bool = cfg!(target_arch = "aarch64");


### PR DESCRIPTION
Adds support for installing binary deps (`wasm-opt`, etc) `aarch64-apple-darwin` target, via usage of `x86_64` binary run through the Apple-provided Rosetta instruction translator. As long as _Rosetta 2_ is installed on the target Apple device, all downloaded binaries will be executed using it automatically. 

More info on Rosetta 2: https://support.apple.com/en-us/HT211861

closes: #952

---

- [x] You have the latest version of `rustfmt` installed
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
