### PR TITLE
Don't create .gitignore in pkg directory

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -3,11 +3,7 @@
 The `wasm-pack build` command creates the files necessary for JavaScript
 interoperability and for publishing a package to npm. This involves compiling
 your code to wasm and generating a pkg folder. This pkg folder will contain the
-wasm binary, a JS wrapper file, your `README`, and a `package.json` file.
-
-The `pkg` directory is automatically `.gitignore`d by default, since it contains
-build artifacts which are not intended to be checked into version
-control.<sup>[0](#footnote-0)</sup>
+wasm binary, a JS wrapper file, your `README`, and a `package.json` file.<sup>[0](#footnote-0)</sup>
 
 ## Path
 
@@ -140,6 +136,5 @@ wasm-pack build examples/js-hello-world --mode no-install -- --offline
 
 <hr style="font-size: 1.5em; margin-top: 2.5em"/>
 
-<sup id="footnote-0">0</sup> If you need to include additional assets in the pkg
-directory and your NPM package, we intend to have a solution for your use case
-soon. [↩](#wasm-pack-build)
+<sup id="footnote-0">0</sup> In contrast to previous releases, a `.gitignore`
+file is no longer created in the `pkg` directory. [↩](#wasm-pack-build)

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -39,7 +39,6 @@ fn find_manifest_from_cwd() -> Result<PathBuf> {
 pub fn create_pkg_dir(out_dir: &Path) -> Result<()> {
     let _ = fs::remove_file(out_dir.join("package.json")); // Clean up package.json from previous runs
     fs::create_dir_all(&out_dir)?;
-    fs::write(out_dir.join(".gitignore"), "*")?;
     Ok(())
 }
 


### PR DESCRIPTION
Closes #728 
Closes #984,
Closes #909
Closes #999.
Supersedes #1131, #985 

### Problematic Behaviour

Currently, `wasm-pack` generates a `.gitignore` file in the `pkg` directory during each build.

### Suggested Solution

This PR proposes removing the automatic creation of the `.gitignore` file without introducing a replacement.

### Justification

While many tools generate an appropriate `.gitignore` during project *initialization*, it’s relatively uncommon (in my experience) for build tools, like compilers, to create `.gitignore` files during a *build*.

Moreover, this behavior has led to several issues, as outlined in the following requests:

- #728
- #984
- #909
- #999

This PR aims to remove the generation of the problematic `.gitignore` file, addressing and potentially superseding these other PRs:

- #1131
- #985

### Changes made

- Remove one line from [src/command/utils.rs](https://github.com/rustwasm/wasm-pack/pull/1408/files#diff-36d20b5b00d9e4e25c74b1cebb9dd935d248c1a9231bf0ebda7d54c6e8cc9119)
- Update documentation in [docs/src/commands/build.md](https://github.com/rustwasm/wasm-pack/pull/1408/files#diff-b2a4b3d52fd1f77d27b83df800176970fd451f1e37aa42266c28c250f402c036)