### PR TITLE
fix: Add `--locked` to `cargo install` to support lower rust versions

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -257,6 +257,7 @@ pub fn cargo_install(
 
     cmd.arg("install")
         .arg("--force")
+        .arg("--locked")
         .arg(crate_name)
         .arg("--root")
         .arg(&tmp);


### PR DESCRIPTION
Resolves #1498 

Add `--locked` to the invocation of `cargo install` as some dependencies with MSRV of 1.81 otherwise make wasm-pack not work on rust<=1.80 unless one has manually installed wasm-bindgen-cli.

An alternative to adding `--locked` would be to print an error message that suggests manually installing wasm-bindgen-cli with `cargo install wasm-bindgen-cli --locked`.