### PR TITLE
Add wasmbindgen option: `omit_default_module_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1031,6 +1031,8 @@
     demangle-name-section = true
     # Should we emit the DWARF debug info custom sections?
     dwarf-debug-info = false
+    # Should we omit the default import path?
+    omit-default-module-path = false
     ```
 
     As always- there are defaults for you to use, but if you love to configure (or have a project that requires it),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1031,8 +1031,6 @@
     demangle-name-section = true
     # Should we emit the DWARF debug info custom sections?
     dwarf-debug-info = false
-    # Should we omit the default import path?
-    omit-default-module-path = false
     ```
 
     As always- there are defaults for you to use, but if you love to configure (or have a project that requires it),

--- a/docs/src/cargo-toml-configuration.md
+++ b/docs/src/cargo-toml-configuration.md
@@ -27,6 +27,8 @@ debug-js-glue = true
 demangle-name-section = true
 # Should we emit the DWARF debug info custom sections?
 dwarf-debug-info = false
+# Should we omit the default import path?
+omit-default-module-path = false
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = ['-O']
@@ -35,6 +37,7 @@ wasm-opt = ['-O']
 debug-js-glue = false
 demangle-name-section = true
 dwarf-debug-info = false
+omit-default-module-path = false
 
 # `wasm-opt` is on by default in for the release profile, but it can be
 # disabled by setting it to `false`
@@ -45,4 +48,5 @@ wasm-opt = false
 debug-js-glue = false
 demangle-name-section = true
 dwarf-debug-info = false
+omit-default-module-path = false
 ```

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -91,6 +91,9 @@ pub fn wasm_bindgen_build(
     if profile.wasm_bindgen_dwarf_debug_info() {
         cmd.arg("--keep-debug");
     }
+    if profile.wasm_bindgen_omit_default_module_path() {
+        cmd.arg("--omit-default-module-path");
+    }
 
     child::run(cmd, "wasm-bindgen").context("Running the wasm-bindgen CLI")?;
     Ok(())

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -118,6 +118,9 @@ struct CargoWasmPackProfileWasmBindgen {
 
     #[serde(default, rename = "dwarf-debug-info")]
     dwarf_debug_info: Option<bool>,
+
+    #[serde(default, rename = "omit-default-module-path")]
+    omit_default_module_path: Option<bool>,
 }
 
 struct Collector(Vec<u8>);
@@ -283,6 +286,7 @@ impl CargoWasmPackProfile {
                 debug_js_glue: Some(true),
                 demangle_name_section: Some(true),
                 dwarf_debug_info: Some(false),
+                omit_default_module_path: Some(false),
             },
             wasm_opt: None,
         }
@@ -294,6 +298,7 @@ impl CargoWasmPackProfile {
                 debug_js_glue: Some(false),
                 demangle_name_section: Some(true),
                 dwarf_debug_info: Some(false),
+                omit_default_module_path: Some(false),
             },
             wasm_opt: Some(CargoWasmPackProfileWasmOpt::Enabled(true)),
         }
@@ -305,6 +310,7 @@ impl CargoWasmPackProfile {
                 debug_js_glue: Some(false),
                 demangle_name_section: Some(true),
                 dwarf_debug_info: Some(false),
+                omit_default_module_path: Some(false),
             },
             wasm_opt: Some(CargoWasmPackProfileWasmOpt::Enabled(true)),
         }
@@ -346,6 +352,7 @@ impl CargoWasmPackProfile {
         d!(wasm_bindgen.debug_js_glue);
         d!(wasm_bindgen.demangle_name_section);
         d!(wasm_bindgen.dwarf_debug_info);
+        d!(wasm_bindgen.omit_default_module_path);
 
         if self.wasm_opt.is_none() {
             self.wasm_opt = defaults.wasm_opt.clone();
@@ -365,6 +372,11 @@ impl CargoWasmPackProfile {
     /// Get this profile's configured `[wasm-bindgen.dwarf-debug-info]` value.
     pub fn wasm_bindgen_dwarf_debug_info(&self) -> bool {
         self.wasm_bindgen.dwarf_debug_info.unwrap()
+    }
+
+    /// Get this profile's configured `[wasm-bindgen.omit-default-module-path]` value.
+    pub fn wasm_bindgen_omit_default_module_path(&self) -> bool {
+        self.wasm_bindgen.omit_default_module_path.unwrap()
     }
 
     /// Get this profile's configured arguments for `wasm-opt`, if enabled.


### PR DESCRIPTION
There is currently no option to run `wasm-bindgen` with `--omit_default_module_path`.

This is relevant for projects that run in a context where usage of `input = new URL('file.wasm', import.meta.url);` is [causing problems](https://github.com/vitejs/vite/issues/5087) (e.g., in web workers).

This PR adds the option to run `wasm-bindgen` with `--omit_default_module_path`.
Reference: https://rustwasm.github.io/wasm-bindgen/reference/cli.html?highlight=omit#--omit-default-module-path