### PR TITLE
Docs: Update npm installation link

### DIFF
--- a/docs/src/prerequisites/npm.md
+++ b/docs/src/prerequisites/npm.md
@@ -21,5 +21,5 @@ your package to the npm registry you'll need an npm account.
 You can find information about signing up for npm [here][npm-signup-info].
 
 [`npm link`]: https://docs.npmjs.com/cli/link
-[npm-install-info]: https://www.npmjs.com/get-npm
+[npm-install-info]: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 [npm-signup-info]: https://www.npmjs.com/signup


### PR DESCRIPTION
https://www.npmjs.com/get-npm doesn't immediately explain how to install npm anymore which can lead to some [confusion](https://www.reddit.com/r/rust/comments/10z5xyp/do_i_have_to_set_up_an_npm_account_to_do_rust_wasm/). https://docs.npmjs.com/downloading-and-installing-node-js-and-npm seems like the best page to link to instead.