### PR TITLE
fix: allow npm binary upgrades

### DIFF
--- a/npm/binary.js
+++ b/npm/binary.js
@@ -1,4 +1,5 @@
 const { Binary } = require("binary-install");
+const { join } = require("path");
 const os = require("os");
 
 const windows = "x86_64-pc-windows-msvc";
@@ -30,7 +31,9 @@ const getBinary = () => {
   const author = "rustwasm";
   const name = "wasm-pack";
   const url = `https://github.com/${author}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
-  return new Binary(platform === windows ? "wasm-pack.exe" : "wasm-pack", url);
+  return new Binary(platform === windows ? "wasm-pack.exe" : "wasm-pack", url, {
+    installDirectory: join(__dirname, "binary")
+  });
 };
 
 const install = () => {


### PR DESCRIPTION
The version of the NPM [`binary-install`](https://www.npmjs.com/package/binary-install) package that `wasm-pack` uses stores binaries at an unversioned path in the `binary-install` package's directory.

This silently prevents version upgrades, as when upgrading to a different version of `wasm-pack`, `binary-install` believes the `wasm-pack` binary is already installed, and keeps using the old one. For example, upgrading the NPM `wasm-pack` package from `0.12.1` to `0.13.0` will continue using the `0.12.1` binary, and so has no effect (likely without the user noticing).

This moves the install directory to `node_modules/wasm-pack/binary/`, which should fix the issue.