### PR TITLE
fix: todo, minor typos, extra clones

### DIFF
--- a/src/build/wasm_target.rs
+++ b/src/build/wasm_target.rs
@@ -5,7 +5,7 @@ use emoji;
 use failure::{Error, ResultExt};
 use log::info;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use PBAR;
 
@@ -81,7 +81,7 @@ fn get_rustc_sysroot() -> Result<PathBuf, Error> {
 }
 
 /// Checks if the wasm32-unknown-unknown is present in rustc's sysroot.
-fn is_wasm32_target_in_sysroot(sysroot: &PathBuf) -> bool {
+fn is_wasm32_target_in_sysroot(sysroot: &Path) -> bool {
     let wasm32_target = "wasm32-unknown-unknown";
 
     let rustlib_path = sysroot.join("lib/rustlib");

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -190,7 +190,7 @@ impl Build {
                 let path = build_opts.path.take().unwrap();
                 build_opts
                     .extra_options
-                    .insert(0, path.to_string_lossy().into_owned().to_string());
+                    .insert(0, path.to_string_lossy().into_owned());
             }
         }
         let crate_path = get_crate_path(build_opts.path)?;
@@ -370,7 +370,7 @@ impl Build {
         let bindgen = install::download_prebuilt_or_cargo_install(
             Tool::WasmBindgen,
             &self.cache,
-            &bindgen_version,
+            bindgen_version,
             self.mode.install_permitted(),
         )?;
         self.bindgen = Some(bindgen);
@@ -382,7 +382,7 @@ impl Build {
         info!("Building the wasm bindings...");
         bindgen::wasm_bindgen_build(
             &self.crate_data,
-            &self.bindgen.as_ref().unwrap(),
+            self.bindgen.as_ref().unwrap(),
             &self.out_dir,
             &self.out_name,
             self.disable_dts,

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -1,4 +1,4 @@
-//! Emoji contants used by `wasm-pack`.
+//! Emoji constants used by `wasm-pack`.
 //!
 //! For the woefully unfamiliar:
 //!

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -10,7 +10,7 @@ use log::debug;
 use log::{info, warn};
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::Command;
 use target;
 use which::which;
@@ -71,7 +71,7 @@ pub fn download_prebuilt_or_cargo_install(
     let msg = format!("{}Installing {}...", emoji::DOWN_ARROW, tool);
     PBAR.info(&msg);
 
-    let dl = download_prebuilt(&tool, &cache, version, install_permitted);
+    let dl = download_prebuilt(&tool, cache, version, install_permitted);
     match dl {
         Ok(dl) => return Ok(dl),
         Err(e) => {
@@ -82,13 +82,13 @@ pub fn download_prebuilt_or_cargo_install(
         }
     }
 
-    cargo_install(tool, &cache, version, install_permitted)
+    cargo_install(tool, cache, version, install_permitted)
 }
 
 /// Check if the tool dependency is locally satisfied.
 pub fn check_version(
     tool: &Tool,
-    path: &PathBuf,
+    path: &Path,
     expected_version: &str,
 ) -> Result<bool, failure::Error> {
     let expected_version = if expected_version == "latest" {
@@ -107,7 +107,7 @@ pub fn check_version(
 }
 
 /// Fetches the version of a CLI tool
-pub fn get_cli_version(tool: &Tool, path: &PathBuf) -> Result<String, failure::Error> {
+pub fn get_cli_version(tool: &Tool, path: &Path) -> Result<String, failure::Error> {
     let mut cmd = Command::new(path);
     cmd.arg("--version");
     let stdout = child::run_capture_stdout(cmd, tool)?;

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -12,7 +12,7 @@
 //! downloaded via curl/sh, and then the shell script downloads this executable
 //! and runs it.
 //!
-//! This may get more complicated over time (self upates anyone?) but for now
+//! This may get more complicated over time (self updates anyone?) but for now
 //! it's pretty simple! We're largely just moving over our currently running
 //! executable to a different path.
 

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -644,7 +644,7 @@ impl CrateData {
             files,
             main: js_file,
             homepage: self.manifest.package.homepage.clone(),
-            keywords: keywords,
+            keywords,
         }
     }
 

--- a/src/test/webdriver.rs
+++ b/src/test/webdriver.rs
@@ -23,13 +23,13 @@ fn get_and_notify(
     name: &str,
     url: &str,
 ) -> Result<Option<PathBuf>, failure::Error> {
-    if let Some(dl) = cache.download(false, name, &[name], &url)? {
+    if let Some(dl) = cache.download(false, name, &[name], url)? {
         return Ok(Some(dl.binary(name)?));
     }
     if installation_allowed {
         PBAR.info(&format!("Getting {}...", name));
     }
-    match cache.download(installation_allowed, name, &[name], &url)? {
+    match cache.download(installation_allowed, name, &[name], url)? {
         Some(dl) => Ok(Some(dl.binary(name)?)),
         None => Ok(None),
     }

--- a/src/test/webdriver.rs
+++ b/src/test/webdriver.rs
@@ -39,8 +39,7 @@ struct Collector(Vec<u8>);
 
 impl Collector {
     pub fn take_content(&mut self) -> Vec<u8> {
-        // TODO: replace with `std::mem::take` once stable
-        std::mem::replace(&mut self.0, Vec::default())
+        std::mem::take(&mut self.0)
     }
 }
 


### PR DESCRIPTION
While struggling with an issue I reviewed some of wasm-pack's source to understand how it works better. En route, I found minor details I wound up poking at: borrows that are re-borrowed and clones that could be skipped, mostly.