### PR TITLE
Use correct path name for locally-installed wasm-opt.

### DIFF
--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -23,7 +23,7 @@ pub fn run(cache: &Cache, out_dir: &Path, args: &[String], install_permitted: bo
         }
     };
 
-    let wasm_opt_path = wasm_opt.binary("bin/wasm-opt")?;
+    let wasm_opt_path = wasm_opt.binary("wasm-opt")?;
     PBAR.info("Optimizing wasm binaries with `wasm-opt`...");
 
     for file in out_dir.read_dir()? {


### PR DESCRIPTION
If wasm-opt is installed in `/usr/bin/wasm-opt`, the previous code tried to execute `/usr/bin/bin/wasm-opt` which of course doesn't exist.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
