### PR TITLE
docs: Added rel path to `--out-dir` example

### DIFF
--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -22,15 +22,18 @@ path is given, the `build` command will run in the current directory.
 
 ## Output Directory
 
-By default, `wasm-pack` will generate a directory for its build output called `pkg`.
-If you'd like to customize this you can use the `--out-dir` flag.
+By default, `wasm-pack` generates a directory for its build output called `pkg` 
+in the same directory as the `Cargo.toml` file.
+Use the `--out-dir` flag to place the build output in a different location.
 
 ```
-wasm-pack build --out-dir out
+wasm-pack build examples/js-hello-world --out-dir ../builds/js-hello-world
 ```
 
-The above command will put your build artifacts in a directory called `out`, instead
-of the default `pkg`.
+The above command will create directory `examples/builds/js-hello-world`
+and place the build artifacts there, instead of the default `examples/js-hello-world/pkg`.
+
+The `--out-dir` path can be absolute or relative to the directory that contains the `Cargo.toml` file.
 
 ## Generated file names
 


### PR DESCRIPTION
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [ ] You reference which issue is being closed in the PR text
       > not applicable, it's a minor docs fix

---
This PR adds a relative path example to `--out-dir` docs section.

The current wording does not make it clear if the path is relative to the current directory or the root of the package.
The proposed clarification and the example should make it less ambiguous and save the users from figuring it out by trial and error.

I was tempted to have multiple examples, like this:

1. `wasm-pack build`
2. `wasm-pack build --out-dir out`
3. `wasm-pack build examples/js-hello-world --out-dir ../builds/js-hello-world`

but opted for a minimal change. Happy to include [1] and [2] if you think it's a good idea. 
