### PR TITLE
pkg-dir option for pack and publish commands

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -31,6 +31,10 @@ pub enum Command {
     #[clap(name = "pack")]
     /// 🍱  create a tar of your npm package but don't publish!
     Pack {
+        #[clap(long = "pkg-dir", short = 'd', default_value = "pkg")]
+        /// The name of the output directory where the npm package is stored
+        pkg_directory: PathBuf,
+
         /// The path to the Rust crate. If not set, searches up the path from the current directory.
         #[clap()]
         path: Option<PathBuf>,
@@ -67,6 +71,10 @@ pub enum Command {
         /// See https://docs.npmjs.com/cli/dist-tag
         #[clap(long = "tag")]
         tag: Option<String>,
+
+        #[clap(long = "pkg-dir", short = 'd', default_value = "pkg")]
+        /// The name of the output directory where the npm package is stored
+        pkg_directory: PathBuf,
 
         /// The path to the Rust crate. If not set, searches up the path from the current directory.
         #[clap()]
@@ -113,10 +121,13 @@ pub fn run_wasm_pack(command: Command) -> Result<()> {
             info!("Running build command...");
             Build::try_from_opts(build_opts).and_then(|mut b| b.run())
         }
-        Command::Pack { path } => {
+        Command::Pack {
+            path,
+            pkg_directory,
+        } => {
             info!("Running pack command...");
             info!("Path: {:?}", &path);
-            pack(path)
+            pack(path, pkg_directory)
         }
         Command::Generate {
             template,
@@ -133,10 +144,11 @@ pub fn run_wasm_pack(command: Command) -> Result<()> {
             path,
             access,
             tag,
+            pkg_directory,
         } => {
             info!("Running publish command...");
             info!("Path: {:?}", &path);
-            publish(&target, path, access, tag)
+            publish(&target, path, access, tag, pkg_directory)
         }
         Command::Login {
             registry,

--- a/src/command/pack.rs
+++ b/src/command/pack.rs
@@ -7,11 +7,11 @@ use std::path::PathBuf;
 
 /// Executes the 'npm pack' command on the 'pkg' directory
 /// which creates a tarball that can be published to the NPM registry
-pub fn pack(path: Option<PathBuf>) -> Result<()> {
+pub fn pack(path: Option<PathBuf>, pkg_directory: PathBuf) -> Result<()> {
     let crate_path = get_crate_path(path)?;
 
     info!("Packing up the npm package...");
-    let pkg_directory = find_pkg_directory(&crate_path).ok_or_else(|| {
+    let pkg_directory = find_pkg_directory(&crate_path, &pkg_directory).ok_or_else(|| {
         anyhow!(
             "Unable to find the pkg directory at path {:#?}, or in a child directory of {:#?}",
             &crate_path,
@@ -19,7 +19,10 @@ pub fn pack(path: Option<PathBuf>) -> Result<()> {
         )
     })?;
     npm::npm_pack(&pkg_directory.to_string_lossy())?;
-    info!("Your package is located at {:#?}", crate_path.join("pkg"));
+    info!(
+        "Your package is located at {:#?}",
+        crate_path.join(pkg_directory)
+    );
 
     PBAR.info("🎒  packed up your package!");
     Ok(())

--- a/src/command/publish/mod.rs
+++ b/src/command/publish/mod.rs
@@ -19,13 +19,14 @@ pub fn publish(
     path: Option<PathBuf>,
     access: Option<Access>,
     tag: Option<String>,
+    pkg_directory: PathBuf,
 ) -> Result<()> {
     let crate_path = get_crate_path(path)?;
 
     info!("Publishing the npm package...");
     info!("npm info located in the npm debug log");
 
-    let pkg_directory = match find_pkg_directory(&crate_path) {
+    let pkg_directory = match find_pkg_directory(&crate_path, &pkg_directory) {
         Some(path) => Ok(path),
         None => {
             // while `wasm-pack publish`, if the pkg directory cannot be found,

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -45,19 +45,19 @@ pub fn create_pkg_dir(out_dir: &Path) -> Result<()> {
 
 /// Locates the pkg directory from a specific path
 /// Returns None if unable to find the 'pkg' directory
-pub fn find_pkg_directory(path: &Path) -> Option<PathBuf> {
-    if is_pkg_directory(path) {
+pub fn find_pkg_directory(path: &Path, pkg_directory: &Path) -> Option<PathBuf> {
+    if is_pkg_directory(path, pkg_directory) {
         return Some(path.to_owned());
     }
 
     WalkDir::new(path)
         .into_iter()
         .filter_map(|x| x.ok().map(|e| e.into_path()))
-        .find(|x| is_pkg_directory(&x))
+        .find(|x| is_pkg_directory(&x, pkg_directory))
 }
 
-fn is_pkg_directory(path: &Path) -> bool {
-    path.exists() && path.is_dir() && path.ends_with("pkg")
+fn is_pkg_directory(path: &Path, pkg_directory: &Path) -> bool {
+    path.exists() && path.is_dir() && path.ends_with(pkg_directory)
 }
 
 /// Render a `Duration` to a form suitable for display on a console


### PR DESCRIPTION
To be able to use these commands when the output directory option to the build command isn't the default pkg.

Resolves #1369

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
