### PR TITLE
Fix example commands in docs broken by PR #851

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -127,13 +127,13 @@ wasm-pack build examples/js-hello-world --mode no-install
 
 ## Extra options
 
-The `build` command can pass extra options straight to `cargo build` even if they are not
-supported in wasm-pack. To use them you should add standalone `--` argument at the very
-end of your command, and all the arguments you want to pass to cargo should go after.
-For example, to build the previous example using cargo's offline feature:
+The `build` command can pass extra options straight to `cargo build` even if
+they are not supported in wasm-pack. To use them simply add the extra arguments
+at the very end of your command, just as you would for `cargo build`. For
+example, to build the previous example using cargo's offline feature:
 
 ```
-wasm-pack build examples/js-hello-world --mode no-install -- --offline
+wasm-pack build examples/js-hello-world --mode no-install --offline
 ```
 
 <hr style="font-size: 1.5em; margin-top: 2.5em"/>

--- a/docs/src/commands/test.md
+++ b/docs/src/commands/test.md
@@ -44,8 +44,8 @@ wasm-pack test --node --firefox --chrome --safari --headless
 The `test` command can pass extra options straight to `cargo test` even if they are not
 supported in wasm-pack.
 
-To use them you should add standalone `--` argument at the very
-end of your command, and all the arguments you want to pass to cargo should go after.
+To use them simply add the extra arguments at the very end of your command, just
+as you would for `cargo test`.
 
 `cargo test -h` for a list of all options that you can pass through.
 
@@ -72,16 +72,16 @@ $ tree crates/foo
 
 ```
 # Run all tests in tests/diff_patch.rs in Firefox
-wasm-pack test crates/foo --firefox --headless -- --test diff_patch
+wasm-pack test crates/foo --firefox --headless --test diff_patch
 
 # Run all tests in tests/diff_patch.rs that contain the word "replace"
-wasm-pack test crates/foo --firefox --headless -- --test diff_patch replace
+wasm-pack test crates/foo --firefox --headless --test diff_patch replace
 
 # Run all tests inside of a `tests` module inside of src/lib/diff.rs
-wasm-pack test crates/foo --firefox --headless -- --lib diff::tests
+wasm-pack test crates/foo --firefox --headless --lib diff::tests
 
 # Same as the above, but only if they contain the word replace
-wasm-pack test crates/foo --firefox --headless -- --lib diff::tests::replace
+wasm-pack test crates/foo --firefox --headless --lib diff::tests::replace
 ```
 
 Note that you can also filter tests by location in which they're supposed to

--- a/docs/src/tutorials/npm-browser-packages/template-deep-dive/wee_alloc.md
+++ b/docs/src/tutorials/npm-browser-packages/template-deep-dive/wee_alloc.md
@@ -40,7 +40,7 @@ allocator, but only if the `wee_alloc` feature is enabled at compile time. The
 feature can be enabled by passing extra options while building:
 
 ```
-$ wasm-pack build -- --features wee_alloc
+$ wasm-pack build --features wee_alloc
 ```
 
 or alternatively you could turn it on by default in `Cargo.toml`:


### PR DESCRIPTION
Since #851 was merged, both `wasm-pack build` and `wasm-pack test` directly pass extra arguments to `cargo build` and `cargo test` without the need for an additional `--`. This PR updates the docs to reflect this change.

EDIT: I just noticed that `wasm-pack build` did not yet use the same syntax as `wasm-pack test`, which would be fixed by #1037 and should be merged first for the doc changes of this PR to make sense.

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
