### PR TITLE
Automatically approve new PRs for running Github test actions

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,0 +1,15 @@
+name: Automatic Approve
+on:
+  schedule: 
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  automatic-approve:
+    name: Automatic Approve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatic Approve
+        uses: mheap/automatic-approve-action@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workflows: "test.yml"


### PR DESCRIPTION
Using https://github.com/marketplace/actions/automatic-approve solves the problem of approval of new PRs for Github action running (providing they don't edit the workflows themselves!)

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
