### PR TITLE
Clean up package.json from previous runs

### DIFF
--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -37,6 +37,7 @@ fn find_manifest_from_cwd() -> Result<PathBuf, failure::Error> {
 
 /// Construct our `pkg` directory in the crate.
 pub fn create_pkg_dir(out_dir: &Path) -> Result<(), failure::Error> {
+    let _ = fs::remove_file(out_dir.join("package.json")); // Clean up package.json from previous runs
     fs::create_dir_all(&out_dir)?;
     fs::write(out_dir.join(".gitignore"), "*")?;
     Ok(())


### PR DESCRIPTION
Remove the package.json file from previous runs to avoid crashes, as discussed in https://github.com/rustwasm/wasm-pack/pull/1110#issuecomment-1059008962