### PR TITLE
Update init.sh

### DIFF
--- a/docs/_installer/init.sh
+++ b/docs/_installer/init.sh
@@ -136,7 +136,7 @@ get_architecture() {
     esac
 
     # See https://github.com/rustwasm/wasm-pack/pull/1088
-    if [ "$_cputype" == "aarch64" ] && [ "$_ostype" == "apple-darwin" ]; then
+    if [ "$_cputype" = "aarch64" ] && [ "$_ostype" = "apple-darwin" ]; then
         _cputype="x86_64"
     fi
 


### PR DESCRIPTION
Closes #1159 
https://stackoverflow.com/a/3411105/9784875
> POSIX sh doesn't understand == for string equality, as that is a bash-ism. Use = instead.
> The other people saying that brackets aren't supported by sh are wrong, btw.