### PR TITLE
Fix mdbook build

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -26,12 +26,12 @@ jobs:
             ~/.cargo/bin
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-0.2 }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-0.3 }}
 
       - name: Install mdbook
         run: |
           (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-          (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.2" mdbook)
+          (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.3" mdbook)
           cargo install-update -a
 
       - name: Build book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -2,8 +2,7 @@ name: Build and deploy documentation book
 
 on:
   push:
-    branches:
-      - master
+  pull_request:    
 
 jobs:
   book:
@@ -31,6 +30,7 @@ jobs:
 
       - name: Deploy book
         uses: JamesIves/github-pages-deploy-action@4.1.4
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           branch: gh-pages
           folder: docs

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,6 +15,19 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-mdbook
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-0.2 }}
+
       - name: Install mdbook
         run: |
           (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)


### PR DESCRIPTION
All 1.x versions of [ammonia](https://crates.io/crates/ammonia/versions) have been yanked, so mdbook 0.2 isn't installable anymore. This PR upgrades to 0.3, and runs the build part of mdbook on PRs so we can pick up issues like this before master merge.

---
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
