### PR TITLE
Be more explicit with available wasm-opt flags in documentation

### DIFF
--- a/docs/src/cargo-toml-configuration.md
+++ b/docs/src/cargo-toml-configuration.md
@@ -21,7 +21,7 @@ The available configuration options and their default values are shown below:
 #
 # In most cases, the `-O[X]` flag is enough. However, if you require extreme
 # optimizations, see the full list of `wasm-opt` optimization flags
-# https://github.com/WebAssembly/binaryen/blob/version_111/test/lit/help/wasm-opt.test
+# https://github.com/WebAssembly/binaryen/blob/version_117/test/lit/help/wasm-opt.test
 wasm-opt = ['-O']
 
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/docs/src/cargo-toml-configuration.md
+++ b/docs/src/cargo-toml-configuration.md
@@ -18,6 +18,10 @@ The available configuration options and their default values are shown below:
 # be set to an array of strings which are explicit arguments to pass to
 # `wasm-opt`. For example `['-Os']` would optimize for size while `['-O4']`
 # would execute very expensive optimizations passes
+#
+# In most cases, the `-O[X]` flag is enough. However, if you require extreme
+# optimizations, see the full list of `wasm-opt` optimization flags
+# https://github.com/WebAssembly/binaryen/blob/version_111/test/lit/help/wasm-opt.test
 wasm-opt = ['-O']
 
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -203,7 +203,7 @@ pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Res
         Tool::WasmOpt => {
             Ok(format!(
         "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_117",
+        vers = "version_117", // Make sure to update the version in docs/src/cargo-toml-configuration.md as well
         target = target,
             ))
         }


### PR DESCRIPTION
Closes #1422

This PR explicitly specifies the available wasm-opt optimization flags for extreme optimization cases.

- [X] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [X] You ran `cargo fmt` on the code base before submitting
- [X] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
