### PR TITLE
[DRAFT] add support for wasm32-unknown-emscripten

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -41,7 +41,7 @@ pub fn wasm_bindgen_build(
     };
 
     let wasm_path = target_directory
-        .join("wasm32-unknown-unknown")
+        .join(data.get_target_triple())
         .join(profile_name)
         .join(data.crate_name())
         .with_extension("wasm");

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -72,10 +72,11 @@ fn wasm_pack_local_version() -> Option<String> {
     Some(output.to_string())
 }
 
-/// Run `cargo build` targetting `wasm32-unknown-unknown`.
+/// Run `cargo build` targetting WebAssembly.
 pub fn cargo_build_wasm(
     path: &Path,
     profile: BuildProfile,
+    target_triple: String,
     extra_options: &[String],
 ) -> Result<()> {
     let msg = format!("{}Compiling to Wasm...", emoji::CYCLONE);
@@ -109,7 +110,7 @@ pub fn cargo_build_wasm(
         }
     }
 
-    cmd.arg("--target").arg("wasm32-unknown-unknown");
+    cmd.arg("--target").arg(target_triple);
 
     // The `cargo` command is executed inside the directory at `path`, so relative paths set via extra options won't work.
     // To remedy the situation, all detected paths are converted to absolute paths.

--- a/src/build/wasm_target.rs
+++ b/src/build/wasm_target.rs
@@ -54,7 +54,11 @@ impl fmt::Display for Wasm32Check {
 /// Ensure that `rustup` has the `wasm32-unknown-unknown` target installed for
 /// current toolchain
 pub fn check_for_wasm32_target(target_triple: String) -> Result<()> {
-    let msg = format!("{}Checking for the Wasm target {}...", emoji::TARGET, target_triple);
+    let msg = format!(
+        "{}Checking for the Wasm target {}...",
+        emoji::TARGET,
+        target_triple
+    );
     PBAR.info(&msg);
 
     // Check if wasm32 target is present, otherwise bail.
@@ -109,17 +113,12 @@ fn does_wasm32_target_libdir_exist(target_triple: String) -> bool {
     match result {
         Ok(wasm32_target_libdir_path) => {
             if wasm32_target_libdir_path.exists() {
-                info!(
-                    "Found {} in {:?}",
-                    target_triple,
-                    wasm32_target_libdir_path
-                );
+                info!("Found {} in {:?}", target_triple, wasm32_target_libdir_path);
                 true
             } else {
                 info!(
                     "Failed to find {} in {:?}",
-                    target_triple,
-                    wasm32_target_libdir_path
+                    target_triple, wasm32_target_libdir_path
                 );
                 false
             }
@@ -168,7 +167,8 @@ fn check_wasm32_target(target_triple: String) -> Result<Wasm32Check> {
 fn rustup_add_wasm_target(target_triple: String) -> Result<()> {
     let mut cmd = Command::new("rustup");
     cmd.arg("target").arg("add").arg(target_triple.clone());
-    child::run(cmd, "rustup").context(format!("Adding the {} target with rustup", target_triple))?;
+    child::run(cmd, "rustup")
+        .context(format!("Adding the {} target with rustup", target_triple))?;
 
     Ok(())
 }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -270,7 +270,7 @@ impl Build {
 
     /// Execute this `Build` command.
     pub fn run(&mut self) -> Result<()> {
-        let process_steps = Build::get_process_steps(self.mode, self.no_pack, self.no_opt);
+        let process_steps = Build::get_process_steps(self.mode, self.no_pack, self.no_opt, self.crate_data.get_target_triple());
 
         let started = Instant::now();
 
@@ -299,6 +299,7 @@ impl Build {
         mode: InstallMode,
         no_pack: bool,
         no_opt: bool,
+        target_triple: String
     ) -> Vec<(&'static str, BuildStep)> {
         macro_rules! steps {
             ($($name:ident),+) => {
@@ -322,23 +323,32 @@ impl Build {
             }
         }
 
-        steps.extend(steps![
-            step_build_wasm,
-            step_create_dir,
-            step_install_wasm_bindgen,
-            step_run_wasm_bindgen,
-        ]);
-
-        if !no_opt {
-            steps.extend(steps![step_run_wasm_opt]);
-        }
-
-        if !no_pack {
+        if target_triple.ends_with("-emscripten") {
             steps.extend(steps![
-                step_create_json,
-                step_copy_readme,
-                step_copy_license,
+                step_install_wasm_bindgen,
+                step_build_wasm,
+                step_create_dir,
+                step_copy_emscripten_outputs,
             ]);
+        } else {               
+            steps.extend(steps![
+                step_build_wasm,
+                step_create_dir,
+                step_install_wasm_bindgen,
+                step_run_wasm_bindgen,
+            ]);
+
+            if !no_opt {
+                steps.extend(steps![step_run_wasm_opt]);
+            }
+
+            if !no_pack {
+                steps.extend(steps![
+                    step_create_json,
+                    step_copy_readme,
+                    step_copy_license,
+                ]);
+            }
         }
 
         steps
@@ -417,6 +427,13 @@ impl Build {
     }
 
     fn step_install_wasm_bindgen(&mut self) -> Result<()> {
+        // TODO(walkingeye): How does this work when this happens before
+        // building the Wasm? There is no Cargo.lock file at that point.
+        // TODO(walkingeye): How does this work when wasm-bindgen points to a
+        // local copy? It still is determining a version and installing it. This
+        // might be a problem I can ignore.
+        // TODO(walkingeye): Require a minimum version of wasm-bindgen for
+        // -emscripten support.
         info!("Identifying wasm-bindgen dependency...");
         let lockfile = Lockfile::new(&self.crate_data)?;
         let bindgen_version = lockfile.require_wasm_bindgen()?;
@@ -447,6 +464,30 @@ impl Build {
             &self.extra_options,
         )?;
         info!("wasm bindings were built at {:#?}.", &self.out_dir);
+        Ok(())
+    }
+
+    fn step_copy_emscripten_outputs(&mut self) -> Result<()> {
+        info!("Copying Emscripten outputs...");
+
+        let profile_name = match self.profile.clone() {
+            BuildProfile::Release | BuildProfile::Profiling => "release",
+            BuildProfile::Dev => "debug",
+            BuildProfile::Custom(profile_name) => &profile_name.clone(),
+        };
+
+        let wasm_path = self.crate_data.target_directory()
+            .join(self.crate_data.get_target_triple())
+            .join(profile_name)
+            .join(self.crate_data.crate_name());
+
+        // TODO(walkingeye): Actually do the copy here. Right now something
+        // is passing `-o /path/to/final.wasm` to the linker, which causes
+        // Emscripten to not output the .js at all. We can sort of override
+        // this was --oformat=js, but then the .js file has the .wasm extension.
+        // I suspect this is a bad assumption in rustc.
+
+        info!("Outputs were copied to {:#?}.", &self.out_dir);
         Ok(())
     }
 

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -361,7 +361,7 @@ impl Build {
 
     fn step_check_for_wasm_target(&mut self) -> Result<()> {
         info!("Checking for wasm-target...");
-        build::wasm_target::check_for_wasm32_target()?;
+        build::wasm_target::check_for_wasm32_target(self.crate_data.get_target_triple())?;
         info!("Checking for wasm-target was successful.");
         Ok(())
     }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -270,7 +270,12 @@ impl Build {
 
     /// Execute this `Build` command.
     pub fn run(&mut self) -> Result<()> {
-        let process_steps = Build::get_process_steps(self.mode, self.no_pack, self.no_opt, self.crate_data.get_target_triple());
+        let process_steps = Build::get_process_steps(
+            self.mode,
+            self.no_pack,
+            self.no_opt,
+            self.crate_data.get_target_triple(),
+        );
 
         let started = Instant::now();
 
@@ -299,7 +304,7 @@ impl Build {
         mode: InstallMode,
         no_pack: bool,
         no_opt: bool,
-        target_triple: String
+        target_triple: String,
     ) -> Vec<(&'static str, BuildStep)> {
         macro_rules! steps {
             ($($name:ident),+) => {
@@ -330,7 +335,7 @@ impl Build {
                 step_create_dir,
                 step_copy_emscripten_outputs,
             ]);
-        } else {               
+        } else {
             steps.extend(steps![
                 step_build_wasm,
                 step_create_dir,
@@ -378,7 +383,12 @@ impl Build {
 
     fn step_build_wasm(&mut self) -> Result<()> {
         info!("Building wasm...");
-        build::cargo_build_wasm(&self.crate_path, self.profile.clone(), self.crate_data.get_target_triple(), &self.extra_options)?;
+        build::cargo_build_wasm(
+            &self.crate_path,
+            self.profile.clone(),
+            self.crate_data.get_target_triple(),
+            &self.extra_options,
+        )?;
 
         info!(
             "wasm built at {:#?}.",
@@ -476,7 +486,9 @@ impl Build {
             BuildProfile::Custom(profile_name) => &profile_name.clone(),
         };
 
-        let wasm_path = self.crate_data.target_directory()
+        let wasm_path = self
+            .crate_data
+            .target_directory()
             .join(self.crate_data.get_target_triple())
             .join(profile_name)
             .join(self.crate_data.crate_name());

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -368,14 +368,14 @@ impl Build {
 
     fn step_build_wasm(&mut self) -> Result<()> {
         info!("Building wasm...");
-        build::cargo_build_wasm(&self.crate_path, self.profile.clone(), &self.extra_options)?;
+        build::cargo_build_wasm(&self.crate_path, self.profile.clone(), self.crate_data.get_target_triple(), &self.extra_options)?;
 
         info!(
             "wasm built at {:#?}.",
             &self
                 .crate_path
                 .join("target")
-                .join("wasm32-unknown-unknown")
+                .join(self.crate_data.get_target_triple())
                 .join("release")
         );
         Ok(())

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -251,7 +251,7 @@ impl Test {
 
     fn step_check_for_wasm_target(&mut self) -> Result<()> {
         info!("Adding wasm-target...");
-        build::wasm_target::check_for_wasm32_target()?;
+        build::wasm_target::check_for_wasm32_target(self.crate_data.get_target_triple())?;
         info!("Adding wasm-target was successful.");
         Ok(())
     }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -600,7 +600,8 @@ impl CrateData {
             "crate-type must be cdylib to compile to {}. Add the following to your \
              Cargo.toml file:\n\n\
              [lib]\n\
-             crate-type = [\"cdylib\", \"rlib\"]", &self.target_triple
+             crate-type = [\"cdylib\", \"rlib\"]",
+            &self.target_triple
         )
     }
 

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -429,7 +429,7 @@ struct NpmData {
 }
 
 #[doc(hidden)]
-pub struct ManifestAndUnsedKeys {
+pub struct ManifestAndUnusedKeys {
     pub manifest: CargoManifest,
     pub unused_keys: BTreeSet<String>,
 }
@@ -482,13 +482,13 @@ impl CrateData {
     }
 
     /// Read the `manifest_path` file and deserializes it using the toml Deserializer.
-    /// Returns a Result containing `ManifestAndUnsedKeys` which contains `CargoManifest`
+    /// Returns a Result containing `ManifestAndUnusedKeys` which contains `CargoManifest`
     /// and a `BTreeSet<String>` containing the unused keys from the parsed file.
     ///
     /// # Errors
     /// Will return Err if the file (manifest_path) couldn't be read or
     /// if deserialize to `CargoManifest` fails.
-    pub fn parse_crate_data(manifest_path: &Path) -> Result<ManifestAndUnsedKeys> {
+    pub fn parse_crate_data(manifest_path: &Path) -> Result<ManifestAndUnusedKeys> {
         let manifest = fs::read_to_string(&manifest_path)
             .with_context(|| anyhow!("failed to read: {}", manifest_path.display()))?;
         let manifest = toml::Deserializer::new(&manifest);
@@ -508,7 +508,7 @@ impl CrateData {
         })
         .with_context(|| anyhow!("failed to parse manifest: {}", manifest_path.display()))?;
 
-        Ok(ManifestAndUnsedKeys {
+        Ok(ManifestAndUnusedKeys {
             manifest,
             unused_keys,
         })
@@ -516,7 +516,7 @@ impl CrateData {
 
     /// Iterating through all the passed `unused_keys` and output
     /// a warning for each unknown key.
-    pub fn warn_for_unused_keys(manifest_and_keys: &ManifestAndUnsedKeys) {
+    pub fn warn_for_unused_keys(manifest_and_keys: &ManifestAndUnusedKeys) {
         manifest_and_keys.unused_keys.iter().for_each(|path| {
             PBAR.warn(&format!(
                 "\"{}\" is an unknown key and will be ignored. Please check your Cargo.toml.",


### PR DESCRIPTION
This is an early draft PR for the purposes of gathering feedback early. There are also pending changes to wasm-bindgen and Emscripten. This is for issue #1468.

This PR does a few things:

1) Removes hard coded references to `wasm32-unknown-unknown`, instead reading `.cargo/config.toml` to determine what the target triple is. If this file isn't present or a triple isn't specified, `wasm32-unknown-unknown` is used as the default.
2) When targeting `-emscripten`, run the wasm-bindgen install step before building. This makes sure it's available for Emscripten during link time.

TODOs:

1) Change the `-o` argument being passed to Emscripten. The default way this is set up passes a full filename ending in `.wasm`, which causes Emscripten to not even attempt to emit JS. This might need a change to rustc.
2) Once `-o` is taken care of, actually copy the final files to `pkg`.
3) After wasm-bindgen is installed, ensure Emscripten can find it. Emscripten is currently reading the location from its own config file, but we might want to set up an environment variable or something to make sure it's using the copy installed by wasm-pack.