### PR TITLE
Add support for wasm-bindgen's browser-only hint

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -19,6 +19,7 @@ pub fn wasm_bindgen_build(
     disable_dts: bool,
     weak_refs: bool,
     reference_types: bool,
+    browser_only: bool,
     target: Target,
     profile: BuildProfile,
     extra_options: &Vec<String>,
@@ -70,6 +71,13 @@ pub fn wasm_bindgen_build(
     let target_arg = build_target_arg(target, &bindgen_path)?;
     if supports_dash_dash_target(&bindgen_path)? {
         cmd.arg("--target").arg(target_arg);
+        if browser_only {
+            if let Target::Bundler = target {
+                cmd.arg("--browser");
+            } else {
+                bail!("You can only specify `--browser` when building for the 'bundler' target.")
+            }
+        }
     } else {
         cmd.arg(target_arg);
     }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -31,6 +31,7 @@ pub struct Build {
     pub disable_dts: bool,
     pub weak_refs: bool,
     pub reference_types: bool,
+    pub browser_only: bool,
     pub target: Target,
     pub no_pack: bool,
     pub no_opt: bool,
@@ -139,6 +140,11 @@ pub struct BuildOptions {
     /// Enable usage of WebAssembly reference types.
     pub reference_types: bool,
 
+    #[clap(long = "browser")]
+    /// Hint that the generated JS should only be compatible with a browser.
+    /// Only supported when using the 'bundler' target.
+    pub browser_only: bool,
+
     #[clap(long = "target", short = 't', default_value = "bundler")]
     /// Sets the target environment. [possible values: bundler, nodejs, web, no-modules, deno]
     pub target: Target,
@@ -189,6 +195,7 @@ impl Default for BuildOptions {
             disable_dts: false,
             weak_refs: false,
             reference_types: false,
+            browser_only: false,
             target: Target::default(),
             debug: false,
             dev: false,
@@ -237,6 +244,7 @@ impl Build {
             disable_dts: build_opts.disable_dts,
             weak_refs: build_opts.weak_refs,
             reference_types: build_opts.reference_types,
+            browser_only: build_opts.browser_only,
             target: build_opts.target,
             no_pack: build_opts.no_pack,
             no_opt: build_opts.no_opt,
@@ -429,6 +437,7 @@ impl Build {
             self.disable_dts,
             self.weak_refs,
             self.reference_types,
+            self.browser_only,
             self.target,
             self.profile,
             &self.extra_options,


### PR DESCRIPTION
Closes #689

Code that runs in a [Worklet](https://developer.mozilla.org/en-US/docs/Web/API/Worklet)/[AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet) context only has access to a limited subset of browser APIs. To allow running under these restrictions, wasm-bindgen provides the `--browser` flag which alters the generated JS code for these environments.

Currently, there is no way to tell `wasm-pack` to use this flag when building. This PR adds support for forwarding this flag to `wasm-bindgen`.

- [x] You have the latest version of `rustfmt` installed
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
