### PR TITLE
Clippy fixes

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -21,7 +21,7 @@ pub fn wasm_bindgen_build(
     reference_types: bool,
     target: Target,
     profile: BuildProfile,
-    extra_options: &Vec<String>,
+    extra_options: &[String],
 ) -> Result<()> {
     let profile_name = match profile.clone() {
         BuildProfile::Release | BuildProfile::Profiling => "release",

--- a/src/build/wasm_target.rs
+++ b/src/build/wasm_target.rs
@@ -68,7 +68,7 @@ pub fn check_for_wasm32_target() -> Result<()> {
 /// Get rustc's sysroot as a PathBuf
 fn get_rustc_sysroot() -> Result<PathBuf> {
     let command = Command::new("rustc")
-        .args(&["--print", "sysroot"])
+        .args(["--print", "sysroot"])
         .output()?;
 
     if command.status.success() {
@@ -84,7 +84,7 @@ fn get_rustc_sysroot() -> Result<PathBuf> {
 /// Get wasm32-unknown-unknown target libdir
 fn get_rustc_wasm32_unknown_unknown_target_libdir() -> Result<PathBuf> {
     let command = Command::new("rustc")
-        .args(&[
+        .args([
             "--target",
             "wasm32-unknown-unknown",
             "--print",

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -45,10 +45,11 @@ pub struct Build {
 
 /// What sort of output we're going to be generating and flags we're invoking
 /// `wasm-bindgen` with.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum Target {
     /// Default output mode or `--target bundler`, indicates output will be
     /// used with a bundle in a later step.
+    #[default]
     Bundler,
     /// Correspond to `--target web` where the output is natively usable as an
     /// ES module in a browser and the wasm is manually instantiated.
@@ -63,12 +64,6 @@ pub enum Target {
     /// Correspond to `--target deno` where the output is natively usable as
     /// a Deno module loaded with `import`.
     Deno,
-}
-
-impl Default for Target {
-    fn default() -> Target {
-        Target::Bundler
-    }
 }
 
 impl fmt::Display for Target {
@@ -115,6 +110,7 @@ pub enum BuildProfile {
 /// Everything required to configure and run the `wasm-pack build` command.
 #[derive(Debug, Args)]
 #[command(allow_hyphen_values = true, trailing_var_arg = true)]
+#[derive(Default)]
 pub struct BuildOptions {
     /// The path to the Rust crate. If not set, searches up the path from the current directory.
     #[clap()]
@@ -184,30 +180,6 @@ pub struct BuildOptions {
 
     /// List of extra options to pass to `cargo build`
     pub extra_options: Vec<String>,
-}
-
-impl Default for BuildOptions {
-    fn default() -> Self {
-        Self {
-            path: None,
-            scope: None,
-            mode: InstallMode::default(),
-            disable_dts: false,
-            weak_refs: false,
-            reference_types: false,
-            target: Target::default(),
-            debug: false,
-            dev: false,
-            no_pack: false,
-            no_opt: false,
-            release: false,
-            profiling: false,
-            profile: None,
-            out_dir: String::new(),
-            out_name: None,
-            extra_options: Vec::new(),
-        }
-    }
 }
 
 type BuildStep = fn(&mut Build) -> Result<()>;

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -16,9 +16,9 @@ pub fn login(
         &scope, &registry, &auth_type
     );
     info!("npm info located in the npm debug log");
-    npm::npm_login(&registry, &scope, &auth_type)?;
+    npm::npm_login(&registry, scope, auth_type)?;
     info!("Logged you in!");
 
-    PBAR.info(&"👋  logged you in!".to_string());
+    PBAR.info("👋  logged you in!");
     Ok(())
 }

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -121,7 +121,7 @@ impl Test {
         } = test_opts;
 
         let first_arg_is_path = path_and_extra_options
-            .get(0)
+            .first()
             .map(|first_arg| !first_arg.starts_with("-"))
             .unwrap_or(false);
 
@@ -295,7 +295,7 @@ impl Test {
         let status = install::download_prebuilt_or_cargo_install(
             Tool::WasmBindgen,
             &self.cache,
-            &bindgen_version,
+            bindgen_version,
             self.mode.install_permitted(),
         )?;
 

--- a/src/command/utils.rs
+++ b/src/command/utils.rs
@@ -38,7 +38,7 @@ fn find_manifest_from_cwd() -> Result<PathBuf> {
 /// Construct our `pkg` directory in the crate.
 pub fn create_pkg_dir(out_dir: &Path) -> Result<()> {
     let _ = fs::remove_file(out_dir.join("package.json")); // Clean up package.json from previous runs
-    fs::create_dir_all(&out_dir)?;
+    fs::create_dir_all(out_dir)?;
     fs::write(out_dir.join(".gitignore"), "*")?;
     Ok(())
 }
@@ -53,7 +53,7 @@ pub fn find_pkg_directory(path: &Path, pkg_directory: &Path) -> Option<PathBuf> 
     WalkDir::new(path)
         .into_iter()
         .filter_map(|x| x.ok().map(|e| e.into_path()))
-        .find(|x| is_pkg_directory(&x, pkg_directory))
+        .find(|x| is_pkg_directory(x, pkg_directory))
 }
 
 fn is_pkg_directory(path: &Path, pkg_directory: &Path) -> bool {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -13,8 +13,8 @@ pub fn generate(template: &str, name: &str, install_status: &install::Status) ->
         .binary(&Tool::CargoGenerate.to_string())?;
     let mut cmd = Command::new(&bin_path);
     cmd.arg("generate");
-    cmd.arg("--git").arg(&template);
-    cmd.arg("--name").arg(&name);
+    cmd.arg("--git").arg(template);
+    cmd.arg("--name").arg(name);
 
     println!(
         "{} Generating a new rustwasm project with name '{}'...",

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -110,7 +110,7 @@ pub fn get_cli_version(tool: &Tool, path: &Path) -> Result<String> {
     let mut cmd = Command::new(path);
     cmd.arg("--version");
     let stdout = child::run_capture_stdout(cmd, tool)?;
-    let version = stdout.trim().split_whitespace().nth(1);
+    let version = stdout.split_whitespace().nth(1);
     match version {
         Some(v) => Ok(v.to_string()),
         None => bail!("Something went wrong! We couldn't determine your version of the wasm-bindgen CLI. We were supposed to set that up for you, so it's likely not your fault! You should file an issue: https://github.com/drager/wasm-pack/issues/new?template=bug_report.md.")

--- a/src/install/mode.rs
+++ b/src/install/mode.rs
@@ -3,21 +3,16 @@ use std::str::FromStr;
 
 /// The `InstallMode` determines which mode of initialization we are running, and
 /// what install steps we perform.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum InstallMode {
     /// Perform all the install steps.
+    #[default]
     Normal,
     /// Don't install tools like `wasm-bindgen`, just use the global
     /// environment's existing versions to do builds.
     Noinstall,
     /// Skip the rustc version check
     Force,
-}
-
-impl Default for InstallMode {
-    fn default() -> InstallMode {
-        InstallMode::Normal
-    }
 }
 
 impl FromStr for InstallMode {

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -24,7 +24,6 @@ use std::path::Path;
 use std::process;
 
 use anyhow::{anyhow, bail, Context, Result};
-use which;
 
 pub fn install() -> ! {
     if let Err(e) = do_install() {

--- a/src/license.rs
+++ b/src/license.rs
@@ -39,12 +39,12 @@ fn glob_license_files(path: &Path) -> Result<Vec<String>> {
 /// Copy the crate's license into the `pkg` directory.
 pub fn copy_from_crate(crate_data: &CrateData, path: &Path, out_dir: &Path) -> Result<()> {
     assert!(
-        fs::metadata(path).ok().map_or(false, |m| m.is_dir()),
+        fs::metadata(path).ok().is_some_and(|m| m.is_dir()),
         "crate directory should exist"
     );
 
     assert!(
-        fs::metadata(&out_dir).ok().map_or(false, |m| m.is_dir()),
+        fs::metadata(out_dir).ok().is_some_and(|m| m.is_dir()),
         "crate's pkg directory should exist"
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn run() -> Result<()> {
     let wasm_pack_version = background_check_for_updates();
 
     // Deprecate `init`
-    if let Some("init") = env::args().nth(1).as_ref().map(|arg| arg.as_str()) {
+    if let Some("init") = env::args().nth(1).as_deref() {
         println!("wasm-pack init is deprecated, consider using wasm-pack build");
     }
 
@@ -111,7 +111,7 @@ fn setup_panic_hooks() {
     let default_hook = panic::take_hook();
 
     if let Err(_) = env::var("RUST_BACKTRACE") {
-        panic::set_hook(Box::new(move |info: &panic::PanicInfo| {
+        panic::set_hook(Box::new(move |info: &panic::PanicHookInfo| {
             // First call the default hook that prints to standard error.
             default_hook(info);
 

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -20,7 +20,7 @@ pub fn npm_pack(path: &str) -> Result<()> {
 pub fn npm_publish(path: &str, access: Option<Access>, tag: Option<String>) -> Result<()> {
     let mut cmd = child::new_command("npm");
     match access {
-        Some(a) => cmd.current_dir(path).arg("publish").arg(&a.to_string()),
+        Some(a) => cmd.current_dir(path).arg("publish").arg(a.to_string()),
         None => cmd.current_dir(path).arg("publish"),
     };
     if let Some(tag) = tag {

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -10,11 +10,11 @@ use crate::PBAR;
 /// Copy the crate's README into the `pkg` directory.
 pub fn copy_from_crate(crate_data: &CrateData, path: &Path, out_dir: &Path) -> Result<()> {
     assert!(
-        fs::metadata(path).ok().map_or(false, |m| m.is_dir()),
+        fs::metadata(path).ok().is_some_and(|m| m.is_dir()),
         "crate directory should exist"
     );
     assert!(
-        fs::metadata(&out_dir).ok().map_or(false, |m| m.is_dir()),
+        fs::metadata(out_dir).ok().is_some_and(|m| m.is_dir()),
         "crate's pkg directory should exist"
     );
 

--- a/src/test/webdriver/geckodriver.rs
+++ b/src/test/webdriver/geckodriver.rs
@@ -77,7 +77,7 @@ pub fn install_geckodriver(cache: &Cache, installation_allowed: bool) -> Result<
 ///
 /// It returns the latest one without checking the installed `Firefox` version
 /// - it should be relatively safe because each `geckodriver` supports many `Firefox` versions:
-/// https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html#supported-platforms
+///   <https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html#supported-platforms>
 fn get_geckodriver_url(target: &str, ext: &str) -> String {
     let fetch_and_save_version =
         || fetch_latest_geckodriver_tag_json().and_then(save_geckodriver_version);


### PR DESCRIPTION
This fixes a bunch of non-pedantic lints using rustc 1.90.0. `cargo fmt` applied.