### PR TITLE
Add Linux arm64 support

### DIFF
--- a/npm/binary.js
+++ b/npm/binary.js
@@ -13,6 +13,9 @@ const getPlatform = () => {
   if (type === "Linux" && arch === "x64") {
     return "x86_64-unknown-linux-musl";
   }
+  if (type === "Linux" && arch === "arm64") {
+    return "aarch64-unknown-linux-musl";
+  }
   if (type === "Darwin" && (arch === "x64" || arch === "arm64")) {
     return "x86_64-apple-darwin";
   }


### PR DESCRIPTION
Adds support for Linux arm64 in the wasm-pack npm package.

Fixes: #1169 


Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
