### PR TITLE
Avoid running wasm-opt indefinitely

### DIFF
--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -30,14 +30,17 @@ pub fn run(
     let wasm_opt_path = wasm_opt.binary(&Tool::WasmOpt.to_string())?;
     PBAR.info("Optimizing wasm binaries with `wasm-opt`...");
 
+    let mut input_paths = Vec::new();
     for file in out_dir.read_dir()? {
         let file = file?;
         let path = file.path();
         if path.extension().and_then(|s| s.to_str()) != Some("wasm") {
             continue;
         }
-
-        let tmp = path.with_extension("wasm-opt.wasm");
+        input_paths.push(path);
+    }
+    for path in input_paths {
+        let tmp = path.with_extension("wasm-opt");
         let mut cmd = Command::new(&wasm_opt_path);
         cmd.arg(&path).arg("-o").arg(&tmp).args(args);
         child::run(cmd, "wasm-opt")?;


### PR DESCRIPTION
POSIX says [1]:

> If a file is removed from or added to the directory after the most recent
> call to opendir() or rewinddir(), whether a subsequent call to readdir()
> returns an entry for that file is unspecified.

Writing `wasm-opt` output, renaming in a same directory being `readdir()`-ed is unspecified, and can cause the `readdir()` to loop indefinitely on certain filesystems.

Fix it by collecting `readdir()` result first before making changes to the directory.

Resolves #1190.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/readdir.html

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
