### PR TITLE
Pass target to compilation time.

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -77,17 +77,19 @@ pub fn cargo_build_wasm(
     path: &Path,
     profile: BuildProfile,
     extra_options: &[String],
+    curr_target: &str,
 ) -> Result<()> {
     let msg = format!("{}Compiling to Wasm...", emoji::CYCLONE);
     PBAR.info(&msg);
 
     let mut cmd = Command::new("cargo");
+    cmd.env("RUSTFLAGS", format!("--cfg=wasmpack_target=\"{}\"", curr_target));
     cmd.current_dir(path).arg("build").arg("--lib");
 
     if PBAR.quiet() {
         cmd.arg("--quiet");
     }
-
+    
     match profile {
         BuildProfile::Profiling => {
             // Once there are DWARF debug info consumers, force enable debug

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -83,13 +83,16 @@ pub fn cargo_build_wasm(
     PBAR.info(&msg);
 
     let mut cmd = Command::new("cargo");
-    cmd.env("RUSTFLAGS", format!("--cfg=wasmpack_target=\"{}\"", curr_target));
+    cmd.env(
+        "RUSTFLAGS",
+        format!("--cfg=wasmpack_target=\"{}\"", curr_target),
+    );
     cmd.current_dir(path).arg("build").arg("--lib");
 
     if PBAR.quiet() {
         cmd.arg("--quiet");
     }
-    
+
     match profile {
         BuildProfile::Profiling => {
             // Once there are DWARF debug info consumers, force enable debug

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -333,7 +333,12 @@ impl Build {
 
     fn step_build_wasm(&mut self) -> Result<()> {
         info!("Building wasm...");
-        build::cargo_build_wasm(&self.crate_path, self.profile, &self.extra_options, self.target.to_string().as_str())?;
+        build::cargo_build_wasm(
+            &self.crate_path,
+            self.profile,
+            &self.extra_options,
+            self.target.to_string().as_str(),
+        )?;
 
         info!(
             "wasm built at {:#?}.",

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -333,7 +333,7 @@ impl Build {
 
     fn step_build_wasm(&mut self) -> Result<()> {
         info!("Building wasm...");
-        build::cargo_build_wasm(&self.crate_path, self.profile, &self.extra_options)?;
+        build::cargo_build_wasm(&self.crate_path, self.profile, &self.extra_options, self.target.to_string().as_str())?;
 
         info!(
             "wasm built at {:#?}.",


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [ x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x ] You ran `cargo fmt` on the code base before submitting
- [x ] You reference which issue is being closed in the PR text

This PR is to provide the function that we can pass the target to compilation time.
See #795 
