### PR TITLE
cargo install wasm-opt if not present

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -272,13 +272,13 @@ pub fn cargo_install(
     // just want them in `$root/*` directly (which matches how the tarballs are
     // laid out, and where the rest of our code expects them to be). So we do a
     // little renaming here.
-    let binaries: Result<Vec<&str>> = match tool {
-        Tool::WasmBindgen => Ok(vec!["wasm-bindgen", "wasm-bindgen-test-runner"]),
-        Tool::CargoGenerate => Ok(vec!["cargo-generate"]),
-        Tool::WasmOpt => bail!("Cannot install wasm-opt with cargo."),
+    let binaries = match tool {
+        Tool::WasmBindgen => vec!["wasm-bindgen", "wasm-bindgen-test-runner"],
+        Tool::CargoGenerate => vec!["cargo-generate"],
+        Tool::WasmOpt => vec!["wasm-opt"],
     };
 
-    for b in binaries?.iter().cloned() {
+    for b in binaries.iter().cloned() {
         let from = tmp
             .join("bin")
             .join(b)

--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -54,7 +54,7 @@ pub fn find_wasm_opt(cache: &Cache, install_permitted: bool) -> Result<Option<Pa
     match install::download_prebuilt_or_cargo_install(
         install::Tool::WasmOpt,
         cache,
-        "latest",
+        "0.116.1",
         install_permitted,
     )? {
         install::Status::Found(download) => Ok(Some(download.binary("wasm-opt")?)),

--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -51,8 +51,13 @@ pub fn find_wasm_opt(cache: &Cache, install_permitted: bool) -> Result<Option<Pa
         return Ok(Some(path));
     }
 
-    match install::download_prebuilt(&install::Tool::WasmOpt, cache, "latest", install_permitted)? {
-        install::Status::Found(download) => Ok(Some(download.binary("bin/wasm-opt")?)),
+    match install::download_prebuilt_or_cargo_install(
+        install::Tool::WasmOpt,
+        cache,
+        "latest",
+        install_permitted,
+    )? {
+        install::Status::Found(download) => Ok(Some(download.binary("wasm-opt")?)),
         install::Status::CannotInstall => {
             PBAR.info("Skipping wasm-opt as no downloading was requested");
             Ok(None)


### PR DESCRIPTION
I ran into https://github.com/rustwasm/wasm-pack/issues/1280. This issue is closed but this still seems to be a problem.

I ran into the following error:
```
$ wasm-pack build --target web --out-name wasm --out-dir ./static
[INFO]: 🎯  Checking for the Wasm target...
[INFO]: 🌀  Compiling to Wasm...
    Finished `release` profile [optimized] target(s) in 0.01s
[INFO]: ⬇️  Installing wasm-bindgen...
Error: failed to download from https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-arm64-macos.tar.gz
To disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.
Caused by: failed to download from https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-arm64-macos.tar.gz
To disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.
```

The original code was written 5 years ago and I assume back then it was not possible to `cargo install wasm-opt`. Now it is and this PR fixes the referenced issue.

PS: If you manually run `cargo install wasm-opt` before running `wasm-pack [...]` you do not have this problem but this PR prevents this step.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
