### PR TITLE
Use `bash` to create release tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
           mv wasm-pack-init.exe ${{ env.RELEASE_DIR }}
 
       - name: Create tarball
+        shell: bash
         run: 7z a -ttar -so -an ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }} | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target }}.tar.gz
 
       - name: Upload Zip


### PR DESCRIPTION
This PR fixes #1097 by using `bash` to create the tarball on Windows.

The issue was probably caused by the behaviour of the `|` operator with the default shell (PowerShell on Windows runners I believe).