### PR TITLE
Update docs for how to pass extra options to cargo.

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -133,7 +133,7 @@ at the very end of your command, just as you would for `cargo build`. For
 example, to build the previous example using cargo's offline feature:
 
 ```
-wasm-pack build examples/js-hello-world --mode no-install --offline
+wasm-pack build examples/js-hello-world --mode no-install -- --offline
 ```
 
 <hr style="font-size: 1.5em; margin-top: 2.5em"/>


### PR DESCRIPTION
This is the correct way to pass extra arguments, such as features to cargo.

This fixes #1059.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
