### PR TITLE
Respect package.readme in Cargo.toml

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -383,7 +383,7 @@ impl Build {
 
     fn step_copy_readme(&mut self) -> Result<()> {
         info!("Copying readme from crate...");
-        readme::copy_from_crate(&self.crate_path, &self.out_dir)?;
+        readme::copy_from_crate(&self.crate_data, &self.crate_path, &self.out_dir)?;
         info!("Copied readme from crate to {:#?}.", &self.out_dir);
         Ok(())
     }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -529,6 +529,14 @@ impl CrateData {
         }
     }
 
+    /// Gets the optional path to the readme, or None if disabled.
+    pub fn crate_readme(&self) -> Option<String> {
+        self.pkg()
+            .readme
+            .clone()
+            .map(|readme_file| readme_file.into_string())
+    }
+
     /// Get the license for the crate at the given path.
     pub fn crate_license(&self) -> &Option<String> {
         &self.pkg().license

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -4,10 +4,11 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
+use crate::manifest::CrateData;
 use crate::PBAR;
 
 /// Copy the crate's README into the `pkg` directory.
-pub fn copy_from_crate(path: &Path, out_dir: &Path) -> Result<()> {
+pub fn copy_from_crate(crate_data: &CrateData, path: &Path, out_dir: &Path) -> Result<()> {
     assert!(
         fs::metadata(path).ok().map_or(false, |m| m.is_dir()),
         "crate directory should exist"
@@ -17,7 +18,11 @@ pub fn copy_from_crate(path: &Path, out_dir: &Path) -> Result<()> {
         "crate's pkg directory should exist"
     );
 
-    let crate_readme_path = path.join("README.md");
+    let crate_readme_path = match crate_data.crate_readme() {
+        None => return Ok(()),
+        Some(readme_path) => path.join(readme_path),
+    };
+
     let new_readme_path = out_dir.join("README.md");
     if crate_readme_path.exists() {
         fs::copy(&crate_readme_path, &new_readme_path).context("failed to copy README")?;

--- a/tests/all/readme.rs
+++ b/tests/all/readme.rs
@@ -4,6 +4,9 @@ extern crate wasm_pack;
 use std::fs;
 
 use crate::utils::{self, fixture};
+use assert_cmd::prelude::*;
+use predicates::boolean::PredicateBooleanExt;
+use wasm_pack::manifest::CrateData;
 use wasm_pack::readme;
 
 #[test]
@@ -11,8 +14,9 @@ fn it_copies_a_readme_default_path() {
     let fixture = fixture::js_hello_world();
     let out_dir = fixture.path.join("pkg");
     fs::create_dir(&out_dir).expect("should create pkg directory OK");
+    let crate_data = CrateData::new(&fixture.path, None).unwrap();
 
-    assert!(readme::copy_from_crate(&fixture.path, &out_dir).is_ok());
+    assert!(readme::copy_from_crate(&crate_data, &fixture.path, &out_dir).is_ok());
 
     let crate_readme_path = fixture.path.join("README.md");
     let pkg_readme_path = out_dir.join("README.md");
@@ -32,12 +36,51 @@ fn it_copies_a_readme_default_path() {
 
 #[test]
 fn it_copies_a_readme_provided_path() {
-    let fixture = fixture::js_hello_world();
+    let fixture = fixture::Fixture::new();
+    fixture
+        .hello_world_src_lib()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            license = "WTFPL"
+            name = "js-hello-world"
+            readme = "docs/README.md"
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["cdylib"]
+
+            [dependencies]
+            # Note that this uses and `=` dependency because there are
+            # various tests which assert that the version of wasm
+            # bindgen downloaded is what we expect, and if `=` is
+            # removed then it will download whatever the newest version
+            # of wasm-bindgen is which may not be what's listed here.
+            wasm-bindgen = "=0.2.74"
+
+            [dev-dependencies]
+            wasm-bindgen-test = "0.3"
+        "#,
+        )
+        .file(
+            "docs/README.md",
+            r#"
+            # Fixture!
+            > an example rust -> wasm project
+        "#,
+        );
+
+    let crate_docs_dir = fixture.path.join("docs");
     let out_dir = fixture.path.join("pkg");
     fs::create_dir(&out_dir).expect("should create pkg directory OK");
+    let crate_data = CrateData::new(&fixture.path, None).unwrap();
 
-    assert!(readme::copy_from_crate(&fixture.path, &out_dir).is_ok());
-    let crate_readme_path = fixture.path.join("README.md");
+    assert!(readme::copy_from_crate(&crate_data, &fixture.path, &out_dir).is_ok());
+    let crate_readme_path = crate_docs_dir.join("README.md");
     let pkg_readme_path = out_dir.join("README.md");
     println!(
         "wasm-pack: should have copied README.md from '{}' to '{}'",
@@ -50,4 +93,43 @@ fn it_copies_a_readme_provided_path() {
     let crate_readme = utils::file::read_file(&crate_readme_path).unwrap();
     let pkg_readme = utils::file::read_file(&pkg_readme_path).unwrap();
     assert_eq!(crate_readme, pkg_readme);
+}
+
+#[test]
+fn it_ignores_a_disabled_readme() {
+    let fixture = fixture::Fixture::new();
+    fixture
+        .hello_world_src_lib()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            authors = ["The wasm-pack developers"]
+            description = "so awesome rust+wasm package"
+            name = "js-hello-world"
+            readme = false
+            repository = "https://github.com/rustwasm/wasm-pack.git"
+            version = "0.1.0"
+
+            [lib]
+            crate-type = ["cdylib"]
+
+            [dependencies]
+            # Note that this uses and `=` dependency because there are
+            # various tests which assert that the version of wasm
+            # bindgen downloaded is what we expect, and if `=` is
+            # removed then it will download whatever the newest version
+            # of wasm-bindgen is which may not be what's listed here.
+            wasm-bindgen = "=0.2.74"
+
+            [dev-dependencies]
+            wasm-bindgen-test = "0.3"
+        "#,
+        )
+        .license()
+        .wasm_pack()
+        .arg("build")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("origin crate has no README").not());
 }


### PR DESCRIPTION
Fixes #1215 by honoring how package.readme is authored in Cargo.toml, if authored. This could be a path or a boolean to disable searching for the path.

Also fixes the existing `it_copies_a_readme_provided_path` test which was an exact copy - just with fewer empty lines - of `it_copies_a_readme_default_path` and wasn't honoring any authored path since there was no way to get the authored path.
