### PR TITLE
feat: add `--no-modules-global` support

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -90,7 +90,7 @@ wasm-pack build --target nodejs
 | *not specified* or `bundler` | [Bundler][bundlers] | Outputs JS that is suitable for interoperation with a Bundler like Webpack. You'll `import` the JS and the `module` key is specified in `package.json`. `sideEffects: false` is by default. |
 | `nodejs`  | [Node.js][deploy-nodejs] | Outputs JS that uses CommonJS modules, for use with a `require` statement. `main` key in `package.json`. |
 | `web` | [Native in browser][deploy-web] | Outputs JS that can be natively imported as an ES module in a browser, but the WebAssembly must be manually instantiated and loaded. |
-| `no-modules` | [Native in browser][deploy-web] | Same as `web`, except the JS is included on a page and modifies global state, and doesn't support as many `wasm-bindgen` features as `web` |
+| `no-modules` | [Native in browser][deploy-web] | Same as `web`, except the JS is included on a page and modifies global state, and doesn't support as many `wasm-bindgen` features as `web`. Pass `--no-modules-global` to change the name of the global. |
 
 [deploy]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html
 [bundlers]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#bundlers

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -17,6 +17,7 @@ pub fn wasm_bindgen_build(
     out_dir: &Path,
     out_name: &Option<String>,
     disable_dts: bool,
+    no_modules_global: &Option<String>,
     target: Target,
     profile: BuildProfile,
 ) -> Result<(), failure::Error> {
@@ -47,6 +48,10 @@ pub fn wasm_bindgen_build(
         .arg("--out-dir")
         .arg(out_dir)
         .arg(dts_arg);
+
+    if let Some(no_modules_global) = no_modules_global {
+        cmd.arg("--no-modules-global").arg(no_modules_global);
+    }
 
     let target_arg = build_target_arg(target, &bindgen_path)?;
     if supports_dash_dash_target(&bindgen_path)? {

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -36,6 +36,7 @@ pub struct Build {
     pub bindgen: Option<install::Status>,
     pub cache: Cache,
     pub extra_options: Vec<String>,
+    pub no_modules_global: Option<String>,
 }
 
 /// What sort of output we're going to be generating and flags we're invoking
@@ -156,6 +157,10 @@ pub struct BuildOptions {
     /// Sets the output file names. Defaults to package name.
     pub out_name: Option<String>,
 
+    #[structopt(long = "no-modules-global")]
+    /// Sets the global name for the no-modules target. Defaults to wasm_bindgen.
+    pub no_modules_global: Option<String>,
+
     #[structopt(allow_hyphen_values = true)]
     /// List of extra options to pass to `cargo build`
     pub extra_options: Vec<String>,
@@ -175,6 +180,7 @@ impl Default for BuildOptions {
             profiling: false,
             out_dir: String::new(),
             out_name: None,
+            no_modules_global: None,
             extra_options: Vec::new(),
         }
     }
@@ -219,6 +225,7 @@ impl Build {
             out_name: build_opts.out_name,
             bindgen: None,
             cache: cache::get_wasm_pack_cache()?,
+            no_modules_global: build_opts.no_modules_global,
             extra_options: build_opts.extra_options,
         })
     }
@@ -386,6 +393,7 @@ impl Build {
             &self.out_dir,
             &self.out_name,
             self.disable_dts,
+            &self.no_modules_global,
             self.target,
             self.profile,
         )?;


### PR DESCRIPTION
This PR adds pass-through support for the `wasm-bindgen` flag `--no-modules-global`, which is very useful when building/running WASM in certain scenarios (browser extensions in particular).

Supercedes #860 which was mysteriously closed last summer. 

Closes #729. 

-------

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨