### PR TITLE
fix: bump cargo-generate version to 0.18.2 (#1245)

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -194,7 +194,7 @@ pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Res
         Tool::CargoGenerate => {
             Ok(format!(
                 "https://github.com/cargo-generate/cargo-generate/releases/download/v{0}/cargo-generate-v{0}-{1}.tar.gz",
-                "0.17.3",
+                "0.18.2",
                 target
             ))
         },


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
