### PR TITLE
Bump `wasm-opt` to version 108.

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -207,7 +207,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String, failure::Error> {
         Tool::WasmOpt => {
             Ok(format!(
         "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_90",
+        vers = "version_108",
         target = target,
             ))
         }


### PR DESCRIPTION
Bump `wasm-opt` to version 108. Solves performance issues caused by the outdated version ()

Closes #1135. 

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text


