### PR TITLE
Recent node versions can import ESModulesPackage output if "type": "module" is specified

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -699,6 +699,7 @@ impl CrateData {
 
         NpmPackage::ESModulesPackage(ESModulesPackage {
             name: data.name,
+            r#type: "module",
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
             version: pkg.version.to_string(),
@@ -729,6 +730,7 @@ impl CrateData {
 
         NpmPackage::ESModulesPackage(ESModulesPackage {
             name: data.name,
+            r#type: "module",
             collaborators: pkg.authors.clone(),
             description: self.manifest.package.description.clone(),
             version: pkg.version.to_string(),

--- a/src/manifest/npm/esmodules.rs
+++ b/src/manifest/npm/esmodules.rs
@@ -3,6 +3,7 @@ use manifest::npm::repository::Repository;
 #[derive(Serialize)]
 pub struct ESModulesPackage {
     pub name: String,
+    pub r#type: &'static str,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub collaborators: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
I accidentally closed #936 while rebasing/updating