### PR TITLE
fixes docs offscreen warning label 

### DIFF
--- a/docs/_theme/header.hbs
+++ b/docs/_theme/header.hbs
@@ -35,10 +35,12 @@
   }
 </style>
 <header class='warning'>
-  This is the <strong>unpublished</strong> documentation of
-  <code>wasm-pack</code>, the published documentation is available
-  <a href="https://rustwasm.github.io/docs/wasm-pack/">
-    on the main Rust and WebAssembly documentation site
-  </a>. Features documented here may not be available in released versions of
-  <code>wasm-pack</code>.
+  <p>
+    This is the <strong>unpublished</strong> documentation of
+    <code>wasm-pack</code>, the published documentation is available
+    <a href="https://rustwasm.github.io/docs/wasm-pack/">
+      on the main Rust and WebAssembly documentation site
+    </a>. Features documented here may not be available in released versions of
+    <code>wasm-pack</code>.
+  </p>
 </header>


### PR DESCRIPTION
I just put the warning header in a `p` tag so that it wouldn't render offscreen.

There's some extra whitespace in the bottom margin of the warning header but I thought I'd keep the change atomic.

Make sure these boxes are checked! 📦✅

- [ ✅] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```


- [ ✅] You ran `cargo fmt` on the code base before submitting
- [ ✅] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
