### PR TITLE
fix: adds back run.js to npm installer

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "postinstall": "node ./install.js"
   },
+  "bin": {
+    "wasm-pack": "node ./run.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rustwasm/wasm-pack.git"


### PR DESCRIPTION
hopefully we can get this in before the release happens otherwise i fear the npm installer may break! i meant to open this PR sooner but just never got around to it. [this](https://github.com/apollographql/rover/pull/1108) is the patch i submitted to the primary repo I work on for comparison to this PR. 

We ended up burning [two](https://github.com/apollographql/rover/releases/tag/v0.5.2) [releases](https://github.com/apollographql/rover/releases/tag/v0.5.3) due to npm install woes, but things are working smoothly now. cc @drager 