### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
       - 'v*' # Run when tag matches v*, i.e. v1.0, v20.15.10
 
 name: Release
+permissions:
+  contents: read
 
 env:
   RELEASE_BIN: wasm-pack
@@ -112,6 +114,8 @@ jobs:
   release:
     name: GitHub Release
     needs: build
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Query version number


### PR DESCRIPTION
Potential fix for [https://github.com/drager/wasm-pack/security/code-scanning/5](https://github.com/drager/wasm-pack/security/code-scanning/5)

To fix the problem, we must add a `permissions` block either at the workflow level (affecting all jobs by default) or at the job level (affecting only that job). The best practice is to set the root workflow `permissions` to a minimal baseline (usually `contents: read`), and then override with job-level permissions only as needed. In this workflow, the `build` job mostly runs CI/build steps and uploads artifacts; uploading artifacts requires only `contents: read`, `actions: read`, and for the upload-release-asset step in `release`, the job needs `contents: read`, and `contents: write` (for creating a release), but more precisely `contents: read` and `contents: write` for release assets. However, the recommended permission for uploading to releases is `contents: read` (to download artifacts) and `contents: write` (to create the release and upload assets).

Therefore:
- Add at the root workflow level:
  ```yaml
  permissions:
    contents: read
  ```
- Add at the job level for the `release` job:
  ```yaml
  permissions:
    contents: write
  ```

This limits the jobs to the least privileges they require, per best practice.  
Change to `.github/workflows/release.yml` as follows:
- Insert the workflow-level `permissions` block after `name: Release` (line 7).
- Insert a job-level `permissions` block in the `release` job under `needs: build` (after line 114).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
