### PR TITLE
Less confusing path output for `new`

### DIFF
--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -17,7 +17,7 @@ pub fn generate(template: String, name: String, install_permitted: bool) -> Resu
     )?;
     generate::generate(&template, &name, &download)?;
 
-    let msg = format!("🐑 Generated new project at /{}", name);
+    let msg = format!("🐑 Generated new project at ./{}", name);
     PBAR.info(&msg);
     Ok(())
 }


### PR DESCRIPTION
Before:
    [INFO]: 🐑 Generated new project at /my-package
After:
    [INFO]: 🐑 Generated new project at ./my-package

---
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [n/a] You reference which issue is being closed in the PR text 
  (seemed self explanatory, not worth creating an issue)

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨