### PR TITLE
Tell bundler that the generated package has side effects. Closes #972.

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -737,7 +737,7 @@ impl CrateData {
             module: data.main,
             homepage: data.homepage,
             types: data.dts_file,
-            side_effects: false,
+            side_effects: true,
             keywords: data.keywords,
             dependencies,
         })
@@ -774,7 +774,7 @@ impl CrateData {
             module: data.main,
             homepage: data.homepage,
             types: data.dts_file,
-            side_effects: false,
+            side_effects: true,
             keywords: data.keywords,
             dependencies,
         })

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -93,7 +93,7 @@ fn it_creates_a_package_json_default_path() {
     );
     assert_eq!(pkg.module, "js_hello_world.js");
     assert_eq!(pkg.types, "js_hello_world.d.ts");
-    assert_eq!(pkg.side_effects, false);
+    assert_eq!(pkg.side_effects, true);
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
@@ -255,7 +255,7 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     );
     assert_eq!(pkg.module, "index.js");
     assert_eq!(pkg.types, "index.d.ts");
-    assert_eq!(pkg.side_effects, false);
+    assert_eq!(pkg.side_effects, true);
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> =

--- a/tests/all/utils/manifest.rs
+++ b/tests/all/utils/manifest.rs
@@ -21,7 +21,7 @@ pub struct NpmPackage {
     pub browser: String,
     #[serde(default = "default_none")]
     pub types: String,
-    #[serde(default = "default_false", rename = "sideEffects")]
+    #[serde(default = "default_true", rename = "sideEffects")]
     pub side_effects: bool,
     pub homepage: Option<String>,
     pub keywords: Option<Vec<String>>,
@@ -34,6 +34,10 @@ fn default_none() -> String {
 
 fn default_false() -> bool {
     false
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
This is a brutal fix for #972, that sets `sideEffects` to true for ES modules so that the Rust main function (annotated `#[wasm_bindgen(start)]`) is not tree-shaked. A better solution would be to detect if the main function is present in the Rust code and emit the `sideEffects` flag accordingly.