### PR TITLE
Fix path to 'wasm-opt'

### DIFF
--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -52,7 +52,7 @@ pub fn find_wasm_opt(cache: &Cache, install_permitted: bool) -> Result<Option<Pa
     }
 
     match install::download_prebuilt(&install::Tool::WasmOpt, cache, "latest", install_permitted)? {
-        install::Status::Found(download) => Ok(Some(download.binary("bin/wasm-opt")?)),
+        install::Status::Found(download) => Ok(Some(download.binary("wasm-opt")?)),
         install::Status::CannotInstall => {
             PBAR.info("Skipping wasm-opt as no downloading was requested");
             Ok(None)


### PR DESCRIPTION
Fixes #1263

Fix typo of path to 'wasm-opt'

30f2b0a26232b54c8ab7e2e09751170f52856eab

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
