### PR TITLE
Update JamesIves/github-pages-deploy-action in GHA workflow to v4.4.1

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -42,7 +42,7 @@ jobs:
           ./build-installer
 
       - name: Deploy book
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           branch: gh-pages


### PR DESCRIPTION
Updates the [`JamesIves/github-pages-deploy-action`](https://github.com/JamesIves/github-pages-deploy-action) action used in the GitHub Actions workflow to its newest version.

Still using an older version of `JamesIves/github-pages-deploy-action` will generate some warning like in this run: https://github.com/rustwasm/wasm-pack/actions/runs/4032230808

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions-rs/toolchain@v1, actions/cache@v2, JamesIves/github-pages-deploy-action@4.1.4. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `JamesIves/github-pages-deploy-action`, because v4.4.1 uses Node.js 16.