### PR TITLE
Replace `atty` with `std::io::IsTerminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,17 +132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,15 +754,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"
@@ -1803,7 +1783,6 @@ version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "atty",
  "binary-install",
  "cargo_metadata",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Ashley Williams <ashley666ashley@gmail.com>", "Jesper Håkansson <je
 repository = "https://github.com/rustwasm/wasm-pack.git"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.70.0"
 readme = "README.md"
 categories = ["wasm"]
 documentation = "https://rustwasm.github.io/wasm-pack/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ documentation = "https://rustwasm.github.io/wasm-pack/"
 
 [dependencies]
 anyhow = "1.0.68"
-atty = "0.2.14"
 binary-install = "0.4.1"
 cargo_metadata = "0.15.2"
 chrono = "0.4.23"
@@ -43,4 +42,3 @@ lazy_static = "1.4.0"
 predicates = "3.0.3"
 serial_test = "2.0.0"
 tempfile = "3.3.0"
-

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ visiting that repo!
 
 ## 🔮 Prerequisites
 
-This project requires Rust 1.30.0 or later.
+This project requires Rust 1.70.0 or later.
 
 - [Development Environment](https://rustwasm.github.io/wasm-pack/book/prerequisites/index.html)
 - [Installation](https://rustwasm.github.io/wasm-pack/installer)

--- a/docs/src/prerequisites/index.md
+++ b/docs/src/prerequisites/index.md
@@ -6,7 +6,7 @@ First you'll want to [install the `wasm-pack` CLI][wasm-pack], and `wasm-pack
 [wasm-pack]: https://rustwasm.github.io/wasm-pack/installer/
 
 Next, since `wasm-pack` is a build tool, you'll want to make sure you have
-[Rust][rust] installed. Make sure `rustc -V` prints out at least 1.30.0.
+[Rust][rust] installed. Make sure `rustc -V` prints out at least 1.70.0.
 
 [rust]: https://www.rust-lang.org/tools/install
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -43,7 +43,7 @@ visiting that repo!
 
 ## 🔮 Prerequisites
 
-This project requires Rust 1.30.0 or later.
+This project requires Rust 1.70.0 or later.
 
 - [Development Environment](https://rustwasm.github.io/wasm-pack/book/prerequisites/index.html)
 - [Installation](https://rustwasm.github.io/wasm-pack/installer)

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -22,21 +22,21 @@ pub struct WasmPackVersion {
     pub latest: String,
 }
 
-/// Ensure that `rustc` is present and that it is >= 1.30.0
+/// Ensure that `rustc` is present and that it is >= 1.70.0
 pub fn check_rustc_version() -> Result<String> {
     let local_minor_version = rustc_minor_version();
     match local_minor_version {
         Some(mv) => {
-            if mv < 30 {
+            if mv < 70 {
                 bail!(
-                    "Your version of Rust, '1.{}', is not supported. Please install Rust version 1.30.0 or higher.",
+                    "Your version of Rust, '1.{}', is not supported. Please install Rust version 1.70.0 or higher.",
                     mv.to_string()
                 )
             } else {
                 Ok(mv.to_string())
             }
         }
-        None => bail!("We can't figure out what your Rust version is- which means you might not have Rust installed. Please install Rust version 1.30.0 or higher."),
+        None => bail!("We can't figure out what your Rust version is- which means you might not have Rust installed. Please install Rust version 1.70.0 or higher."),
     }
 }
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -19,11 +19,10 @@
 use std::env;
 use std::fs;
 use std::io;
-use std::path::Path;
 use std::process;
+use std::{io::IsTerminal, path::Path};
 
 use anyhow::{anyhow, bail, Context, Result};
-use atty;
 use which;
 
 pub fn install() -> ! {
@@ -93,7 +92,7 @@ fn confirm_can_overwrite(dst: &Path) -> Result<()> {
 
     // If we're not attached to a TTY then we can't get user input, so there's
     // nothing to do except inform the user about the `-f` flag.
-    if !atty::is(atty::Stream::Stdin) {
+    if !io::stdin().is_terminal() {
         bail!(
             "existing wasm-pack installation found at `{}`, pass `-f` to \
              force installation over this file, otherwise aborting \

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::redundant_closure, clippy::redundant_pattern_matching)]
 
 extern crate anyhow;
-extern crate atty;
 extern crate clap;
 extern crate env_logger;
 extern crate human_panic;


### PR DESCRIPTION
`atty` is unmaintained: https://rustsec.org/advisories/RUSTSEC-2024-0375.html.

This PR removes it from the dependencies and instead uses https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html. This means the `msrv` is bumped to `1.70.0`.