### PR TITLE
Fix capitalization: considerations to Considerations

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,7 +4,7 @@
 - [Quickstart](./quickstart.md)
 - [Prerequisites](./prerequisites/index.md)
   - [npm (optional)](./prerequisites/npm.md)
-  - [considerations](./prerequisites/considerations.md)
+  - [Considerations](./prerequisites/considerations.md)
   - [Non-`rustup` setups](./prerequisites/non-rustup-setups.md)
 - [Commands](./commands/index.md)
   - [`new`](./commands/new.md)


### PR DESCRIPTION
Fixes inconsistent capitalization in documentation summary. 'considerations' should be 'Considerations' to match the Title Case convention used by other entries.