### PR TITLE
Implement wasm-opt linux aarch64 condition

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -173,7 +173,8 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String> {
 /// Get the download URL for some tool at some version, architecture and operating system
 pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Result<String> {
     let target = match (os, arch, tool) {
-        (Os::Linux, Arch:AArch64, Tool::WasmOpt) => "aarch64-linux",
+        (Os::Linux, Arch::AArch64, Tool::WasmOpt) => "aarch64-linux",
+        (Os::Linux, Arch::AArch64, _) => "aarch64-unknown-linux-musl",
         (Os::Linux, Arch::X86_64, Tool::WasmOpt) => "x86_64-linux",
         (Os::Linux, Arch::X86_64, _) => "x86_64-unknown-linux-musl",
         (Os::MacOS, Arch::X86_64, Tool::WasmOpt) => "x86_64-macos",

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -173,6 +173,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String> {
 /// Get the download URL for some tool at some version, architecture and operating system
 pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Result<String> {
     let target = match (os, arch, tool) {
+        (Os::Linux, Arch:AArch64, Tool::WasmOpt) => "aarch64-linux",
         (Os::Linux, Arch::X86_64, Tool::WasmOpt) => "x86_64-linux",
         (Os::Linux, Arch::X86_64, _) => "x86_64-unknown-linux-musl",
         (Os::MacOS, Arch::X86_64, Tool::WasmOpt) => "x86_64-macos",
@@ -201,7 +202,7 @@ pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Res
         Tool::WasmOpt => {
             Ok(format!(
         "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_111",
+        vers = "version_117",
         target = target,
             ))
         }

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -174,7 +174,7 @@ fn prebuilt_url(tool: &Tool, version: &str) -> Result<String> {
 pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Result<String> {
     let target = match (os, arch, tool) {
         (Os::Linux, Arch::AArch64, Tool::WasmOpt) => "aarch64-linux",
-        (Os::Linux, Arch::AArch64, _) => "aarch64-unknown-linux-musl",
+        (Os::Linux, Arch::AArch64, _) => "aarch64-unknown-linux-gnu",
         (Os::Linux, Arch::X86_64, Tool::WasmOpt) => "x86_64-linux",
         (Os::Linux, Arch::X86_64, _) => "x86_64-unknown-linux-musl",
         (Os::MacOS, Arch::X86_64, Tool::WasmOpt) => "x86_64-macos",


### PR DESCRIPTION
Closes #1392 
Make sure these boxes are checked! 📦✅

- [✅] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [✅] You ran `cargo fmt` on the code base before submitting
- [✅] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
