### PR TITLE
Fix value parser for `Option<PathBuf>`

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -18,7 +18,6 @@ use self::publish::{access::Access, publish};
 use self::test::{Test, TestOptions};
 use crate::install::InstallMode;
 use anyhow::Result;
-use clap::builder::ValueParser;
 use clap::Subcommand;
 use log::info;
 use std::path::PathBuf;
@@ -33,7 +32,7 @@ pub enum Command {
     /// 🍱  create a tar of your npm package but don't publish!
     Pack {
         /// The path to the Rust crate. If not set, searches up the path from the current directory.
-        #[clap(value_parser = ValueParser::os_string())]
+        #[clap()]
         path: Option<PathBuf>,
     },
 
@@ -70,7 +69,7 @@ pub enum Command {
         tag: Option<String>,
 
         /// The path to the Rust crate. If not set, searches up the path from the current directory.
-        #[clap(value_parser = ValueParser::os_string())]
+        #[clap()]
         path: Option<PathBuf>,
     },
 

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -9,7 +9,6 @@ use crate::manifest;
 use crate::test::{self, webdriver};
 use anyhow::{bail, Result};
 use binary_install::Cache;
-use clap::builder::ValueParser;
 use clap::Args;
 use console::style;
 use log::info;
@@ -32,7 +31,7 @@ pub struct TestOptions {
     /// copy.
     pub firefox: bool,
 
-    #[clap(long = "geckodriver", value_parser = ValueParser::os_string())]
+    #[clap(long = "geckodriver")]
     /// The path to the `geckodriver` WebDriver client for testing in
     /// Firefox. Implies `--firefox`.
     pub geckodriver: Option<PathBuf>,
@@ -44,7 +43,7 @@ pub struct TestOptions {
     /// copy.
     pub chrome: bool,
 
-    #[clap(long = "chromedriver", value_parser = ValueParser::os_string())]
+    #[clap(long = "chromedriver")]
     /// The path to the `chromedriver` WebDriver client for testing in
     /// Chrome. Implies `--chrome`.
     pub chromedriver: Option<PathBuf>,
@@ -56,7 +55,7 @@ pub struct TestOptions {
     /// download the `safaridriver` WebDriver client for you.
     pub safari: bool,
 
-    #[clap(long = "safaridriver", value_parser = ValueParser::os_string())]
+    #[clap(long = "safaridriver")]
     /// The path to the `safaridriver` WebDriver client for testing in
     /// Safari. Implies `--safari`.
     pub safaridriver: Option<PathBuf>,


### PR DESCRIPTION
A value parser for `OsString` cannot parse a command line argument for `Option<PathBuf>`, which let it failed to specify paths for `pack`, `publish` and `test` commands, which was introduced by https://github.com/rustwasm/wasm-pack/commit/73e059f754948ecd794a3809953bc5d49b93dce4.

close #1304.

```bash
$ ./target/debug/wasm-pack publish abc
thread 'main' panicked at 'Mismatch between definition and access of `path`. Could not downcast to std::path::PathBuf, need to downcast to std::ffi::os_str::OsString
', src/command/mod.rs:74:15
```

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
