### PR TITLE
Use same syntax for extra arguments as wasm-pack test

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Instant;
+use structopt::clap::AppSettings;
 use PBAR;
 
 /// Everything required to configure and run the `wasm-pack build` command.
@@ -101,6 +102,13 @@ pub enum BuildProfile {
 
 /// Everything required to configure and run the `wasm-pack build` command.
 #[derive(Debug, StructOpt)]
+#[structopt(
+    // Allows unknown `--option`s to be parsed as positional arguments, so we can forward it to `cargo`.
+    setting = AppSettings::AllowLeadingHyphen,
+
+    // Allows `--` to be parsed as an argument, so we can forward it to `cargo`.
+    setting = AppSettings::TrailingVarArg,
+)]
 pub struct BuildOptions {
     /// The path to the Rust crate. If not set, searches up the path from the current directory.
     #[structopt(parse(from_os_str))]
@@ -148,7 +156,7 @@ pub struct BuildOptions {
     /// Sets the output file names. Defaults to package name.
     pub out_name: Option<String>,
 
-    #[structopt(last = true)]
+    #[structopt(allow_hyphen_values = true)]
     /// List of extra options to pass to `cargo build`
     pub extra_options: Vec<String>,
 }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -184,7 +184,15 @@ type BuildStep = fn(&mut Build) -> Result<(), Error>;
 
 impl Build {
     /// Construct a build command from the given options.
-    pub fn try_from_opts(build_opts: BuildOptions) -> Result<Self, Error> {
+    pub fn try_from_opts(mut build_opts: BuildOptions) -> Result<Self, Error> {
+        if let Some(path) = &build_opts.path {
+            if path.to_string_lossy().starts_with("--") {
+                let path = build_opts.path.take().unwrap();
+                build_opts
+                    .extra_options
+                    .insert(0, path.to_string_lossy().into_owned().to_string());
+            }
+        }
         let crate_path = get_crate_path(build_opts.path)?;
         let crate_data = manifest::CrateData::new(&crate_path, build_opts.out_name.clone())?;
         let out_dir = crate_path.join(PathBuf::from(build_opts.out_dir));

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -264,7 +264,6 @@ fn build_with_arbitrary_cargo_options() {
     fixture
         .wasm_pack()
         .arg("build")
-        .arg("--")
         .arg("--no-default-features")
         .assert()
         .success();


### PR DESCRIPTION
The syntax for passing extra arguments to `wasm-pack build` and `wasm-pack test` has diverged due to #851, with the result that an additional `--` is expected by `wasm-pack build` but not by `wasm-pack test`:

```
wasm-pack build -- --features foo
wasm-pack test --features foo
```

This PR mirrors the change made in #851 and applies it to `wasm-pack build` so that both commands use the same syntax again (without the need for an extra `--` and with the same syntax as `cargo build` and `cargo test`):

```
wasm-pack build --features foo
wasm-pack test --features foo
```

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
