### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   book:
+    permissions:
+      contents: write
     name: Build and deploy book
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/drager/wasm-pack/security/code-scanning/2](https://github.com/drager/wasm-pack/security/code-scanning/2)

To fix this problem, you should explicitly declare the `permissions` block for the job (or at the workflow root) and set it to the least privilege required. The workflow shown builds and deploys the documentation book using the `JamesIves/github-pages-deploy-action`, which requires `contents: write` to push to the repository (gh-pages branch), while other steps only need read access. The optimal fix is to set `permissions` at the job or workflow level to:
```yaml
permissions:
  contents: write
```
You should place this block either directly below `jobs:` for an individual job, or at the top level (below the workflow name/on). Editing just the job (i.e., just above line 9) is sufficient and more precise.

No additional methods, imports, or definitions are required. This strictly involves modifying the YAML in `.github/workflows/book.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
