### PR TITLE
Replace two mentions of `wasm-pack init` with `wasm-pack build` in the docs

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -122,7 +122,7 @@ wasm-pack build examples/js-hello-world --mode no-install
 
 | Option        | Description                                                                              |
 |---------------|------------------------------------------------------------------------------------------|
-| `no-install`  | `wasm-pack init` implicitly and create wasm binding  without installing `wasm-bindgen`.  |
+| `no-install`  | `wasm-pack build` implicitly and create wasm binding without installing `wasm-bindgen`.  |
 | `normal`      | do all the stuffs of `no-install` with installed `wasm-bindgen`.                         |
 
 ## Extra options

--- a/docs/src/tutorials/npm-browser-packages/packaging-and-publishing.md
+++ b/docs/src/tutorials/npm-browser-packages/packaging-and-publishing.md
@@ -7,7 +7,7 @@ command:
 $ wasm-pack build --scope MYSCOPE
 ```
 
-where `MYSCOPE` is your npm username. Normally you could just type `wasm-pack init` but since
+where `MYSCOPE` is your npm username. Normally you could just type `wasm-pack build` but since
 other people are doing this tutorial as well we don't want conflicts with the `wasm-add` package
 name! This command when run does a few things:
 


### PR DESCRIPTION
Two small documentation fixes.