### PR TITLE
fix: removes `--always-auth` from `npm login`

### DIFF
--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -6,7 +6,6 @@ use log::info;
 pub fn login(
     registry: Option<String>,
     scope: &Option<String>,
-    always_auth: bool,
     auth_type: &Option<String>,
 ) -> Result<()> {
     let registry = registry.unwrap_or_else(|| npm::DEFAULT_NPM_REGISTRY.to_string());
@@ -17,7 +16,7 @@ pub fn login(
         &scope, &registry, always_auth, &auth_type
     );
     info!("npm info located in the npm debug log");
-    npm::npm_login(&registry, &scope, always_auth, &auth_type)?;
+    npm::npm_login(&registry, &scope, &auth_type)?;
     info!("Logged you in!");
 
     PBAR.info(&"👋  logged you in!".to_string());

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -12,8 +12,8 @@ pub fn login(
 
     info!("Logging in to npm...");
     info!(
-        "Scope: {:?} Registry: {}, Always Auth: {}, Auth Type: {:?}.",
-        &scope, &registry, always_auth, &auth_type
+        "Scope: {:?} Registry: {}, Auth Type: {:?}.",
+        &scope, &registry, &auth_type
     );
     info!("npm info located in the npm debug log");
     npm::npm_login(&registry, &scope, &auth_type)?;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -91,12 +91,6 @@ pub enum Command {
         /// associated with the specified scope.
         scope: Option<String>,
 
-        #[structopt(long = "always-auth", short = "a")]
-        /// If specified, save configuration indicating that all requests to the
-        /// given registry should include authorization information. Useful for
-        /// private registries. Can be used with --registry and / or --scope
-        always_auth: bool,
-
         #[structopt(long = "auth-type", short = "t")]
         /// Default: 'legacy'.
         /// Type: 'legacy', 'sso', 'saml', 'oauth'.
@@ -148,15 +142,14 @@ pub fn run_wasm_pack(command: Command) -> Result<()> {
         Command::Login {
             registry,
             scope,
-            always_auth,
             auth_type,
         } => {
             info!("Running login command...");
             info!(
-                "Registry: {:?}, Scope: {:?}, Always Auth: {}, Auth Type: {:?}",
-                &registry, &scope, &always_auth, &auth_type
+                "Registry: {:?}, Scope: {:?}, Auth Type: {:?}",
+                &registry, &scope, &auth_type
             );
-            login(registry, &scope, always_auth, &auth_type)
+            login(registry, &scope, &auth_type)
         }
         Command::Test(test_opts) => {
             info!("Running test command...");

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -32,20 +32,11 @@ pub fn npm_publish(path: &str, access: Option<Access>, tag: Option<String>) -> R
 }
 
 /// Run the `npm login` command.
-pub fn npm_login(
-    registry: &str,
-    scope: &Option<String>,
-    always_auth: bool,
-    auth_type: &Option<String>,
-) -> Result<()> {
+pub fn npm_login(registry: &str, scope: &Option<String>, auth_type: &Option<String>) -> Result<()> {
     let mut args = vec!["login".to_string(), format!("--registry={}", registry)];
 
     if let Some(scope) = scope {
         args.push(format!("--scope={}", scope));
-    }
-
-    if always_auth {
-        args.push("--always_auth".to_string());
     }
 
     if let Some(auth_type) = auth_type {


### PR DESCRIPTION
`npm login` doesn't support `--always-auth` anymore, instead it is under the [`adduser` subcommand][1].

[1]: https://docs.npmjs.com/cli/v6/commands/npm-adduser#always-auth

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [-] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
