### PR TITLE
fix: Add exe to binary name if windows

### DIFF
--- a/npm/binary.js
+++ b/npm/binary.js
@@ -1,13 +1,14 @@
 const { Binary } = require("binary-install");
 const os = require("os");
-const { join } = require("path");
+
+const windows = "x86_64-pc-windows-msvc";
 
 const getPlatform = () => {
   const type = os.type();
   const arch = os.arch();
 
   if (type === "Windows_NT" && arch === "x64") {
-    return "x86_64-pc-windows-msvc";
+    return windows;
   }
   if (type === "Linux" && arch === "x64") {
     return "x86_64-unknown-linux-musl";
@@ -25,7 +26,7 @@ const getBinary = () => {
   const author = "rustwasm";
   const name = "wasm-pack";
   const url = `https://github.com/${author}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
-  return new Binary(name, url );
+  return new Binary(platform === windows ? "wasm-pack.exe" : "wasm-pack", url);
 };
 
 const run = () => {
@@ -46,5 +47,5 @@ const uninstall = () => {
 module.exports = {
   install,
   run,
-  uninstall
+  uninstall,
 };

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -357,9 +357,9 @@
       }
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ ] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [ ] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
