### PR TITLE
feat(webdriver): support geckodriver for `macos-aarch64`

### DIFF
--- a/src/test/webdriver/geckodriver.rs
+++ b/src/test/webdriver/geckodriver.rs
@@ -42,8 +42,10 @@ pub fn install_geckodriver(cache: &Cache, installation_allowed: bool) -> Result<
         ("linux64", "tar.gz")
     } else if target::LINUX && target::aarch64 {
         ("linux-aarch64", "tar.gz")
-    } else if target::MACOS {
+    } else if target::MACOS && target::x86_64 {
         ("macos", "tar.gz")
+    } else if target::MACOS && target::aarch64 {
+        ("macos-aarch64", "tar.gz")
     } else if target::WINDOWS && target::x86 {
         ("win32", "zip")
     } else if target::WINDOWS && target::x86_64 {


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
    - https://github.com/rustwasm/wasm-pack/issues/1449

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨

Introduces support to download Geckodriver in macOS `aarch64` based on artifacts available
in Mozilla's releases: https://github.com/mozilla/geckodriver/releases.