### PR TITLE
feat: allow bindgen-cli --split-linked-modules #1092

### DIFF
--- a/docs/src/cargo-toml-configuration.md
+++ b/docs/src/cargo-toml-configuration.md
@@ -29,6 +29,8 @@ demangle-name-section = true
 dwarf-debug-info = false
 # Should we omit the default import path?
 omit-default-module-path = false
+# Controls whether wasm-bindgen will split linked modules out into their own files. Enabling this is recommended, because it allows lazy-loading the linked modules and setting a stricter Content Security Policy. Only available in wasm-bindgen 0.2.95 and later.
+split-linked-modules = false
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = ['-O']

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -92,6 +92,9 @@ pub fn wasm_bindgen_build(
     if profile.wasm_bindgen_omit_default_module_path() {
         cmd.arg("--omit-default-module-path");
     }
+    if profile.wasm_bindgen_split_linked_modules() {
+        cmd.arg("--split-linked-modules");
+    }
 
     child::run(cmd, "wasm-bindgen").context("Running the wasm-bindgen CLI")?;
     Ok(())

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -127,6 +127,9 @@ struct CargoWasmPackProfileWasmBindgen {
 
     #[serde(default, rename = "omit-default-module-path")]
     omit_default_module_path: Option<bool>,
+
+    #[serde(default, rename = "split-linked-modules")]
+    split_linked_modules: Option<bool>,
 }
 
 /// Struct for storing information received from crates.io
@@ -283,6 +286,7 @@ impl CargoWasmPackProfile {
                 demangle_name_section: Some(true),
                 dwarf_debug_info: Some(false),
                 omit_default_module_path: Some(false),
+                split_linked_modules: Some(false),
             },
             wasm_opt: None,
         }
@@ -295,6 +299,7 @@ impl CargoWasmPackProfile {
                 demangle_name_section: Some(true),
                 dwarf_debug_info: Some(false),
                 omit_default_module_path: Some(false),
+                split_linked_modules: Some(false),
             },
             wasm_opt: Some(CargoWasmPackProfileWasmOpt::Enabled(true)),
         }
@@ -307,6 +312,7 @@ impl CargoWasmPackProfile {
                 demangle_name_section: Some(true),
                 dwarf_debug_info: Some(false),
                 omit_default_module_path: Some(false),
+                split_linked_modules: Some(false),
             },
             wasm_opt: Some(CargoWasmPackProfileWasmOpt::Enabled(true)),
         }
@@ -319,6 +325,7 @@ impl CargoWasmPackProfile {
                 demangle_name_section: Some(true),
                 dwarf_debug_info: Some(false),
                 omit_default_module_path: Some(false),
+                split_linked_modules: Some(false),
             },
             wasm_opt: Some(CargoWasmPackProfileWasmOpt::Enabled(true)),
         }
@@ -370,6 +377,7 @@ impl CargoWasmPackProfile {
         d!(wasm_bindgen.demangle_name_section);
         d!(wasm_bindgen.dwarf_debug_info);
         d!(wasm_bindgen.omit_default_module_path);
+        d!(wasm_bindgen.split_linked_modules);
 
         if self.wasm_opt.is_none() {
             self.wasm_opt = defaults.wasm_opt.clone();
@@ -394,6 +402,11 @@ impl CargoWasmPackProfile {
     /// Get this profile's configured `[wasm-bindgen.omit-default-module-path]` value.
     pub fn wasm_bindgen_omit_default_module_path(&self) -> bool {
         self.wasm_bindgen.omit_default_module_path.unwrap()
+    }
+
+    /// Get this profile's configured `[wasm-bindgen.split-linked-modules]` value.
+    pub fn wasm_bindgen_split_linked_modules(&self) -> bool {
+        self.wasm_bindgen.split_linked_modules.unwrap()
     }
 
     /// Get this profile's configured arguments for `wasm-opt`, if enabled.


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
