### PR TITLE
Mark snippets and the bundler target's main file as having side effects

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -723,10 +723,10 @@ impl CrateData {
                 url: repo_url,
             }),
             files: data.files,
-            module: data.main,
+            module: data.main.clone(),
             homepage: data.homepage,
             types: data.dts_file,
-            side_effects: false,
+            side_effects: vec![format!("./{}", data.main), "./snippets/*".to_owned()],
             keywords: data.keywords,
             dependencies,
         })
@@ -758,7 +758,7 @@ impl CrateData {
             module: data.main,
             homepage: data.homepage,
             types: data.dts_file,
-            side_effects: false,
+            side_effects: vec!["./snippets/*".to_owned()],
             keywords: data.keywords,
             dependencies,
         })

--- a/src/manifest/npm/esmodules.rs
+++ b/src/manifest/npm/esmodules.rs
@@ -22,7 +22,7 @@ pub struct ESModulesPackage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub types: Option<String>,
     #[serde(rename = "sideEffects")]
-    pub side_effects: bool,
+    pub side_effects: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keywords: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -93,7 +93,10 @@ fn it_creates_a_package_json_default_path() {
     );
     assert_eq!(pkg.module, "js_hello_world.js");
     assert_eq!(pkg.types, "js_hello_world.d.ts");
-    assert_eq!(pkg.side_effects, false);
+    assert_eq!(
+        pkg.side_effects,
+        vec!["./js_hello_world.js", "./snippets/*"]
+    );
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
@@ -255,7 +258,7 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     );
     assert_eq!(pkg.module, "index.js");
     assert_eq!(pkg.types, "index.d.ts");
-    assert_eq!(pkg.side_effects, false);
+    assert_eq!(pkg.side_effects, vec!["./index.js", "./snippets/*"]);
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> =

--- a/tests/all/utils/manifest.rs
+++ b/tests/all/utils/manifest.rs
@@ -21,8 +21,8 @@ pub struct NpmPackage {
     pub browser: String,
     #[serde(default = "default_none")]
     pub types: String,
-    #[serde(default = "default_false", rename = "sideEffects")]
-    pub side_effects: bool,
+    #[serde(default = "Vec::new", rename = "sideEffects")]
+    pub side_effects: Vec<String>,
     pub homepage: Option<String>,
     pub keywords: Option<Vec<String>>,
     pub dependencies: Option<HashMap<String, String>>,
@@ -30,10 +30,6 @@ pub struct NpmPackage {
 
 fn default_none() -> String {
     "".to_string()
-}
-
-fn default_false() -> bool {
-    false
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
This is a less extreme version of #1208, which only marks snippets and the main file on the bundler target as having side effects instead of all files.

This means that the JS shim file which contains the vast majority of the JS code is still properly marked as having no side effects, allowing bundlers to get rid of things like unused `new TextEncoder` calls which could theoretically have side effects but don't.

Fixes #972
Fixes rustwasm/wasm-bindgen#3276