### PR TITLE
Restore --version command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub static PBAR: ProgressOutput = ProgressOutput::new();
 
 /// 📦 ✨  pack and publish your wasm!
 #[derive(Debug, Parser)]
+#[command(version)]
 pub struct Cli {
     /// The subcommand to run.
     #[clap(subcommand)] // Note that we mark a field as a subcommand


### PR DESCRIPTION
Fixes #1301, which was introduced by 73e059f754948ecd794a3809953bc5d49b93dce4.

It prints `wasm-pack 0.12.0`, just like wasm-pack 0.11.0 printed `wasm-pack 0.11.0`. That is to say: clap 4 formats the version the same way as structopt. It also adds the same `-V` short alias that structopt does.