### PR TITLE
Requests using proxy settings from ENV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1693,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_json",
+ "socks",
  "url",
  "webpki-roots",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ siphasher = "0.3.10"
 strsim = "0.10.0"
 clap = { version = "4.2.5", features = ["derive"] }
 toml = "0.7.3"
-ureq = { version = "2.6.2", features = ["json"] }
+ureq = { version = "2.6.2", features = ["json", "socks-proxy"] }
 walkdir = "2.3.2"
 which = "4.4.0"
 path-clean = "1.0.1"

--- a/src/install/krate.rs
+++ b/src/install/krate.rs
@@ -17,7 +17,10 @@ pub struct KrateResponse {
 impl Krate {
     pub fn new(name: &Tool) -> Result<Krate> {
         let krate_address = format!("https://crates.io/api/v1/crates/{}", name);
-        let res = ureq::get(&krate_address)
+        let res = ureq::builder()
+            .try_proxy_from_env(true)
+            .build()
+            .get(&krate_address)
             .set(
                 "user-agent",
                 &format!("wasm-pack/{}", VERSION.unwrap_or("unknown")),

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -227,6 +227,7 @@ impl Crate {
     fn check_wasm_pack_latest_version() -> Result<Crate> {
         let url = "https://crates.io/api/v1/crates/wasm-pack";
         let agent = ureq::builder()
+            .try_proxy_from_env(true)
             .user_agent(&format!(
                 "wasm-pack/{} ({})",
                 WASM_PACK_VERSION.unwrap_or_else(|| "unknown"),

--- a/src/test/webdriver/chromedriver.rs
+++ b/src/test/webdriver/chromedriver.rs
@@ -134,13 +134,14 @@ struct GoodLatestVersions {
 /// Retrieve the latest version of chromedriver from the json endpoints.
 /// See: <https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints>
 fn fetch_chromedriver_version() -> Result<String> {
-    let info: GoodLatestVersions = ureq::get(
-        "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json",
-    )
-    .call()
-    .context("fetching of chromedriver's LATEST_RELEASE failed")?
-    .into_json()
-    .context("converting chromedriver version response to GoodLatestVersions failed")?;
+    let info: GoodLatestVersions = ureq::builder()
+        .try_proxy_from_env(true)
+        .build()
+        .get("https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json")
+        .call()
+        .context("fetching of chromedriver's LATEST_RELEASE failed")?
+        .into_json()
+        .context("converting chromedriver version response to GoodLatestVersions failed")?;
 
     let version = info
         .channels

--- a/src/test/webdriver/geckodriver.rs
+++ b/src/test/webdriver/geckodriver.rs
@@ -141,12 +141,14 @@ fn should_load_geckodriver_version_from_stamp(json: &serde_json::Value) -> bool 
 }
 
 fn fetch_latest_geckodriver_tag_json() -> Result<String> {
-    let content: serde_json::Value =
-        ureq::get("https://github.com/mozilla/geckodriver/releases/latest")
-            .set("Accept", "application/json")
-            .call()
-            .context("fetching of geckodriver's latest release data failed")?
-            .into_json()?;
+    let content: serde_json::Value = ureq::builder()
+        .try_proxy_from_env(true)
+        .build()
+        .get("https://github.com/mozilla/geckodriver/releases/latest")
+        .set("Accept", "application/json")
+        .call()
+        .context("fetching of geckodriver's latest release data failed")?
+        .into_json()?;
 
     get_version_from_json(content)
 }


### PR DESCRIPTION
This PR enables ureq to use proxy settings from ENV, it solves lots of pain in network restricted environments.

I also send a PR to binary-install https://github.com/rustwasm/binary-install/pull/34