### PR TITLE
Do not warn about missing license files if the crate is explicitly unlicensed

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -54,7 +54,11 @@ pub fn copy_from_crate(
         "crate's pkg directory should exist"
     );
 
-    match (crate_data.crate_license(), crate_data.crate_license_file()) {
+    match (
+        crate_data.crate_license().as_deref(),
+        crate_data.crate_license_file(),
+    ) {
+        (Some("NONE" | "LicenseRef-None"), _) => {}
         (Some(_), _) => {
             let license_files = glob_license_files(path);
 


### PR DESCRIPTION
`wasm-pack` emits a warning/information if the `license` field is either missing from a `Cargo.toml` or specified but a corresponding `LICENSE*` file is missing. This is the right behavior for most cases, however, some (e.g., proprietary) crates are explicitly unlicensed in which case this message adds extra clutter to build processes.

There seem to be two prevalent ways to indicate an unlicensed crate within the license field / SPDX license expressions:
- [`NONE` as declared in the spec.](https://spdx.github.io/spdx-spec/package-information/#713-concluded-license-field)
- [`LicenseRef-None` is also used for this purpose.](https://github.com/spdx/spdx-spec/issues/49#issuecomment-1135765779)

This PR suppresses the information message about missing license files if either value is found in the `Cargo.toml`'s license field.

<hr>

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
