### PR TITLE
Docs: Add wasm-pack test example for single test

### DIFF
--- a/docs/src/commands/test.md
+++ b/docs/src/commands/test.md
@@ -74,8 +74,11 @@ $ tree crates/foo
 # Run all tests in tests/diff_patch.rs in Firefox
 wasm-pack test crates/foo --firefox --headless --test diff_patch
 
-# Run all tests in tests/diff_patch.rs that contain the word "replace"
+# Run all tests in tests/diff_patch.rs that contain the word "replace" (does that still work?)
 wasm-pack test crates/foo --firefox --headless --test diff_patch replace
+
+# Run single test in tests/diff_patch.rs 
+wasm-pack test crates/foo --firefox --headless --test diff_patch -- modname::test_name
 
 # Run all tests inside of a `tests` module inside of src/lib/diff.rs
 wasm-pack test crates/foo --firefox --headless --lib diff::tests


### PR DESCRIPTION
The name-matching example for selecting tests didn't work for me. Maybe something changed in `wasm-pack` or `cargo test`?

However, specifying the full module+test name worked, like described in the cargo test docs: https://doc.rust-lang.org/cargo/commands/cargo-test.html

