### PR TITLE
Make Deno target available

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -115,6 +115,7 @@ fn build_target_arg_legacy(target: Target, cli_path: &Path) -> Result<String, fa
             }
         }
         Target::Bundler => "--browser",
+        Target::Deno => "--deno",
     };
     Ok(target_arg.to_string())
 }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -55,6 +55,9 @@ pub enum Target {
     /// in a browser but pollutes the global namespace and must be manually
     /// instantiated.
     NoModules,
+    /// Correspond to `--target deno` where the output is natively usable as
+    /// a Deno module loaded with `import`.
+    Deno,
 }
 
 impl Default for Target {
@@ -70,6 +73,7 @@ impl fmt::Display for Target {
             Target::Web => "web",
             Target::Nodejs => "nodejs",
             Target::NoModules => "no-modules",
+            Target::Deno => "deno",
         };
         write!(f, "{}", s)
     }
@@ -83,6 +87,7 @@ impl FromStr for Target {
             "web" => Ok(Target::Web),
             "nodejs" => Ok(Target::Nodejs),
             "no-modules" => Ok(Target::NoModules),
+            "deno" => Ok(Target::Deno),
             _ => bail!("Unknown target: {}", s),
         }
     }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -590,6 +590,8 @@ impl CrateData {
             Target::NoModules => self.to_nomodules(scope, disable_dts, existing_deps, out_dir),
             Target::Bundler => self.to_esmodules(scope, disable_dts, existing_deps, out_dir),
             Target::Web => self.to_web(scope, disable_dts, existing_deps, out_dir),
+            // Deno does not need package.json
+            Target::Deno => return Ok(()),
         };
 
         let npm_json = serde_json::to_string_pretty(&npm_data)?;


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

This PR makes Deno available since `wasm-bindgen` does support it as a target now.
This PR continues the work done in https://github.com/rustwasm/wasm-pack/pull/908. I decided to push the discussed changes here as a separate PR as the original PR creator did not seem to be working on this anymore.

Related PR
https://github.com/rustwasm/wasm-pack/pull/908

Related issues
https://github.com/rustwasm/wasm-pack/issues/672
https://github.com/rustwasm/wasm-pack/issues/879