### PR TITLE
cleanup: remove outdated TOC heading

### DIFF
--- a/docs/src/tutorials/npm-browser-packages/template-deep-dive/wee_alloc.md
+++ b/docs/src/tutorials/npm-browser-packages/template-deep-dive/wee_alloc.md
@@ -2,7 +2,6 @@
 
 1. [What is `wee_alloc`?](#what-is-wee_alloc)
 2. [Enabling `wee_alloc`](#enabling-wee_alloc)
-3. [Rust nightly](#rust-nightly)
 
 ## What is `wee_alloc`?
 


### PR DESCRIPTION
That section is gone.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
