### PR TITLE
fix comment as nightly is no longer used for cargo test

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -9,8 +9,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::process::Command;
 
-/// Run `cargo test` with the `nightly` toolchain and targeting
-/// `wasm32-unknown-unknown`.
+/// Run `cargo test` targeting `wasm32-unknown-unknown`.
 pub fn cargo_test_wasm<I, K, V>(
     path: &Path,
     release: bool,


### PR DESCRIPTION
Function comment incorrectly made reference to using the nightly toolchain. That requirement was removed a little while ago, but the comment had not been fixed.
