### PR TITLE
Fix error and warnings in install script

### DIFF
--- a/docs/_installer/init.sh
+++ b/docs/_installer/init.sh
@@ -42,7 +42,7 @@ main() {
 
     which rustup > /dev/null 2>&1
     need_ok "failed to find Rust installation, is rustup installed?"
-    local _rustup=`which rustup`
+    local _rustup=$(which rustup)
     local _tardir="wasm-pack-$VERSION-${_arch}"
     local _url="$UPDATE_ROOT/${_tardir}.tar.gz"
     local _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t wasm-pack)"
@@ -98,7 +98,7 @@ get_architecture() {
     set -u
 
 
-    if [ "$_ostype" = Darwin -a "$_cputype" = i386 ]; then
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
         # Darwin `uname -s` lies
         if sysctl hw.optional.x86_64 | grep -q ': 1'; then
             local _cputype=x86_64
@@ -136,7 +136,7 @@ get_architecture() {
     esac
 
     # See https://github.com/rustwasm/wasm-pack/pull/1088
-    if [ "$_cputype" == "aarch64" ] && [ "$_ostype" == "apple-darwin" ]; then
+    if [ "$_cputype" = "aarch64" ] && [ "$_ostype" = "apple-darwin" ]; then
         _cputype="x86_64"
     fi
 


### PR DESCRIPTION
- Fixed error on line 139 - "==" was being used, whereas sh expects a "=" (and we do this correctly throughout the rest of the file). See https://www.shellcheck.net/wiki/SC3014 for more.
- Changed the use of backticks to the use of `$()` as specified in https://www.shellcheck.net/wiki/SC2006
- Changed the use of `-a` to `&&` as specified in https://www.shellcheck.net/wiki/SC2166

Closes #1159 
Closes #1217
Closes #1283

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
