### PR TITLE
Fix getting the target-dir in wasm_bindgen_build

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -29,17 +29,14 @@ pub fn wasm_bindgen_build(
     };
 
     let out_dir = out_dir.to_str().unwrap();
-    let has_target_dir_overwrite = extra_options.contains(&"--target-dir".to_string());
-    let target_directory = if has_target_dir_overwrite {
-        let i = extra_options
-            .binary_search(&"--target-dir".to_string())
-            .unwrap();
-        extra_options
-            .get(i + 1)
+
+    let target_directory = {
+        let mut has_target_dir_iter = extra_options.iter();
+        has_target_dir_iter
+            .find(|&it| it == "--target-dir")
+            .and_then(|_| has_target_dir_iter.next())
             .map(Path::new)
             .unwrap_or(data.target_directory())
-    } else {
-        data.target_directory()
     };
 
     let wasm_path = target_directory

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -38,6 +38,20 @@ fn it_should_not_make_a_pkg_json_if_passed_no_pack() {
 }
 
 #[test]
+fn it_should_build_js_hello_world_example_with_custom_target_dir() {
+    let fixture = utils::fixture::js_hello_world();
+    fixture
+        .wasm_pack()
+        .arg("build")
+        .arg("--target-dir")
+        .arg("target2")
+        .arg("--all-features")
+        .arg("--offline")
+        .assert()
+        .success();
+}
+
+#[test]
 fn it_should_build_crates_in_a_workspace() {
     let fixture = utils::fixture::Fixture::new();
     fixture


### PR DESCRIPTION
Fixes #1278

The bug was caused by using [binary_search](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.binary_search) on `extra_options` which is not sorted.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

