### PR TITLE
chore: Remove unmaintained dependency atty in favor of stdlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,17 +132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,15 +754,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"
@@ -1803,7 +1783,6 @@ version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "atty",
  "binary-install",
  "cargo_metadata",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ documentation = "https://rustwasm.github.io/wasm-pack/"
 
 [dependencies]
 anyhow = "1.0.68"
-atty = "0.2.14"
 binary-install = "0.4.1"
 cargo_metadata = "0.15.2"
 chrono = "0.4.23"

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -112,9 +112,7 @@ fn confirm_can_overwrite(dst: &Path) -> Result<()> {
     );
     eprint!("info: would you like to overwrite this file? [y/N]: ");
     let mut line = String::new();
-    stdin
-        .read_line(&mut line)
-        .context("failed to read stdin")?;
+    stdin.read_line(&mut line).context("failed to read stdin")?;
 
     if line.starts_with('y') || line.starts_with('Y') {
         return Ok(());

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -19,11 +19,11 @@
 use std::env;
 use std::fs;
 use std::io;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::process;
 
 use anyhow::{anyhow, bail, Context, Result};
-use atty;
 use which;
 
 pub fn install() -> ! {
@@ -91,9 +91,11 @@ fn confirm_can_overwrite(dst: &Path) -> Result<()> {
         return Ok(());
     }
 
+    let stdin = io::stdin();
+
     // If we're not attached to a TTY then we can't get user input, so there's
     // nothing to do except inform the user about the `-f` flag.
-    if !atty::is(atty::Stream::Stdin) {
+    if !stdin.is_terminal() {
         bail!(
             "existing wasm-pack installation found at `{}`, pass `-f` to \
              force installation over this file, otherwise aborting \
@@ -110,7 +112,7 @@ fn confirm_can_overwrite(dst: &Path) -> Result<()> {
     );
     eprint!("info: would you like to overwrite this file? [y/N]: ");
     let mut line = String::new();
-    io::stdin()
+    stdin
         .read_line(&mut line)
         .context("failed to read stdin")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure, clippy::redundant_pattern_matching)]
 
 extern crate anyhow;
-extern crate atty;
 extern crate clap;
 extern crate env_logger;
 extern crate human_panic;


### PR DESCRIPTION
As per https://github.com/softprops/atty/issues/57#issuecomment-2367878741 we can just use the stdlib functionality that exists in Rust 1.70