### PR TITLE
Fix local navigation backing one step too far

### DIFF
--- a/docs/src/tutorials/npm-browser-packages/index.md
+++ b/docs/src/tutorials/npm-browser-packages/index.md
@@ -9,7 +9,7 @@ much Rust knowledge to complete this tutorial.
 Be sure to have done the following before starting:
 
 1. [Install `wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/)
-1. Read and install the [Prerequisites](../../../prerequisites/index.html).
+1. Read and install the [Prerequisites](../../prerequisites/index.html).
 
 ⚠️ We strongly recommend that you install [Node.js] using a version manager. You can learn more [here](https://npmjs.com/get-npm).
 


### PR DESCRIPTION
Reduces number of steps taken backwards to reach the correct page of prerequisites

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

This PR closes #1386 
