### PR TITLE
feat: add support for macos aarch64

### DIFF
--- a/npm/binary.js
+++ b/npm/binary.js
@@ -13,7 +13,7 @@ const getPlatform = () => {
   if (type === "Linux" && arch === "x64") {
     return "x86_64-unknown-linux-musl";
   }
-  if (type === "Darwin" && arch === "x64") {
+  if (type === "Darwin" && (arch === "x64" || arch === "arm64")) {
     return "x86_64-apple-darwin";
   }
 

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -172,7 +172,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
             Tool::WasmOpt => "x86-linux",
             _ => bail!("Unrecognized target!"),
         }
-    } else if target::MACOS && target::x86_64 {
+    } else if target::MACOS && (target::x86_64 || target::aarch64) {
         "x86_64-apple-darwin"
     } else if target::WINDOWS && target::x86_64 {
         match tool {

--- a/src/target.rs
+++ b/src/target.rs
@@ -13,3 +13,5 @@ pub const WINDOWS: bool = cfg!(target_os = "windows");
 pub const x86_64: bool = cfg!(target_arch = "x86_64");
 #[allow(non_upper_case_globals)]
 pub const x86: bool = cfg!(target_arch = "x86");
+#[allow(non_upper_case_globals)]
+pub const aarch64: bool = cfg!(target_arch = "aarch64");


### PR DESCRIPTION
This PR fixes #913 for MacOS (aarch64) and will download `x86_64-apple-darwin`. Ideally, binaryen would release a native build but until then we can just use the x86 version which works fine on Apple Sillicon.

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text