### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     name: Test
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/drager/wasm-pack/security/code-scanning/1](https://github.com/drager/wasm-pack/security/code-scanning/1)

The best way to fix this problem is to add an explicit `permissions` block to the job (or to the root of the workflow, if preferred). Since no steps in the job modify repository contents, pull requests, issues, or anything outside of what `contents: read` permits, the safest and recommended configuration is to set `contents: read`. This limits the GITHUB_TOKEN permissions and adheres to the principle of least privilege. To implement this, edit `.github/workflows/test.yml`, and under either the root of the workflow or (typically better for clarity) under the job definition, add:

```yaml
permissions:
  contents: read
```

If using job-scoped permissions, insert after line corresponding to the start of the job (`test:`) or after job name (`name: Test`). No imports, methods, or other code are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
