### PR TITLE
fix: wasm-pack bin script entry

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node ./install.js"
   },
   "bin": {
-    "wasm-pack": "node ./run.js"
+    "wasm-pack": "./run.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A bin entry in a package.json has to be a local file and not a command to be linked by a package manager.

See https://docs.npmjs.com/cli/v9/configuring-npm/package-json#bin
> To use this, supply a bin field in your package.json which is a map of command name to local file name.

this fixes #1248 