### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,4 +1,7 @@
 name: Automatic Approve
+permissions:
+  contents: read
+  pull-requests: write
 on:
   schedule: 
     - cron: "0 0 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/drager/wasm-pack/security/code-scanning/3](https://github.com/drager/wasm-pack/security/code-scanning/3)

To fix this problem, you should explicitly add a `permissions` block to the workflow file specifying only the minimal privileges necessary for the workflow (and its job) to function. Since we're using an automatic approve action that likely only needs to write to pull requests and possibly read workflow contents, we can set `contents: read` and `pull-requests: write`. You can add this block either at the workflow level (right after the workflow name, so all jobs inherit the permissions) or at the job level under `automatic-approve`. The preferred approach is to add it at the top level so all jobs (including any added later) will inherit least privilege by default.

Edit `.github/workflows/approve.yml`:
- Insert the following block after the workflow `name:` and before the `on:` key:
  ```yaml
  permissions:
    contents: read
    pull-requests: write
  ```
- No imports, methods, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
