### PR TITLE
fix(manifest/npm): set correct `sideEffects` for bundler target

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -14,6 +14,7 @@ use std::{collections::HashMap, fs};
 
 use self::npm::{
     repository::Repository, CommonJSPackage, ESModulesPackage, NoModulesPackage, NpmPackage,
+    SideEffects,
 };
 use crate::command::build::{BuildProfile, Target};
 use crate::PBAR;
@@ -723,10 +724,10 @@ impl CrateData {
                 url: repo_url,
             }),
             files: data.files,
-            module: data.main,
+            module: data.main.clone(),
             homepage: data.homepage,
             types: data.dts_file,
-            side_effects: false,
+            side_effects: SideEffects::StringVec([data.main].to_vec()),
             keywords: data.keywords,
             dependencies,
         })
@@ -758,7 +759,7 @@ impl CrateData {
             module: data.main,
             homepage: data.homepage,
             types: data.dts_file,
-            side_effects: false,
+            side_effects: SideEffects::Bool(false),
             keywords: data.keywords,
             dependencies,
         })

--- a/src/manifest/npm/esmodules.rs
+++ b/src/manifest/npm/esmodules.rs
@@ -3,6 +3,13 @@ use std::collections::HashMap;
 use crate::manifest::npm::repository::Repository;
 
 #[derive(Serialize)]
+#[serde(untagged)]
+pub enum SideEffects {
+    Bool(bool),
+    StringVec(Vec<String>),
+}
+
+#[derive(Serialize)]
 pub struct ESModulesPackage {
     pub name: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -22,7 +29,7 @@ pub struct ESModulesPackage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub types: Option<String>,
     #[serde(rename = "sideEffects")]
-    pub side_effects: bool,
+    pub side_effects: SideEffects,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keywords: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/manifest/npm/mod.rs
+++ b/src/manifest/npm/mod.rs
@@ -4,7 +4,7 @@ mod nomodules;
 pub mod repository;
 
 pub use self::commonjs::CommonJSPackage;
-pub use self::esmodules::ESModulesPackage;
+pub use self::esmodules::{ESModulesPackage, SideEffects};
 pub use self::nomodules::NoModulesPackage;
 
 #[derive(Serialize)]

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -3,6 +3,7 @@ use assert_cmd::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
+use utils::manifest::SideEffects;
 use wasm_pack::command::build::Target;
 use wasm_pack::command::utils::get_crate_path;
 use wasm_pack::{self, emoji, license, manifest};
@@ -93,7 +94,12 @@ fn it_creates_a_package_json_default_path() {
     );
     assert_eq!(pkg.module, "js_hello_world.js");
     assert_eq!(pkg.types, "js_hello_world.d.ts");
-    assert_eq!(pkg.side_effects, false);
+    assert_eq!(
+        pkg.side_effects,
+        Some(SideEffects::StringVec(
+            ["js_hello_world.js".to_string()].to_vec()
+        ))
+    );
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> = [
@@ -255,7 +261,10 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     );
     assert_eq!(pkg.module, "index.js");
     assert_eq!(pkg.types, "index.d.ts");
-    assert_eq!(pkg.side_effects, false);
+    assert_eq!(
+        pkg.side_effects,
+        Some(SideEffects::StringVec(["index.js".to_string()].to_vec()))
+    );
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
     let expected_files: HashSet<String> =

--- a/tests/all/utils/manifest.rs
+++ b/tests/all/utils/manifest.rs
@@ -21,8 +21,8 @@ pub struct NpmPackage {
     pub browser: String,
     #[serde(default = "default_none")]
     pub types: String,
-    #[serde(default = "default_false", rename = "sideEffects")]
-    pub side_effects: bool,
+    #[serde(rename = "sideEffects")]
+    pub side_effects: Option<SideEffects>,
     pub homepage: Option<String>,
     pub keywords: Option<Vec<String>>,
     pub dependencies: Option<HashMap<String, String>>,
@@ -32,8 +32,11 @@ fn default_none() -> String {
     "".to_string()
 }
 
-fn default_false() -> bool {
-    false
+#[derive(Deserialize, PartialEq, Debug)]
+#[serde(untagged)]
+pub enum SideEffects {
+    Bool(bool),
+    StringVec(Vec<String>),
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

Fix #1235. Set `sideEffects` to the entry file for `bundler` target while keep `false` for `web` target.