### PR TITLE
fix: Ignore LICENSE* directories.

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -54,6 +54,19 @@ pub fn copy_from_crate(crate_data: &CrateData, path: &Path, out_dir: &Path) -> R
 
             match license_files {
                 Ok(files) => {
+                    let files: Vec<_> = files
+                        .iter()
+                        .filter_map(|file| {
+                            let file = path.join(file);
+
+                            if file.is_file() {
+                                file.file_name().map(|file| file.to_os_string())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+
                     if files.is_empty() {
                         PBAR.info("License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory");
                         return Ok(());
@@ -61,10 +74,6 @@ pub fn copy_from_crate(crate_data: &CrateData, path: &Path, out_dir: &Path) -> R
 
                     for license_file in files {
                         let crate_license_path = path.join(&license_file);
-                        if crate_license_path.is_dir() {
-                            continue;
-                        }
-
                         let new_license_path = out_dir.join(&license_file);
                         if fs::copy(&crate_license_path, &new_license_path).is_err() {
                             PBAR.info("origin crate has no LICENSE");

--- a/src/license.rs
+++ b/src/license.rs
@@ -58,8 +58,13 @@ pub fn copy_from_crate(crate_data: &CrateData, path: &Path, out_dir: &Path) -> R
                         PBAR.info("License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory");
                         return Ok(());
                     }
+
                     for license_file in files {
                         let crate_license_path = path.join(&license_file);
+                        if crate_license_path.is_dir() {
+                            continue;
+                        }
+
                         let new_license_path = out_dir.join(&license_file);
                         if fs::copy(&crate_license_path, &new_license_path).is_err() {
                             PBAR.info("origin crate has no LICENSE");


### PR DESCRIPTION
Fixes an issue where when following REUSE (https://reuse.software/) you create a LICENSES directory, but it has more licenses in it than that of your project, so should be ignored.

Anyway, if you don't ignore it the current logic is still wrong, because it treats all LICENSE* like they are files and does not go down the directory path if it is a directory.

Make sure these boxes are checked! 📦✅

- [X] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [X] You ran `cargo fmt` on the code base before submitting
- [X] You reference which issue is being closed in the PR text

I don't think an issue would be closed, but this is maybe related to #1551.

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
