### PR TITLE
Update dependencies to fix active advisories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.68"
 atty = "0.2.14"
 binary-install = "0.2.0"
 cargo_metadata = "0.15.2"
-chrono = "0.4.23"
+chrono = "0.4.31"
 console = "0.15.5"
 dialoguer = "0.10.3"
 env_logger = { version = "0.10.0", default-features = false }
@@ -32,7 +32,7 @@ siphasher = "0.3.10"
 strsim = "0.10.0"
 clap = { version = "4.2.5", features = ["derive"] }
 toml = "0.7.3"
-ureq = { version = "2.6.2", features = ["json"] }
+ureq = { version = "2.8.0", features = ["json"] }
 walkdir = "2.3.2"
 which = "4.4.0"
 


### PR DESCRIPTION
Remove active advisories by updating the dependencies to versions that fixed the issues causing the advisories.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

Fixes parts of the #1338 

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
