### PR TITLE
Fix binary tool version check

### DIFF
--- a/src/install/krate.rs
+++ b/src/install/krate.rs
@@ -1,5 +1,6 @@
 use crate::install::Tool;
 use anyhow::Result;
+use log::debug;
 use serde::Deserialize;
 const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
 
@@ -25,6 +26,10 @@ impl Krate {
             .call()?;
 
         let kr: KrateResponse = res.into_json()?;
+        debug!(
+            "Latest `{name}` version on crates.io is {}",
+            kr.krate.max_version
+        );
         Ok(kr.krate)
     }
 }

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -99,7 +99,7 @@ pub fn check_version(tool: &Tool, path: &Path, expected_version: &str) -> Result
 
     let v = get_cli_version(tool, path)?;
     info!(
-        "Checking installed `{}` version == expected version: {} == {}",
+        r#"Checking installed `{}` version == expected version: "{}" == "{}""#,
         tool, v, &expected_version
     );
     Ok(v == expected_version)
@@ -110,7 +110,7 @@ pub fn get_cli_version(tool: &Tool, path: &Path) -> Result<String> {
     let mut cmd = Command::new(path);
     cmd.arg("--version");
     let stdout = child::run_capture_stdout(cmd, tool)?;
-    let version = stdout.trim().split_whitespace().nth(1);
+    let version = stdout.trim().split_whitespace().last();
     match version {
         Some(v) => Ok(v.to_string()),
         None => bail!("Something went wrong! We couldn't determine your version of the wasm-bindgen CLI. We were supposed to set that up for you, so it's likely not your fault! You should file an issue: https://github.com/rustwasm/wasm-pack/issues/new?template=bug_report.md.")


### PR DESCRIPTION
I was wondering why `wasm-pack` is insisting on pulling and building `cargo-generate` despite there already being one at `/usr/bin/cargo-generate`. I'm on EndeavourOS too so it is the newest version `0.18.4`.

Turns out, the version check logic no longer works for the newest `cargo-generate`. Right now `cargo-generate --version` prints `cargo generate 0.18.4`, which means the current logic is actually evaluating `"generate" == "0.18.4"`. The same problem also exists for `wasm-opt`. This patch fixes this, along with adding a few helpful debug prints.

You can test before and after using `RUST_LOG=debug cargo run -- new --mode no-install version-test`.