### PR TITLE
Add `--target web` to quick start build command

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -4,8 +4,9 @@
 1. [Install this tool.]
 1. Run `wasm-pack new hello-wasm`.
 1. `cd hello-wasm`
-1. Run `wasm-pack build`.
+1. Run `wasm-pack build --target web`.
 1. This tool generates files in a `pkg` dir
+1. Import it: `import init, { greet } from "./pkg/hello_wasm.js"`, initialize it: `await init()`, and then use it: `greet("WebAssembly")`
 1. To publish to npm, run `wasm-pack publish`. You may need to login to the
    registry you want to publish to. You can login using `wasm-pack login`.
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -6,7 +6,7 @@
 1. `cd hello-wasm`
 1. Run `wasm-pack build --target web`.
 1. This tool generates files in a `pkg` dir
-1. Import it: `import init, { greet } from "./pkg/hello_wasm.js"`, initialize it: `await init()`, and then use it: `greet("WebAssembly")`
+1. Import it: `import init, { greet } from "./pkg/hello_wasm.js"`, initialize it: `await init()`, and then use it: `greet()`
 1. To publish to npm, run `wasm-pack publish`. You may need to login to the
    registry you want to publish to. You can login using `wasm-pack login`.
 


### PR DESCRIPTION
Looks like about 15k other devs ran into the same issue as me:

https://stackoverflow.com/a/64342488/11950764

And the MDN article includes `--target web` in their instructions: https://developer.mozilla.org/en-US/docs/WebAssembly/Rust_to_Wasm

So I figured that these instructions should also have that flag.

I also added an extra dot point below the `build` dot point which briefly indicates how to use the built package.

Thanks!