### PR TITLE
In profiling mode, tell wasm-opt to retain debug symbols.

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -314,7 +314,9 @@ impl CargoWasmPackProfile {
                 demangle_name_section: Some(true),
                 dwarf_debug_info: Some(false),
             },
-            wasm_opt: Some(CargoWasmPackProfileWasmOpt::Enabled(true)),
+            wasm_opt: Some(CargoWasmPackProfileWasmOpt::ExplicitArgs(vec![
+                "--debuginfo".to_string(),
+            ])),
         }
     }
 


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
