### PR TITLE
Add --inline parameter to bundle wasm binary into js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "atty",
+ "base64 0.13.0",
  "binary-install",
  "cargo_metadata",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://rustwasm.github.io/wasm-pack/"
 
 [dependencies]
 atty = "0.2.11"
+base64 = "0.13"
 cargo_metadata = "0.8.0"
 console = "0.6.1"
 dialoguer = "0.3.0"

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -135,7 +135,7 @@ pub fn download_prebuilt(
     };
     match tool {
         Tool::WasmBindgen => {
-            let binaries = &["wasm-bindgen", "wasm-bindgen-test-runner"];
+            let binaries = &["wasm-bindgen", "wasm2es6js", "wasm-bindgen-test-runner"];
             match cache.download(install_permitted, "wasm-bindgen", binaries, &url)? {
                 Some(download) => Ok(Status::Found(download)),
                 None => bail!("wasm-bindgen v{} is not installed!", version),
@@ -277,7 +277,11 @@ pub fn cargo_install(
     // laid out, and where the rest of our code expects them to be). So we do a
     // little renaming here.
     let binaries: Result<Vec<&str>, failure::Error> = match tool {
-        Tool::WasmBindgen => Ok(vec!["wasm-bindgen", "wasm-bindgen-test-runner"]),
+        Tool::WasmBindgen => Ok(vec![
+            "wasm-bindgen",
+            "wasm-bindgen-test-runner",
+            "wasm2es6js",
+        ]),
         Tool::CargoGenerate => Ok(vec!["cargo-generate"]),
         Tool::WasmOpt => bail!("Cannot install wasm-opt with cargo."),
     };


### PR DESCRIPTION
This is another attempt to solve https://github.com/rustwasm/wasm-pack/pull/739 and https://github.com/rustwasm/wasm-bindgen/pull/1880

Since wasm-pack does optimization after bindgen, it makes more sense to inline the optimized wasm in this tool to reduce js file size, instead of doing it in bindgen.  Please let me know you concerns, thanks!

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
