### PR TITLE
fix: optimize out-dir display (close: #1395)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1735,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot",
+ "path-clean",
  "predicates",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ toml = "0.7.3"
 ureq = { version = "2.6.2", features = ["json"] }
 walkdir = "2.3.2"
 which = "4.4.0"
+path-clean = "1.0.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -16,6 +16,7 @@ use anyhow::{anyhow, bail, Error, Result};
 use binary_install::Cache;
 use clap::Args;
 use log::info;
+use path_clean::PathClean;
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -217,7 +218,7 @@ impl Build {
         }
         let crate_path = get_crate_path(build_opts.path)?;
         let crate_data = manifest::CrateData::new(&crate_path, build_opts.out_name.clone())?;
-        let out_dir = crate_path.join(PathBuf::from(build_opts.out_dir));
+        let out_dir = crate_path.join(PathBuf::from(build_opts.out_dir)).clean();
 
         let dev = build_opts.dev || build_opts.debug;
         let profile = match (dev, build_opts.release, build_opts.profiling) {


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

close: https://github.com/rustwasm/wasm-pack/issues/1395

```
wasm-pack build --out-dir=../fib-wasm/wasm
```
Optimize out-dir display, from  
```
[INFO]: 📦   Your wasm pkg is ready to publish at /root/code/fib-wasm/fib-rs/../fib-wasm/wasm.
```
to
```
[INFO]: 📦   Your wasm pkg is ready to publish at /root/code/fib-wasm/fib-wasm/wasm.
```
I'm not sure if the clean function needs to be called in other places where the display function is called, it seems that just optimizing the display of out-dir is enough