### PR TITLE
Turn off cargo colors during log level test

### DIFF
--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -351,6 +351,10 @@ impl Fixture {
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.current_dir(&self.path);
         cmd.env("WASM_PACK_CACHE", self.cache_dir());
+
+        // Some of the tests assume that Cargo's output does not contain colors.
+        cmd.env_remove("CARGO_TERM_COLOR");
+
         cmd
     }
 


### PR DESCRIPTION
Without this, some tests fail if Cargo prints any colors in its output.

````console
$ CARGO_TERM_COLOR=always cargo test --all --locked
...
failures:

---- log_level::log_level_error stdout ----
Created fixture at /git/tmp/wasm-pack/target/t/.tmpOZ8y7e/wasm-pack
thread 'log_level::log_level_error' panicked at 'Unexpected stderr, failed ((var.contains(Finished release [optimized] target(s) in ) && (! var.contains([WARN]: ⚠️   origin crate has no README))) && (! (((((var.contains([INFO]: 🎯  Checking for the Wasm target...) && var.contains([INFO]: 🌀  Compiling to Wasm...)) && var.contains([INFO]: License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory)) && var.contains([INFO]: Optimizing wasm binaries with `wasm-opt`...)) && var.contains([INFO]: ✨   Done in )) && var.contains([INFO]: 📦   Your wasm pkg is ready to publish at ))))
├── var as str:     Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on package cache
│       Finished release [optimized] target(s) in 2.01s
└── (var.contains(Finished release [optimized] target(s) in ) && (! var.contains([WARN]: ⚠️   origin crate has no README)))
    └── var.contains(Finished release [optimized] target(s) in )
        └── var:     Blocking waiting for file lock on package cache
                Blocking waiting for file lock on package cache
                Blocking waiting for file lock on package cache
                Finished release [optimized] target(s) in 2.01s

command=`cd "/git/tmp/wasm-pack/target/t/.tmpOZ8y7e/wasm-pack" && WASM_PACK_CACHE="/git/tmp/wasm-pack/target/test_cache" "/git/tmp/wasm-pack/target/debug/wasm-pack" "--log-level" "error" "build"`
code=0
stdout=""
stderr=```
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[32m    Finished\u{1b}[0m release [optimized] target(s) in 2.01s
```

', /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/core/src/ops/function.rs:250:5

---- log_level::log_level_warn stdout ----
Created fixture at /git/tmp/wasm-pack/target/t/.tmpEmPy7P/wasm-pack
thread 'log_level::log_level_warn' panicked at 'Unexpected stderr, failed ((var.contains(Finished release [optimized] target(s) in ) && var.contains([WARN]: ⚠️   origin crate has no README)) && (! (((((var.contains([INFO]: 🎯  Checking for the Wasm target...) && var.contains([INFO]:   Compiling to Wasm...)) && var.contains([INFO]: License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory)) && var.contains([INFO]: Optimizing wasm binaries with `wasm-opt`...)) && var.contains([INFO]: ✨   Done in )) && var.contains([INFO]: 📦   Your wasm pkg is ready to publish at ))))
├── var as str:     Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on build directory
│       Finished release [optimized] target(s) in 2.51s
│   [WARN]: ⚠️   origin crate has no README
└── (var.contains(Finished release [optimized] target(s) in ) && var.contains([WARN]: ⚠️   origin crate has no README))
    └── var.contains(Finished release [optimized] target(s) in )
        └── var:     Blocking waiting for file lock on package cache
                Blocking waiting for file lock on package cache
                Blocking waiting for file lock on package cache
                Blocking waiting for file lock on package cache
                Blocking waiting for file lock on build directory
                Finished release [optimized] target(s) in 2.51s
            [WARN]: ⚠️   origin crate has no README

command=`cd "/git/tmp/wasm-pack/target/t/.tmpEmPy7P/wasm-pack" && WASM_PACK_CACHE="/git/tmp/wasm-pack/target/test_cache" "/git/tmp/wasm-pack/target/debug/wasm-pack" "--log-level" "warn" "build"`
code=0
stdout=""
stderr=```
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on build directory
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[32m    Finished\u{1b}[0m release [optimized] target(s) in 2.51s
[WARN]: ⚠\u{fe0f}   origin crate has no README
```

', /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/core/src/ops/function.rs:250:5

---- log_level::log_level_info stdout ----
Created fixture at /git/tmp/wasm-pack/target/t/.tmpyOqVXG/wasm-pack
thread 'log_level::log_level_info' panicked at 'Unexpected stderr, failed ((var.contains(Finished release [optimized] target(s) in ) && var.contains([WARN]: ⚠️   origin crate has no README)) && (((((var.contains([INFO]: 🎯  Checking for the Wasm target...) && var.contains([INFO]: 🌀  Compiling to Wasm...)) && var.contains([INFO]: License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory)) && var.contains([INFO]: Optimizing wasm binaries with `wasm-opt`...)) && var.contains([INFO]: ✨   Done in )) && var.contains([INFO]: 📦   Your wasm pkg is ready to publish at )))
├── var as str: [INFO]: 🎯  Checking for the Wasm target...
│   [INFO]: 🌀  Compiling to Wasm...
│       Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on package cache
│       Blocking waiting for file lock on build directory
│       Finished release [optimized] target(s) in 2.38s
│   [INFO]: ⬇️  Installing wasm-bindgen...
│   [INFO]: found wasm-opt at "/usr/bin/wasm-opt"
│   [INFO]: Optimizing wasm binaries with `wasm-opt`...
│   [WARN]: ⚠️   origin crate has no README
│   [INFO]: License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory
│   [INFO]: ✨   Done in 2.71s
│   [INFO]: 📦   Your wasm pkg is ready to publish at /git/tmp/wasm-pack/target/t/.tmpyOqVXG/wasm-pack/pkg.
└── (var.contains(Finished release [optimized] target(s) in ) && var.contains([WARN]: ⚠️   origin crate has no README))
    └── var.contains(Finished release [optimized] target(s) in )
        └── var: [INFO]: 🎯  Checking for the Wasm target...
            [INFO]: 🌀  Compiling to Wasm...
                Blocking waiting for file lock on package cache
                Blocking waiting for file lock on package cache
                Blocking waiting for file lock on package cache
                Blocking waiting for file lock on package cache
                Blocking waiting for file lock on build directory
                Finished release [optimized] target(s) in 2.38s
            [INFO]: ⬇️  Installing wasm-bindgen...
            [INFO]: found wasm-opt at "/usr/bin/wasm-opt"
            [INFO]: Optimizing wasm binaries with `wasm-opt`...
            [WARN]: ⚠️   origin crate has no README
            [INFO]: License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory
            [INFO]: ✨   Done in 2.71s
            [INFO]: 📦   Your wasm pkg is ready to publish at /git/tmp/wasm-pack/target/t/.tmpyOqVXG/wasm-pack/pkg.

command=`cd "/git/tmp/wasm-pack/target/t/.tmpyOqVXG/wasm-pack" && WASM_PACK_CACHE="/git/tmp/wasm-pack/target/test_cache" "/git/tmp/wasm-pack/target/debug/wasm-pack" "--log-level" "info" "build"`
code=0
stdout=""
stderr=```
[INFO]: 🎯  Checking for the Wasm target...
[INFO]: 🌀  Compiling to Wasm...
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on package cache
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[36m    Blocking\u{1b}[0m waiting for file lock on build directory
\u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[32m    Finished\u{1b}[0m release [optimized] target(s) in 2.38s
[INFO]: ⬇\u{fe0f}  Installing wasm-bindgen...
[INFO]: found wasm-opt at \"/usr/bin/wasm-opt\"
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[WARN]: ⚠\u{fe0f}   origin crate has no README
[INFO]: License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory
[INFO]: ✨   Done in 2.71s
[INFO]: 📦   Your wasm pkg is ready to publish at /git/tmp/wasm-pack/target/t/.tmpyOqVXG/wasm-pack/pkg.
```

', /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/core/src/ops/function.rs:250:5


failures:
    log_level::log_level_error
    log_level::log_level_info
    log_level::log_level_warn
````