### PR TITLE
remove greenkeeper

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -6,12 +6,10 @@ This tool seeks to be a one-stop shop for building and working with rust-
 generated WebAssembly that you would like to interop with JavaScript, in the
 browser or with Node.js. `wasm-pack` helps you build rust-generated
 WebAssembly packages that you could publish to the npm registry, or otherwise use
-alongside any javascript packages in workflows that you already use, such as [webpack]
-or [greenkeeper].
+alongside any javascript packages in workflows that you already use, such as [webpack].
 
 [bundler-support]: https://github.com/rustwasm/team/blob/master/goals/bundler-integration.md#details
 [webpack]: https://webpack.js.org/
-[greenkeeper]: https://greenkeeper.io/
 
 This project is a part of the [rust-wasm] group. You can find more info by
 visiting that repo!


### PR DESCRIPTION
Greenkeeper said goodbye in June 2020, so no longer good to link to as an example.

Alternative might be to link to Snyk instead?

Issue #1001 

Make sure these boxes are checked! 📦✅

- [ ] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [ ] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
