### PR TITLE
Add aarch64-linux support

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -168,6 +168,11 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
             Tool::WasmOpt => "x86-linux",
             _ => "x86_64-unknown-linux-musl",
         }
+    } else if target::LINUX && target::aarch64 {
+        match tool {
+            Tool::WasmOpt => "aarch64-linux",
+            _ => "aarch64-unknown-linux-musl",
+        }
     } else if target::LINUX && target::x86 {
         match tool {
             Tool::WasmOpt => "x86-linux",

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -162,7 +162,6 @@ pub fn download_prebuilt(
 /// Returns the URL of a precompiled version of wasm-bindgen, if we have one
 /// available for our host platform.
 fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
-    println!("Tool: {}, Version: {:?}", tool, version);
     let target = if target::LINUX && target::x86_64 {
         match tool {
             Tool::WasmOpt => "x86-linux",

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -162,6 +162,7 @@ pub fn download_prebuilt(
 /// Returns the URL of a precompiled version of wasm-bindgen, if we have one
 /// available for our host platform.
 fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
+    println!("Tool: {}, Version: {:?}", tool, version);
     let target = if target::LINUX && target::x86_64 {
         match tool {
             Tool::WasmOpt => "x86-linux",


### PR DESCRIPTION
No issue, but related to #913. `wasm-opt` does include pre-built binaries for `aarch64-linux`, so we add a conditional to handle that case. Let me know if you still want me to create an issue

- [x] You have the latest version of `rustfmt` installed
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
