### PR TITLE
fix: add the snippets directory by default

### DIFF
--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -668,6 +668,7 @@ impl CrateData {
             let js_bg_file = format!("{}_bg.js", name_prefix);
             files.push(js_bg_file);
         }
+        files.push("snippets".into());
 
         let pkg = &self.data.packages[self.current_idx];
         let npm_name = match scope {

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -105,6 +105,7 @@ fn it_creates_a_package_json_default_path() {
         "js_hello_world_bg.js",
         "js_hello_world_bg.wasm",
         "js_hello_world.js",
+        "snippets",
     ]
     .iter()
     .map(|&s| String::from(s))
@@ -135,6 +136,7 @@ fn it_creates_a_package_json_provided_path() {
         "js_hello_world_bg.js",
         "js_hello_world_bg.wasm",
         "js_hello_world.js",
+        "snippets",
     ]
     .iter()
     .map(|&s| String::from(s))
@@ -165,6 +167,7 @@ fn it_creates_a_package_json_provided_path_with_scope() {
         "js_hello_world_bg.js",
         "js_hello_world_bg.wasm",
         "js_hello_world.js",
+        "snippets",
     ]
     .iter()
     .map(|&s| String::from(s))
@@ -199,6 +202,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_node() {
         "js_hello_world_bg.wasm",
         "js_hello_world.d.ts",
         "js_hello_world.js",
+        "snippets",
     ]
     .iter()
     .map(|&s| String::from(s))
@@ -233,6 +237,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_nomodules() {
         "js_hello_world.d.ts",
         "js_hello_world_bg.wasm",
         "js_hello_world.js",
+        "snippets",
     ]
     .iter()
     .map(|&s| String::from(s))
@@ -265,11 +270,16 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     assert_eq!(pkg.side_effects, vec!["./index.js", "./snippets/*"]);
 
     let actual_files: HashSet<String> = pkg.files.into_iter().collect();
-    let expected_files: HashSet<String> =
-        ["index_bg.wasm", "index_bg.js", "index.d.ts", "index.js"]
-            .iter()
-            .map(|&s| String::from(s))
-            .collect();
+    let expected_files: HashSet<String> = [
+        "index_bg.wasm",
+        "index_bg.js",
+        "index.d.ts",
+        "index.js",
+        "snippets",
+    ]
+    .iter()
+    .map(|&s| String::from(s))
+    .collect();
     assert_eq!(actual_files, expected_files);
 }
 
@@ -315,6 +325,7 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
         "js_hello_world_bg.wasm",
         "js_hello_world_bg.js",
         "js_hello_world.js",
+        "snippets",
     ]
     .iter()
     .map(|&s| String::from(s))
@@ -356,6 +367,7 @@ fn it_creates_a_package_json_with_npm_dependencies_provided_by_wasm_bindgen() {
         "js_hello_world_bg.wasm",
         "js_hello_world_bg.js",
         "js_hello_world.js",
+        "snippets",
     ]
     .iter()
     .map(|&s| String::from(s))


### PR DESCRIPTION
This should fix https://github.com/rustwasm/wasm-pack/issues/1206

I don't know what is _the way_ to detect if the `snippets` directory should be included so, by default, I include it considering it's already in the `sideEffect` section.
Another possibility would be to add to the `Cargo.toml` metadata a `package-json` section that allows to add some files and enforce it there.

Tell me if it's ok with you or if you need some updates 😉 

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
