### PR TITLE
fix: update chromedriver download URL, resolve test issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
             os: ubuntu-latest
             rust: stable
           - build: macos-stable
-            os: macos-latest
+            os: macos-13
             rust: stable
           - build: windows-stable
             os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
             os: ubuntu-latest
             rust: stable
           - build: macos-stable
-            os: macos-13
+            os: macos-latest
             rust: stable
           - build: windows-stable
             os: windows-latest
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: nanasess/setup-chromedriver@master
+      - if: matrix.os == 'macos-latest'
+        run: brew install --cask firefox
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v3
         env:
-          cache-name: cache-dependencies
+          cache-name: cache-dependencies-bust
         with:
           path: |
             ~/.cargo/.crates.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v3
         env:
-          cache-name: cache-dependencies-bust
+          cache-name: cache-dependencies
         with:
           path: |
             ~/.cargo/.crates.toml

--- a/src/test/webdriver/chromedriver.rs
+++ b/src/test/webdriver/chromedriver.rs
@@ -156,7 +156,7 @@ fn fetch_chromedriver_version() -> Result<String> {
 
 fn assemble_chromedriver_url(chromedriver_version: &str, target: &str) -> String {
     format!(
-        "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/{version}/{target}/chromedriver-{target}.zip",
+        "https://storage.googleapis.com/chrome-for-testing-public/{version}/{target}/chromedriver-{target}.zip",
         version = chromedriver_version,
         target = target,
     )

--- a/tests/all/log_level.rs
+++ b/tests/all/log_level.rs
@@ -16,7 +16,9 @@ fn matches_info() -> impl Predicate<str> + PredicateReflection {
 }
 
 fn matches_cargo() -> impl Predicate<str> + PredicateReflection {
-    contains("Finished release [optimized] target(s) in ")
+    contains("Finished release [optimized] target(s) in ").or(contains(
+        "Finished `release` profile [optimized] target(s) in ",
+    ))
 }
 
 #[test]


### PR DESCRIPTION
This fixes a few things to get CI working for the repo again:
- The chromedriver releases were previously 404ing, causing these tests to fail. The URL for where these are hosted was changed, so it's just a simple update to get this working again.
- In later Cargo releases, the output format for the "Finished..." log line changed. I've fixed this by making `matches_cargo` accept both the old and new formats.
- With MacOS 14 (and by extension, M1) runners becoming the `macos-latest` default, the current geckodriver setup fails for that platform. ~It's not entirely obvious to me why at this point. Downgrading to the `macos-13` runner has these tests working again. This is probably the most.. questionable change as it'd be better to track down why the latest runners don't work.~ Edit: It seems like the only thing preventing macOS from working was that I needed to manually install Firefox. I'm guessing this was available in the previous macOS runners by default.

---

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

Closes #1390 

