### PR TITLE
Add new line at the end of package.json

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -594,7 +594,7 @@ impl CrateData {
             Target::Deno => return Ok(()),
         };
 
-        let npm_json = serde_json::to_string_pretty(&npm_data)?;
+        let npm_json = format!("{}\n", serde_json::to_string_pretty(&npm_data)?);
 
         fs::write(&pkg_file_path, npm_json)
             .with_context(|_| format!("failed to write: {}", pkg_file_path.display()))?;


### PR DESCRIPTION
Standard Javascript tools add a newline at the end of `package.json`.  

Closes #1161

