### PR TITLE
Use the same profile name for both Cargo and wasm-pack

### DIFF
--- a/docs/src/cargo-toml-configuration.md
+++ b/docs/src/cargo-toml-configuration.md
@@ -3,8 +3,8 @@
 `wasm-pack` can be configured via the `package.metadata.wasm-pack` key in
 `Cargo.toml`. Every option has a default, and is not required.
 
-There are three profiles: `dev`, `profiling`, and `release`. These correspond to
-the `--dev`, `--profiling`, and `--release` flags passed to `wasm-pack build`.
+There are three built-in profiles: `dev`, `profiling`, and `release`. These correspond to
+the `--dev`, `--profiling`, and `--release` flags passed to `wasm-pack build`. `wasm_pack` can also be invoked with the `--profile [some custom profile]` option to use a custom profile name. This will also pass that profile to the cargo invocation.
 
 The available configuration options and their default values are shown below:
 
@@ -44,6 +44,7 @@ debug-js-glue = false
 demangle-name-section = true
 dwarf-debug-info = false
 omit-default-module-path = false
+split_linked_modules = false
 
 # `wasm-opt` is on by default in for the release profile, but it can be
 # disabled by setting it to `false`
@@ -55,4 +56,16 @@ debug-js-glue = false
 demangle-name-section = true
 dwarf-debug-info = false
 omit-default-module-path = false
+split_linked_modules = false
+
+# `custom_profile_name` can be anything and must match the value in the `--profile` option when invoking `wasm-pack`.
+[package.metadata.wasm-pack.profile.custom_profile_name]
+wasm-opt = ['-O']
+
+[package.metadata.wasm-pack.profile.custom_profile_name.wasm-bindgen]
+debug-js-glue = false
+demangle-name-section = true
+dwarf-debug-info = false
+omit-default-module-path = false
+split_linked_modules = false
 ```

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -552,9 +552,9 @@ fn parse_crate_data_returns_unused_keys_in_cargo_toml() {
             [dependencies]
             wasm-bindgen = "0.2"
 
-            # Note: production is not valid.
-            [package.metadata.wasm-pack.profile.production.wasm-bindgen]
-            debug-js-glue = true
+            # Note: underscore instead of hyphen is not valid.
+            [package.metadata.wasm-pack.profile.release.wasm-bindgen]
+            debug_js_glue = true
             "#,
         )
         .hello_world_src_lib()
@@ -565,7 +565,7 @@ fn parse_crate_data_returns_unused_keys_in_cargo_toml() {
         .assert()
         .success()
         .stderr(predicates::str::contains(format!(
-        "[WARN]: {} \"package.metadata.wasm-pack.profile.production\" is an unknown key and will \
+        "[WARN]: {} \"package.metadata.wasm-pack.profile.release.wasm-bindgen.debug_js_glue\" is an unknown key and will \
          be ignored. Please check your Cargo.toml.",
         emoji::WARN
     )));

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -163,13 +163,13 @@ impl Fixture {
     pub fn cargo_toml_with_custom_profile(&self, name: &str, profile_name: &str) -> &Self {
         self.file(
             "Cargo.toml",
-            &format!(
+            format!(
                 r#"
                     [package]
                     authors = ["The wasm-pack developers"]
                     description = "so awesome rust+wasm package"
                     license = "WTFPL"
-                    name = "{}"
+                    name = "{name}"
                     repository = "https://github.com/rustwasm/wasm-pack.git"
                     version = "0.1.0"
 
@@ -187,12 +187,14 @@ impl Fixture {
                     [dev-dependencies]
                     wasm-bindgen-test = "0.3"
 
-                    [profile.{}]
+                    [profile.{profile_name}]
                     inherits = "release"
                     opt-level = 'z'
                     lto = true
-                "#,
-                name, profile_name
+
+                    [package.metadata.wasm-pack.profile.{profile_name}]
+                    wasm-opt = ["-Oz"]
+                "#
             ),
         )
     }


### PR DESCRIPTION
When running `wasm-pack` with a custom profile (`wasm-pack build . --profile custom_profile_name`), the Cargo profile with name `custom_profile_name` will be used, but `wasm-pack` will use a profile called `custom`.

More concisely,
Cargo will use `[profile.custom_profile_name]`, whereas
`wasm-pack` will use `[package.metadata.wasm-pack.profile.custom]`

This PR makes `wasm-pack` use the custom profile name provided with the `--profile` option so that
`wasm-pack` will now use `[package.metadata.wasm-pack.profile.custom_profile_name]`.

Closes #1488.

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
