### PR TITLE
fix(npm): update npm package download url

### DIFF
--- a/npm/binary.js
+++ b/npm/binary.js
@@ -28,11 +28,11 @@ const getPlatform = () => {
 const getBinary = () => {
   const platform = getPlatform();
   const version = require("./package.json").version;
-  const author = "rustwasm";
+  const author = "drager";
   const name = "wasm-pack";
   const url = `https://github.com/${author}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
   return new Binary(platform === windows ? "wasm-pack.exe" : "wasm-pack", url, {
-    installDirectory: join(__dirname, "binary")
+    installDirectory: join(__dirname, "binary"),
   });
 };
 
@@ -44,7 +44,7 @@ const install = () => {
 const run = () => {
   const binary = getBinary();
   binary.run();
-}
+};
 
 module.exports = {
   install,


### PR DESCRIPTION
The npm binary.js install still referred to old wasm repo. So I made the change to point to new url.
Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
