### PR TITLE
Docs: Add a description of `build --target deno` 

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -91,11 +91,13 @@ wasm-pack build --target nodejs
 | `nodejs`  | [Node.js][deploy-nodejs] | Outputs JS that uses CommonJS modules, for use with a `require` statement. `main` key in `package.json`. |
 | `web` | [Native in browser][deploy-web] | Outputs JS that can be natively imported as an ES module in a browser, but the WebAssembly must be manually instantiated and loaded. |
 | `no-modules` | [Native in browser][deploy-web] | Same as `web`, except the JS is included on a page and modifies global state, and doesn't support as many `wasm-bindgen` features as `web` |
+| `deno` | [Deno][deploy-deno] | Outputs JS that can be natively imported as an ES module in deno. |
 
 [deploy]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html
 [bundlers]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#bundlers
 [deploy-nodejs]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#nodejs
 [deploy-web]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#without-a-bundler
+[deploy-deno]: https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html#deno
 
 ## Scope
 


### PR DESCRIPTION
emm...

> Outputs JS that can be natively imported as an ES module in deno.

Is this description correct?