### PR TITLE
Fix many broken cargo tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,15 @@ For help setting up a global .gitignore check out this [GitHub article]!
 
 [GitHub article]: https://help.github.com/articles/ignoring-files/#create-a-global-gitignore
 
+## Running tests
+
+Some of this project's tests run in the browser with webdriver. macOS users
+may need to first run:
+
+```
+safaridriver --enable
+```
+
 ## Conduct
 
 As mentioned in the readme file, this project is a part of the [`rust-wasm` working group],

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -176,8 +176,9 @@ fn dash_dash_web_target_has_error_on_old_bindgen() {
     let output = String::from_utf8(cmd.get_output().stderr.clone()).unwrap();
 
     assert!(
-        output.contains("Please update your project to wasm-bindgen version >= 0.2.39"),
-        "Output did not contain 'Please update your project to wasm-bindgen version >= 0.2.39', output was {}",
+        output.contains("Please update your project to wasm-bindgen version >= 0.2.39")
+            || output.contains("older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust"),
+        "Output did not contain 'Please update your project to wasm-bindgen version >= 0.2.39' or 'older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust', output was {}",
         output
     );
 }

--- a/tests/all/download.rs
+++ b/tests/all/download.rs
@@ -10,7 +10,7 @@ fn can_download_prebuilt_wasm_bindgen() {
     let dir = tempfile::TempDir::new().unwrap();
     let cache = binary_install::Cache::at(dir.path());
     if let install::Status::Found(dl) =
-        install::download_prebuilt(&Tool::WasmBindgen, &cache, "0.2.74", true).unwrap()
+        install::download_prebuilt(&Tool::WasmBindgen, &cache, "0.2.95", true).unwrap()
     {
         assert!(dl.binary("wasm-bindgen").unwrap().is_file());
         assert!(dl.binary("wasm-bindgen-test-runner").unwrap().is_file())
@@ -27,7 +27,7 @@ fn can_download_prebuilt_wasm_bindgen() {
 ))]
 fn downloading_prebuilt_wasm_bindgen_handles_http_errors() {
     let dir = tempfile::TempDir::new().unwrap();
-    let bad_version = "0.2.74-some-trailing-version-stuff-that-does-not-exist";
+    let bad_version = "0.2.95-some-trailing-version-stuff-that-does-not-exist";
     let cache = binary_install::Cache::at(dir.path());
     let result = install::download_prebuilt(&Tool::WasmBindgen, &cache, bad_version, true);
     assert!(result.is_err());

--- a/tests/all/lockfile.rs
+++ b/tests/all/lockfile.rs
@@ -8,7 +8,7 @@ fn it_gets_wasm_bindgen_version() {
     fixture.cargo_check();
     let data = CrateData::new(&fixture.path, None).unwrap();
     let lock = Lockfile::new(&data).unwrap();
-    assert_eq!(lock.wasm_bindgen_version(), Some("0.2.74"),);
+    assert_eq!(lock.wasm_bindgen_version(), Some("0.2.95"),);
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn it_gets_wasm_bindgen_version_in_crate_inside_workspace() {
                 crate-type = ["cdylib"]
 
                 [dependencies]
-                wasm-bindgen = "=0.2.74"
+                wasm-bindgen = "=0.2.95"
             "#,
         )
         .file(
@@ -62,7 +62,7 @@ fn it_gets_wasm_bindgen_version_in_crate_inside_workspace() {
     fixture.cargo_check();
     let data = CrateData::new(&fixture.path.join("blah"), None).unwrap();
     let lock = Lockfile::new(&data).unwrap();
-    assert_eq!(lock.wasm_bindgen_version(), Some("0.2.74"),);
+    assert_eq!(lock.wasm_bindgen_version(), Some("0.2.95"),);
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn it_gets_wasm_bindgen_version_from_dependencies() {
                 crate-type = ["cdylib"]
 
                 [dependencies]
-                wasm-bindgen = "=0.2.74"
+                wasm-bindgen = "=0.2.95"
             "#,
         )
         .file(
@@ -130,5 +130,5 @@ fn it_gets_wasm_bindgen_version_from_dependencies() {
     fixture.cargo_check();
     let data = CrateData::new(&fixture.path.join("parent"), None).unwrap();
     let lock = Lockfile::new(&data).unwrap();
-    assert_eq!(lock.wasm_bindgen_version(), Some("0.2.74"),);
+    assert_eq!(lock.wasm_bindgen_version(), Some("0.2.95"),);
 }

--- a/tests/all/lockfile.rs
+++ b/tests/all/lockfile.rs
@@ -1,4 +1,5 @@
 use crate::utils::fixture;
+use semver::{Version, VersionReq};
 use wasm_pack::lockfile::Lockfile;
 use wasm_pack::manifest::CrateData;
 
@@ -17,7 +18,8 @@ fn it_gets_wasm_bindgen_test_version() {
     fixture.cargo_check();
     let data = CrateData::new(&fixture.path, None).unwrap();
     let lock = Lockfile::new(&data).unwrap();
-    assert_eq!(lock.wasm_bindgen_test_version(), Some("0.3.24"),);
+    let ver = Version::parse(lock.wasm_bindgen_test_version().unwrap()).unwrap();
+    assert!(VersionReq::parse("0.3").unwrap().matches(&ver));
 }
 
 #[test]

--- a/tests/all/readme.rs
+++ b/tests/all/readme.rs
@@ -60,7 +60,7 @@ fn it_copies_a_readme_provided_path() {
             # bindgen downloaded is what we expect, and if `=` is
             # removed then it will download whatever the newest version
             # of wasm-bindgen is which may not be what's listed here.
-            wasm-bindgen = "=0.2.74"
+            wasm-bindgen = "=0.2.95"
 
             [dev-dependencies]
             wasm-bindgen-test = "0.3"
@@ -120,7 +120,7 @@ fn it_ignores_a_disabled_readme() {
             # bindgen downloaded is what we expect, and if `=` is
             # removed then it will download whatever the newest version
             # of wasm-bindgen is which may not be what's listed here.
-            wasm-bindgen = "=0.2.74"
+            wasm-bindgen = "=0.2.95"
 
             [dev-dependencies]
             wasm-bindgen-test = "0.3"

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -144,7 +144,7 @@ impl Fixture {
                     # bindgen downloaded is what we expect, and if `=` is
                     # removed then it will download whatever the newest version
                     # of wasm-bindgen is which may not be what's listed here.
-                    wasm-bindgen = "=0.2.74"
+                    wasm-bindgen = "=0.2.95"
 
                     [dev-dependencies]
                     wasm-bindgen-test = "0.3"
@@ -182,7 +182,7 @@ impl Fixture {
                     # bindgen downloaded is what we expect, and if `=` is
                     # removed then it will download whatever the newest version
                     # of wasm-bindgen is which may not be what's listed here.
-                    wasm-bindgen = "=0.2.74"
+                    wasm-bindgen = "=0.2.95"
 
                     [dev-dependencies]
                     wasm-bindgen-test = "0.3"
@@ -265,7 +265,7 @@ impl Fixture {
 
         static INSTALL_WASM_BINDGEN: Once = Once::new();
         let cache = self.cache();
-        let version = "0.2.74";
+        let version = "0.2.95";
 
         let download = || {
             if let Ok(download) =


### PR DESCRIPTION
This fixes most, but not all, test failures mentioned in #1508 . There are still one or two different failures on macOS 15.5 depending on the rust version used.

## Template

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
