### PR TITLE
feat(webdriver): support geckodriver for `linux-aarch64`

### DIFF
--- a/src/test/webdriver/geckodriver.rs
+++ b/src/test/webdriver/geckodriver.rs
@@ -40,6 +40,8 @@ pub fn install_geckodriver(cache: &Cache, installation_allowed: bool) -> Result<
         ("linux32", "tar.gz")
     } else if target::LINUX && target::x86_64 {
         ("linux64", "tar.gz")
+    } else if target::LINUX && target::aarch64 {
+        ("linux-aarch64", "tar.gz")
     } else if target::MACOS {
         ("macos", "tar.gz")
     } else if target::WINDOWS && target::x86 {

--- a/tests/all/webdriver.rs
+++ b/tests/all/webdriver.rs
@@ -19,6 +19,7 @@ fn can_install_chromedriver() {
 #[cfg(any(
     all(target_os = "linux", target_arch = "x86"),
     all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "linux", target_arch = "aarch64"),
     all(target_os = "macos", target_arch = "x86_64"),
     all(target_os = "macos", target_arch = "aarch64"),
     all(target_os = "windows", target_arch = "x86"),


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [-] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

Introduces support to download Geckodriver in Linux `aarch64` based on artifacts available 
in Mozilla's releases: https://github.com/mozilla/geckodriver/releases.
