### PR TITLE
Do not remove the pkg directory

### DIFF
--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -37,7 +37,6 @@ fn find_manifest_from_cwd() -> Result<PathBuf, failure::Error> {
 
 /// Construct our `pkg` directory in the crate.
 pub fn create_pkg_dir(out_dir: &Path) -> Result<(), failure::Error> {
-    let _ = fs::remove_dir_all(&out_dir); // Clean up any existing directory and ignore errors
     fs::create_dir_all(&out_dir)?;
     fs::write(out_dir.join(".gitignore"), "*")?;
     Ok(())


### PR DESCRIPTION
A recent commit (d79e72189c523586debcee2ebbf6a2fd065e8abf) ensured that the `pkg` directory was removed as the first step of attempting to create it. Unfortunately, this causes a problem for [webpack](https://webpack.js.org/) when watching the `pkg` directory. Webpack is unable to recover its watching and so any watch server must be restarted, which is a blocker when using it.

Please note that there was [some debate](https://github.com/rustwasm/wasm-pack/pull/986#discussion_r676967231) about whether to remove the `pkg` directory. It is unclear to me what the actual benefits of it are, and whether this PR re-introduces some other problem. However, wasmpack appears to have existed as per the behaviour of this PR for a few years.

This PR reverses the change made in the above commit and fixes https://github.com/rustwasm/wasm-pack/issues/1099.