### PR TITLE
fix: the path to wasm-opt was incorrect causing wasm-pack build command to fail

### DIFF
--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -23,7 +23,7 @@ pub fn run(cache: &Cache, out_dir: &Path, args: &[String], install_permitted: bo
         }
     };
 
-    let wasm_opt_path = wasm_opt.binary("bin/wasm-opt")?;
+    let wasm_opt_path = wasm_opt.binary(&install::Tool::WasmOpt.to_string())?;
     PBAR.info("Optimizing wasm binaries with `wasm-opt`...");
 
     for file in out_dir.read_dir()? {


### PR DESCRIPTION
Fixes #1263 

```console
$ ................./github.com/rustwasm/wasm-pack/target/debug/wasm-pack build
[INFO]: 🎯  Checking for the Wasm target...
[INFO]: 🌀  Compiling to Wasm...
   Compiling proc-macro2 v1.0.54
   Compiling quote v1.0.26
   Compiling unicode-ident v1.0.8
   Compiling log v0.4.17
   Compiling syn v1.0.109
   Compiling wasm-bindgen-shared v0.2.84
   Compiling cfg-if v1.0.0
   Compiling bumpalo v3.12.0
   Compiling once_cell v1.17.1
   Compiling wasm-bindgen v0.2.84
   Compiling wasm-bindgen-backend v0.2.84
   Compiling wasm-bindgen-macro-support v0.2.84
   Compiling wasm-bindgen-macro v0.2.84
   Compiling startfunc v0.1.0 (................./startfunc)
    Finished release [optimized] target(s) in 10.27s
[INFO]: ⬇️  Installing wasm-bindgen...
[INFO]: found wasm-opt at "/usr/local/bin/wasm-opt"
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[INFO]: Optional fields missing from Cargo.toml: 'description', 'repository', and 'license'. These are not necessary, but recommended
[INFO]: ✨   Done in 10.67s
[INFO]: 📦   Your wasm pkg is ready to publish at ................./startfunc/pkg.
```
---

Make sure these boxes are checked! 📦✅

- [✅] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [✅] You ran `cargo fmt` on the code base before submitting
- [✅] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
