### PR TITLE
Allow for custom URL for binary downloads via NPM 

### DIFF
--- a/npm/binary.js
+++ b/npm/binary.js
@@ -28,11 +28,23 @@ const getPlatform = () => {
 const getBinary = () => {
   const platform = getPlatform();
   const version = require("./package.json").version;
-  const author = "rustwasm";
-  const name = "wasm-pack";
-  const url = `https://github.com/${author}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
+
+  const author = process.env.WASMPACK_REPO_AUTHOR || "rustwasm";
+  const name = process.env.WASMPACK_REPO_NAME || "wasm-pack";
+
+  let url = process.env.WASMPACK_CUSTOM_URL;
+  if (url) {
+    url = url
+      .replace("{{author}}", author)
+      .replace("{{name}}", name)
+      .replace("{{version}}", version)
+      .replace("{{platform}}", platform);
+  } else {
+    url = `https://github.com/${author}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
+  }
+
   return new Binary(platform === windows ? "wasm-pack.exe" : "wasm-pack", url, {
-    installDirectory: join(__dirname, "binary")
+    installDirectory: join(__dirname, "binary"),
   });
 };
 
@@ -44,7 +56,7 @@ const install = () => {
 const run = () => {
   const binary = getBinary();
   binary.run();
-}
+};
 
 module.exports = {
   install,


### PR DESCRIPTION
As discussed in #605, the ability to be able to specify a custom URL for binary downloads is instrumental when working in certain environments, for example, my company blocks Github even when going through a proxy.

This PR includes three environment variables that allow for over-riding the URL and certain download aspects of the current vendoring script, namely:

- `WASMPACK_CUSTOM_URL` (allowing `{{author}}`, `{{name}}`, `{{version}}`, and `{{platform}}` placeholders)
- `WASMPACK_REPO_AUTHOR` to override the default author
- `WASMPACK_REPO_NAME` to override the default name

Make sure these boxes are checked! 📦✅

- [X] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [X] You ran `cargo fmt` on the code base before submitting
- [X] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
