### PR TITLE
feat: update doc and reference to github repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1102,7 +1102,7 @@
     installing the target on your specific rust setup- including the fact that
     it may _not_ be possible to add the target to some setups.
 
-    Check out the docs [here](https://drager.github.io/wasm-pack/book/prerequisites/non-rustup-setups.html).
+    Check out the docs [here](https://wasm-bindgen.github.io/wasm-pack/book/prerequisites/non-rustup-setups.html).
 
     [issue/579]: https://github.com/rustwasm/wasm-pack/issues/579
     [pull/602]: https://github.com/rustwasm/wasm-pack/pull/602
@@ -1183,7 +1183,7 @@
     wasm-pack build --target web
     ```
 
-    Learn more about how to use this target by [checking out the docs!](https://drager.github.io/wasm-pack/book/commands/build.html#target)
+    Learn more about how to use this target by [checking out the docs!](https://wasm-bindgen.github.io/wasm-pack/book/commands/build.html#target)
 
     [pull/567]: https://github.com/rustwasm/wasm-pack/pull/567
 
@@ -1363,7 +1363,7 @@
 
     [DebugSteve]: https://github.com/DebugSteven
     [single location]: https://rustwasm.github.io/docs.html
-    [See `wasm-pack's` master docs here]: https://drager.github.io/wasm-pack/book/
+    [See `wasm-pack's` master docs here]: https://wasm-bindgen.github.io/wasm-pack/book/
     [pull/565]: https://github.com/rustwasm/wasm-pack/pull/565
 
   - **Add new QuickStart guide for "Hybrid Applications with Webpack" - [DebugSteven] [pull/536]**
@@ -1378,7 +1378,7 @@
     [This template] hasn't gotten as much attention because we've lacked a quickstart guide for folks to discover
     and follow- now we've got one!
 
-    Check out the guide [here](https://drager.github.io/wasm-pack/book/tutorials/hybrid-applications-with-webpack/index.html)!
+    Check out the guide [here](https://wasm-bindgen.github.io/wasm-pack/book/tutorials/hybrid-applications-with-webpack/index.html)!
 
     [This temaplte]: https://github.com/rustwasm/rust-webpack-template
     [DebugSteven]: https://github.com/DebugSteven
@@ -1391,7 +1391,7 @@
     However, for folks who don't use the template, `wee_alloc` is something important to know about- so now we have
     given it its own section!
 
-    Check out the deepdive [here](https://drager.github.io/wasm-pack/book/tutorials/npm-browser-packages/template-deep-dive/wee_alloc.html)!
+    Check out the deepdive [here](https://wasm-bindgen.github.io/wasm-pack/book/tutorials/npm-browser-packages/template-deep-dive/wee_alloc.html)!
 
     [surma]: https://github.com/surma
     [pull/542]: https://github.com/rustwasm/wasm-pack/pull/542
@@ -1482,7 +1482,7 @@
     As always- there are defaults for you to use, but if you love to configure (or have a project that requires it),
     get excited, as your options have grown now and will continue to!
 
-    [profile-config-docs]: https://drager.github.io/wasm-pack/book/cargo-toml-configuration.html
+    [profile-config-docs]: https://wasm-bindgen.github.io/wasm-pack/book/cargo-toml-configuration.html
     [`cargo profile` documentation]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections
     [issue/153]: https://github.com/rustwasm/wasm-pack/issues/153
     [issue/160]: https://github.com/rustwasm/wasm-pack/issues/160
@@ -1510,7 +1510,7 @@
     In the above example, the flag `-Z offline` will be passed to `cargo build`. This feature is documented
     [here][cargo opts docs].
 
-    [cargo opts docs]: https://drager.github.io/wasm-pack/book/commands/build.html#extra-options
+    [cargo opts docs]: https://wasm-bindgen.github.io/wasm-pack/book/commands/build.html#extra-options
     [torkve]: https://github.com/torkve
     [issue/455]: https://github.com/rustwasm/wasm-pack/issues/455
     [pull/461]: https://github.com/rustwasm/wasm-pack/pull/461
@@ -1849,7 +1849,7 @@
 
     This PR also has a complete rework of our documentation.
 
-    Check it out [here](https://drager.github.io/wasm-pack/)!
+    Check it out [here](https://wasm-bindgen.github.io/wasm-pack/)!
 
   - #### 🍱 Module Support
 
@@ -2062,7 +2062,7 @@
       This is experimental- so please try it out and file issues as you run into things!
       You'll always be able to use `cargo install` as a backup.
 
-      Checkout the new installer [here](https://drager.github.io/wasm-pack/installer/)!
+      Checkout the new installer [here](https://wasm-bindgen.github.io/wasm-pack/installer/)!
 
       [pull/307]: https://github.com/rustwasm/wasm-pack/pull/307
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,12 @@ name = "wasm-pack"
 description = "📦✨ your favorite rust -> wasm workflow tool!"
 version = "0.14.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>", "Jesper Håkansson <jesper@jesperh.se>"]
-repository = "https://github.com/drager/wasm-pack.git"
+repository = "https://github.com/wasm-bindgen/wasm-pack.git"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 readme = "README.md"
 categories = ["wasm"]
-documentation = "https://drager.github.io/wasm-pack/"
+documentation = "https://wasm-bindgen.github.io/wasm-pack/"
 
 [dependencies]
 anyhow = "1.0.100"

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
   </p>
 
   <p>
-    <a href="https://github.com/drager/wasm-pack/actions/workflows/test.yml"><img alt="Build Status" src="https://github.com/drager/wasm-pack/actions/workflows/test.yml/badge.svg?branch=master"/></a>
+    <a href="https://github.com/wasm-bindgen/wasm-pack/actions/workflows/test.yml"><img alt="Build Status" src="https://github.com/wasm-bindgen/wasm-pack/actions/workflows/test.yml/badge.svg?branch=master"/></a>
     <a href="https://crates.io/crates/wasm-pack"><img alt="crates.io" src="https://img.shields.io/crates/v/wasm-pack"/></a>
   </p>
 
   <h3>
-    <a href="https://drager.github.io/wasm-pack/book">Docs</a>
+    <a href="https://wasm-bindgen.github.io/wasm-pack/book">Docs</a>
     <span> | </span>
-    <a href="https://github.com/drager/wasm-pack/blob/master/CONTRIBUTING.md">Contributing</a>
+    <a href="https://github.com/wasm-bindgen/wasm-pack/blob/master/CONTRIBUTING.md">Contributing</a>
     <span> | </span>
     <a href="https://discordapp.com/channels/442252698964721669/443151097398296587">Chat</a>
   </h3>
@@ -38,21 +38,21 @@ alongside any javascript packages in workflows that you already use, such as [we
 
 This project requires Rust 1.30.0 or later.
 
-- [Development Environment](https://drager.github.io/wasm-pack/book/prerequisites/index.html)
-- [Installation](https://drager.github.io/wasm-pack/installer)
+- [Development Environment](https://wasm-bindgen.github.io/wasm-pack/book/prerequisites/index.html)
+- [Installation](https://wasm-bindgen.github.io/wasm-pack/installer)
 
 ## ⚡ Quickstart Guide
 
 Visit the [quickstart guide] in our documentation.
 
-[quickstart guide]: https://drager.github.io/wasm-pack/book/quickstart.html
+[quickstart guide]: https://wasm-bindgen.github.io/wasm-pack/book/quickstart.html
 
 ## 🎙️ Commands
 
-- [`new`](https://drager.github.io/wasm-pack/book/commands/new.html): Generate a new RustWasm project using a template
-- [`build`](https://drager.github.io/wasm-pack/book/commands/build.html): Generate an npm wasm pkg from a rustwasm crate
-- [`test`](https://drager.github.io/wasm-pack/book/commands/test.html): Run browser tests
-- [`pack` and `publish`](https://drager.github.io/wasm-pack/book/commands/pack-and-publish.html): Create a tarball of your rustwasm pkg and/or publish to a registry
+- [`new`](https://wasm-bindgen.github.io/wasm-pack/book/commands/new.html): Generate a new RustWasm project using a template
+- [`build`](https://wasm-bindgen.github.io/wasm-pack/book/commands/build.html): Generate an npm wasm pkg from a rustwasm crate
+- [`test`](https://wasm-bindgen.github.io/wasm-pack/book/commands/test.html): Run browser tests
+- [`pack` and `publish`](https://wasm-bindgen.github.io/wasm-pack/book/commands/pack-and-publish.html): Create a tarball of your rustwasm pkg and/or publish to a registry
 
 ## 📝 Logging
 
@@ -71,7 +71,7 @@ RUST_LOG=info wasm-pack build
 Read our [guide] on getting up and running for developing `wasm-pack`, and
 check out our [contribution policy].
 
-[guide]: https://drager.github.io/wasm-pack/book/contributing.html
+[guide]: https://wasm-bindgen.github.io/wasm-pack/book/contributing.html
 [contribution policy]: CONTRIBUTING.md
 
 ## 🤹‍♀️ Governance

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,2 +1,0 @@
-[template]
-sub_templates = ["wasm-pack-template"]

--- a/docs/_installer/index.html
+++ b/docs/_installer/index.html
@@ -30,7 +30,7 @@
           </a>
         </li>
         <li class="navbar-item">
-          <a href="https://github.com/drager/wasm-pack/issues/new/choose"
+          <a href="https://github.com/wasm-bindgen/wasm-pack/issues/new/choose"
             >File an Issue</a
           >
         </li>
@@ -53,7 +53,7 @@
           by running:
         </p>
         <pre class="primary">
-curl https://drager.github.io/wasm-pack/installer/init.sh -sSf | sh</pre
+curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | sh</pre
         >
         <p>
           If you're not on *nix, or you don't like installing from <b>curl</b>,
@@ -66,7 +66,7 @@ curl https://drager.github.io/wasm-pack/installer/init.sh -sSf | sh</pre
           You appear to be running Windows 64-bit. Download and run
           <a
             class="winlink"
-            href="https://github.com/drager/wasm-pack/releases/download/$VERSION/wasm-pack-init.exe"
+            href="https://github.com/wasm-bindgen/wasm-pack/releases/download/$VERSION/wasm-pack-init.exe"
             >wasm-pack-init.exe</a
           >
           then follow the onscreen instructions.
@@ -78,7 +78,7 @@ curl https://drager.github.io/wasm-pack/installer/init.sh -sSf | sh</pre
           wasm-pack.
         </p>
         <pre class="primary">
-curl https://drager.github.io/wasm-pack/installer/init.sh -sSf | sh</pre
+curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | sh</pre
         >
         <p>
           If you're not on Windows 64-bit, follow the alternate instructions
@@ -90,7 +90,7 @@ curl https://drager.github.io/wasm-pack/installer/init.sh -sSf | sh</pre
         <p>I don't recognize your platform.</p>
         <p>
           We would appreciate it if you
-          <a href="https://github.com/drager/wasm-pack/issues/new"
+          <a href="https://github.com/wasm-bindgen/wasm-pack/issues/new"
             >reported an issue</a
           >, along with the following values:
         </p>

--- a/docs/_installer/init.sh
+++ b/docs/_installer/init.sh
@@ -41,7 +41,7 @@ fi
 
 # Resolve "latest" to actual version number
 if [ "$VERSION" = "latest" ]; then
-    VERSION=$(curl -s https://api.github.com/repos/drager/wasm-pack/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([^"]+)".*/\1/')
+    VERSION=$(curl -s https://api.github.com/repos/wasm-bindgen/wasm-pack/releases/latest | grep '"tag_name"' | sed -E 's/.*"v?([^"]+)".*/\1/')
     if [ -z "$VERSION" ]; then
         err "failed to fetch latest version from GitHub API"
     fi
@@ -53,7 +53,7 @@ case "$VERSION" in
     *) VERSION="v$VERSION" ;;
 esac
 
-UPDATE_ROOT="https://github.com/drager/wasm-pack/releases/download/$VERSION"
+UPDATE_ROOT="https://github.com/wasm-bindgen/wasm-pack/releases/download/$VERSION"
 
 main() {
     downloader --check
@@ -173,7 +173,7 @@ get_architecture() {
 
     esac
 
-    # See https://github.com/drager/wasm-pack/pull/1088
+    # See https://github.com/wasm-bindgen/wasm-pack/pull/1088
     if [ "$_cputype" = "aarch64" ] && [ "$_ostype" = "apple-darwin" ]; then
         _cputype="x86_64"
     fi

--- a/docs/_theme/header.hbs
+++ b/docs/_theme/header.hbs
@@ -38,7 +38,7 @@
   <p>
     This is the <strong>unpublished</strong> documentation of
     <code>wasm-pack</code>, the published documentation is available
-    <a href="https://drager.github.io/wasm-pack/">
+    <a href="https://wasm-bindgen.github.io/wasm-pack/">
       on the main Rust and WebAssembly documentation site
     </a>. Features documented here may not be available in released versions of
     <code>wasm-pack</code>.

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
           </a>
         </a>
         <li class="navbar-item">
-          <a href="https://github.com/drager/wasm-pack/issues/new/choose">File an Issue</a>
+          <a href="https://github.com/wasm-bindgen/wasm-pack/issues/new/choose">File an Issue</a>
         </li>
         <li class="navbar-item">
           <a href="/wasm-pack/book">Documentation</a>
@@ -44,7 +44,7 @@
         <div class="five columns" id="installer">
           <a class="button button-primary" href="/wasm-pack/installer">✨ Install wasm-pack 0.14.0 ✨</a>
           <p>20 Jan 2026 |
-            <a href="https://github.com/drager/wasm-pack/releases/tag/v0.14.0">
+            <a href="https://github.com/wasm-bindgen/wasm-pack/releases/tag/v0.14.0">
               Release Notes
             </a>
           </p>

--- a/docs/src/commands/new.md
+++ b/docs/src/commands/new.md
@@ -9,7 +9,7 @@ It takes 3 parameters, name, template, and mode:
 wasm-pack new <name> --template <template> --mode <normal|noinstall|force>
 ```
 
-The default template is [`wasm-bindgen/wasm-pack-template`](https://github.com/wasm-bindgen/wasm-pack-template).
+The default template is [`drager/wasm-pack-template`](https://github.com/drager/wasm-pack-template).
 
 ## Name
 
@@ -24,7 +24,7 @@ wasm-pack new myproject
 The `wasm-pack new` command can be given an optional template argument, e.g.:
 
 ```
-wasm-pack new myproject --template https://github.com/wasm-bindgen/wasm-pack-template
+wasm-pack new myproject --template https://github.com/drager/wasm-pack-template
 ```
 
 The template can be an address to a git repo that contains a [`cargo-generate`]

--- a/docs/src/commands/new.md
+++ b/docs/src/commands/new.md
@@ -9,7 +9,7 @@ It takes 3 parameters, name, template, and mode:
 wasm-pack new <name> --template <template> --mode <normal|noinstall|force>
 ```
 
-The default template is [`rustwasm/wasm-pack`](https://github.com/rustwasm/wasm-pack),
+The default template is [`wasm-bindgen/wasm-pack`](https://github.com/wasm-bindgen/wasm-pack),
 which includes the `wasm-pack-template` cargo-generate template.
 
 ## Name
@@ -25,7 +25,7 @@ wasm-pack new myproject
 The `wasm-pack new` command can be given an optional template argument, e.g.:
 
 ```
-wasm-pack new myproject --template https://github.com/rustwasm/wasm-pack
+wasm-pack new myproject --template https://github.com/wasm-bindgen/wasm-pack
 ```
 
 The template can be an address to a git repo that contains a [`cargo-generate`]

--- a/docs/src/commands/new.md
+++ b/docs/src/commands/new.md
@@ -9,7 +9,7 @@ It takes 3 parameters, name, template, and mode:
 wasm-pack new <name> --template <template> --mode <normal|noinstall|force>
 ```
 
-The default template is [`drager/wasm-pack-template`](https://github.com/drager/wasm-pack-template).
+The default template is [`wasm-bindgen/wasm-pack-template`](https://github.com/wasm-bindgen/wasm-pack-template).
 
 ## Name
 
@@ -24,7 +24,7 @@ wasm-pack new myproject
 The `wasm-pack new` command can be given an optional template argument, e.g.:
 
 ```
-wasm-pack new myproject --template https://github.com/drager/wasm-pack-template
+wasm-pack new myproject --template https://github.com/wasm-bindgen/wasm-pack-template
 ```
 
 The template can be an address to a git repo that contains a [`cargo-generate`]

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -8,11 +8,11 @@ using it. You can find them documented [here][1].
 You'll also want to check out the contributing [guidelines].
 
 [1]: ./prerequisites/index.html
-[guidelines]: https://github.com/drager/wasm-pack/blob/master/CONTRIBUTING.md
+[guidelines]: https://github.com/wasm-bindgen/wasm-pack/blob/master/CONTRIBUTING.md
 
 ## 🏃‍♀️ Up and Running
 
-1. fork and clone the `drager/wasm-pack` repository
+1. fork and clone the `wasm-bindgen/wasm-pack` repository
 2. install [node/npm]
 3. `cd wasm-pack`
 4. `cargo run`. To test command line arguments you can run `cargo run -- <args>`.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,4 +1,4 @@
-![wasm ferris](https://drager.github.io/wasm-pack/public/img/wasm-ferris.png)
+![wasm ferris](https://wasm-bindgen.github.io/wasm-pack/public/img/wasm-ferris.png)
 
 <h1 style="text-align: center;">Welcome to the <code>wasm-pack</code> docs!</h1>
 
@@ -11,4 +11,4 @@ alongside any javascript packages in workflows that you already use, such as [we
 [webpack]: https://webpack.js.org/
 
 
-![demo](https://github.com/drager/wasm-pack/raw/master/demo.gif)
+![demo](https://github.com/wasm-bindgen/wasm-pack/raw/master/demo.gif)

--- a/docs/src/prerequisites/index.md
+++ b/docs/src/prerequisites/index.md
@@ -3,7 +3,7 @@
 First you'll want to [install the `wasm-pack` CLI][wasm-pack], and `wasm-pack
 -V` should print the version that you just installed.
 
-[wasm-pack]: https://drager.github.io/wasm-pack/installer/
+[wasm-pack]: https://wasm-bindgen.github.io/wasm-pack/installer/
 
 Next, since `wasm-pack` is a build tool, you'll want to make sure you have
 [Rust][rust] installed. Make sure `rustc -V` prints out at least 1.30.0.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -11,4 +11,4 @@
    registry you want to publish to. You can login using `wasm-pack login`.
 
 [`rustup`]: https://rustup.rs/
-[Install this tool.]: https://drager.github.io/wasm-pack/installer/
+[Install this tool.]: https://wasm-bindgen.github.io/wasm-pack/installer/

--- a/docs/src/tutorials/npm-browser-packages/getting-started.md
+++ b/docs/src/tutorials/npm-browser-packages/getting-started.md
@@ -11,14 +11,14 @@ cargo install cargo-generate
 Then run:
 
 ```
-cargo generate --git https://github.com/drager/wasm-pack-template
+cargo generate --git https://github.com/wasm-bindgen/wasm-pack-template
 ```
 
 You will be prompted to give your project a name. Once you do, you will have a directory
 with a new project, ready to go. We'll talk about what's been included in this template
 further in this guide.
 
-[rustwasm wasm-pack-template]: https://github.com/drager/wasm-pack-template
+[rustwasm wasm-pack-template]: https://github.com/wasm-bindgen/wasm-pack-template
 
 ## Manual Setup
 

--- a/docs/src/tutorials/npm-browser-packages/getting-started.md
+++ b/docs/src/tutorials/npm-browser-packages/getting-started.md
@@ -11,7 +11,7 @@ cargo install cargo-generate
 Then run:
 
 ```
-cargo generate --git https://github.com/wasm-bindgen/wasm-pack
+cargo generate wasm-bindgen/wasm-pack
 ```
 
 You will be prompted to give your project a name. Once you do, you will have a directory

--- a/docs/src/tutorials/npm-browser-packages/getting-started.md
+++ b/docs/src/tutorials/npm-browser-packages/getting-started.md
@@ -11,7 +11,7 @@ cargo install cargo-generate
 Then run:
 
 ```
-cargo generate --git https://github.com/rustwasm/wasm-pack wasm-pack-template
+cargo generate --git https://github.com/wasm-bindgen/wasm-pack
 ```
 
 You will be prompted to give your project a name. Once you do, you will have a directory

--- a/docs/src/tutorials/npm-browser-packages/getting-started.md
+++ b/docs/src/tutorials/npm-browser-packages/getting-started.md
@@ -11,14 +11,14 @@ cargo install cargo-generate
 Then run:
 
 ```
-cargo generate --git https://github.com/wasm-bindgen/wasm-pack-template
+cargo generate --git https://github.com/drager/wasm-pack-template
 ```
 
 You will be prompted to give your project a name. Once you do, you will have a directory
 with a new project, ready to go. We'll talk about what's been included in this template
 further in this guide.
 
-[rustwasm wasm-pack-template]: https://github.com/wasm-bindgen/wasm-pack-template
+[rustwasm wasm-pack-template]: https://github.com/drager/wasm-pack-template
 
 ## Manual Setup
 

--- a/docs/src/tutorials/npm-browser-packages/index.md
+++ b/docs/src/tutorials/npm-browser-packages/index.md
@@ -8,7 +8,7 @@ much Rust knowledge to complete this tutorial.
 
 Be sure to have done the following before starting:
 
-1. [Install `wasm-pack`](https://drager.github.io/wasm-pack/installer/)
+1. [Install `wasm-pack`](https://wasm-bindgen.github.io/wasm-pack/installer/)
 1. Read and install the [Prerequisites](../../prerequisites/index.html).
 
 ⚠️ We strongly recommend that you install [Node.js] using a version manager. You can learn more [here](https://npmjs.com/get-npm).

--- a/npm/README.md
+++ b/npm/README.md
@@ -7,14 +7,14 @@
   </p>
 
   <p>
-    <a href="https://github.com/drager/wasm-pack/actions/workflows/test.yml"><img alt="Build Status" src="https://github.com/drager/wasm-pack/actions/workflows/test.yml/badge.svg?branch=master"/></a>
+    <a href="https://github.com/wasm-bindgen/wasm-pack/actions/workflows/test.yml"><img alt="Build Status" src="https://github.com/wasm-bindgen/wasm-pack/actions/workflows/test.yml/badge.svg?branch=master"/></a>
     <a href="https://crates.io/crates/wasm-pack"><img alt="crates.io" src="https://img.shields.io/crates/v/wasm-pack"/></a>
   </p>
 
   <h3>
     <a href="https://drager.github.io/wasm-pack/book">Docs</a>
     <span> | </span>
-    <a href="https://github.com/drager/wasm-pack/blob/master/CONTRIBUTING.md">Contributing</a>
+    <a href="https://github.com/wasm-bindgen/wasm-pack/blob/master/CONTRIBUTING.md">Contributing</a>
     <span> | </span>
     <a href="https://discordapp.com/channels/442252698964721669/443151097398296587">Chat</a>
   </h3>
@@ -38,21 +38,21 @@ alongside any javascript packages in workflows that you already use, such as [we
 
 This project requires Rust 1.30.0 or later.
 
-- [Development Environment](https://drager.github.io/wasm-pack/book/prerequisites/index.html)
-- [Installation](https://drager.github.io/wasm-pack/installer)
+- [Development Environment](https://wasm-bindgen.github.io/wasm-pack/book/prerequisites/index.html)
+- [Installation](https://wasm-bindgen.github.io/wasm-pack/installer)
 
 ## ⚡ Quickstart Guide
 
 Visit the [quickstart guide] in our documentation.
 
-[quickstart guide]: https://drager.github.io/wasm-pack/book/quickstart.html
+[quickstart guide]: https://wasm-bindgen.github.io/wasm-pack/book/quickstart.html
 
 ## 🎙️ Commands
 
-- [`new`](https://drager.github.io/wasm-pack/book/commands/new.html): Generate a new RustWasm project using a template
-- [`build`](https://drager.github.io/wasm-pack/book/commands/build.html): Generate an npm wasm pkg from a rustwasm crate
-- [`test`](https://drager.github.io/wasm-pack/book/commands/test.html): Run browser tests
-- [`pack` and `publish`](https://drager.github.io/wasm-pack/book/commands/pack-and-publish.html): Create a tarball of your rustwasm pkg and/or publish to a registry
+- [`new`](https://wasm-bindgen.github.io/wasm-pack/book/commands/new.html): Generate a new RustWasm project using a template
+- [`build`](https://wasm-bindgen.github.io/wasm-pack/book/commands/build.html): Generate an npm wasm pkg from a rustwasm crate
+- [`test`](https://wasm-bindgen.github.io/wasm-pack/book/commands/test.html): Run browser tests
+- [`pack` and `publish`](https://wasm-bindgen.github.io/wasm-pack/book/commands/pack-and-publish.html): Create a tarball of your rustwasm pkg and/or publish to a registry
 
 ## 📝 Logging
 
@@ -71,7 +71,7 @@ RUST_LOG=info wasm-pack build
 Read our [guide] on getting up and running for developing `wasm-pack`, and
 check out our [contribution policy].
 
-[guide]: https://drager.github.io/wasm-pack/book/contributing.html
+[guide]: https://wasm-bindgen.github.io/wasm-pack/book/contributing.html
 [contribution policy]: CONTRIBUTING.md
 
 ## 🤹‍♀️ Governance

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -31,7 +31,7 @@ const getPlatform = () => {
 const getBinary = () => {
   const platform = getPlatform();
   const version = require("./package.json").version;
-  const author = "drager";
+  const author = "wasm-bindgen";
   const name = "wasm-pack";
   const url = `https://github.com/${author}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
   return new Binary(platform === windows ? "wasm-pack.exe" : "wasm-pack", url, {

--- a/npm/package.json
+++ b/npm/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/drager/wasm-pack.git"
+    "url": "git+https://github.com/wasm-bindgen/wasm-pack.git"
   },
   "keywords": [
     "wasm",
@@ -25,9 +25,9 @@
   "author": "Jesper Håkansson <jesper@jesperh.se>",
   "license": "MIT OR Apache-2.0",
   "bugs": {
-    "url": "https://github.com/drager/wasm-pack/issues"
+    "url": "https://github.com/wasm-bindgen/wasm-pack/issues"
   },
-  "homepage": "https://github.com/drager/wasm-pack#readme",
+  "homepage": "https://github.com/wasm-bindgen/wasm-pack#readme",
   "dependencies": {
     "binary-install": "^1.1.2"
   },

--- a/src/build/wasm_target.rs
+++ b/src/build/wasm_target.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Wasm32Check<'_> {
             let rustup_string = if self.is_rustup {
                 "It looks like Rustup is being used.".to_owned()
             } else {
-                format!("It looks like Rustup is not being used. For non-Rustup setups, the {} target needs to be installed manually. See https://drager.github.io/wasm-pack/book/prerequisites/non-rustup-setups.html on how to do this.", self.target)
+                format!("It looks like Rustup is not being used. For non-Rustup setups, the {} target needs to be installed manually. See https://wasm-bindgen.github.io/wasm-pack/book/prerequisites/non-rustup-setups.html on how to do this.", self.target)
             };
 
             writeln!(

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -15,9 +15,7 @@ pub fn generate(template: String, name: String, install_permitted: bool) -> Resu
         "latest",
         install_permitted,
     )?;
-    let template_subfolder =
-        (template == generate::DEFAULT_TEMPLATE).then_some(generate::DEFAULT_TEMPLATE_SUBFOLDER);
-    generate::generate(&template, template_subfolder, &name, &download)?;
+    generate::generate(&template, &name, &download)?;
 
     let msg = format!("🐑 Generated new project at /{}", name);
     PBAR.info(&msg);

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -48,7 +48,7 @@ pub enum Command {
         /// The URL to the template
         #[clap(
             long = "template",
-            default_value = "https://github.com/wasm-bindgen/wasm-pack-template"
+            default_value = "https://github.com/drager/wasm-pack-template"
         )]
         template: String,
         #[clap(long = "mode", short = 'm', default_value = "normal")]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -48,7 +48,7 @@ pub enum Command {
         /// The URL to the template
         #[clap(
             long = "template",
-            default_value = "https://github.com/drager/wasm-pack-template"
+            default_value = "https://github.com/wasm-bindgen/wasm-pack-template"
         )]
         template: String,
         #[clap(long = "mode", short = 'm', default_value = "normal")]

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -78,7 +78,7 @@ pub struct TestOptions {
     /// If the path is not provided, this command searches up the path from the current directory.
     ///
     /// This is a workaround to allow wasm pack to provide the same command line interface as `cargo`.
-    /// See <https://github.com/drager/wasm-pack/pull/851> for more information.
+    /// See <https://github.com/wasm-bindgen/wasm-pack/pull/851> for more information.
     pub path_and_extra_options: Vec<String>,
 }
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -8,18 +8,11 @@ use std::path::Path;
 use std::process::Command;
 
 /// Default git repository used by `wasm-pack new`.
-pub const DEFAULT_TEMPLATE: &str = "https://github.com/rustwasm/wasm-pack";
-/// Template subfolder inside the default git repository.
-pub const DEFAULT_TEMPLATE_SUBFOLDER: &str = "wasm-pack-template";
+pub const DEFAULT_TEMPLATE: &str = "https://github.com/wasm-bindgen/wasm-pack";
 
 /// Run `cargo generate` in the current directory to create a new
 /// project from a template
-pub fn generate(
-    template: &str,
-    template_subfolder: Option<&str>,
-    name: &str,
-    install_status: &install::Status,
-) -> Result<()> {
+pub fn generate(template: &str, name: &str, install_status: &install::Status) -> Result<()> {
     let bin_path = install::get_tool_path(install_status, Tool::CargoGenerate)?
         .binary(&Tool::CargoGenerate.to_string())?;
     let mut cmd = Command::new(&bin_path);
@@ -28,9 +21,6 @@ pub fn generate(
         cmd.arg("--path").arg(template);
     } else {
         cmd.arg("--git").arg(template);
-    }
-    if let Some(template_subfolder) = template_subfolder {
-        cmd.arg(template_subfolder);
     }
     cmd.arg("--name").arg(name);
 

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -113,7 +113,7 @@ pub fn get_cli_version(tool: &Tool, path: &Path) -> Result<String> {
     let version = stdout.trim().split_whitespace().nth(1);
     match version {
         Some(v) => Ok(v.to_string()),
-        None => bail!("Something went wrong! We couldn't determine your version of the wasm-bindgen CLI. We were supposed to set that up for you, so it's likely not your fault! You should file an issue: https://github.com/drager/wasm-pack/issues/new?template=bug_report.md.")
+        None => bail!("Something went wrong! We couldn't determine your version of the wasm-bindgen CLI. We were supposed to set that up for you, so it's likely not your fault! You should file an issue: https://github.com/wasm-bindgen/wasm-pack/issues/new?template=bug_report.md.")
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn run() -> Result<()> {
         match wasm_pack_version {
             Ok(wasm_pack_version) =>
                 PBAR.warn(&format!("There's a newer version of wasm-pack available, the new version is: {}, you are using: {}. \
-                To update, navigate to: https://drager.github.io/wasm-pack/installer/", wasm_pack_version.latest, wasm_pack_version.local)),
+                To update, navigate to: https://wasm-bindgen.github.io/wasm-pack/installer/", wasm_pack_version.latest, wasm_pack_version.local)),
             Err(err) => PBAR.warn(&format!("{}", err))
         }
     }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -30,7 +30,7 @@ use toml;
 
 const WASM_PACK_METADATA_KEY: &str = "package.metadata.wasm-pack";
 const WASM_PACK_VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
-const WASM_PACK_REPO_URL: &str = "https://github.com/drager/wasm-pack";
+const WASM_PACK_REPO_URL: &str = "https://github.com/wasm-bindgen/wasm-pack";
 
 /// Store for metadata learned about a crate
 pub struct CrateData {

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -70,7 +70,7 @@ fn it_should_build_crates_in_a_workspace() {
                 description = "so awesome rust+wasm package"
                 license = "WTFPL"
                 name = "blah"
-                repository = "https://github.com/drager/wasm-pack.git"
+                repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                 version = "0.1.0"
 
                 [lib]
@@ -243,7 +243,7 @@ fn build_with_and_without_wasm_bindgen_debug() {
                     description = "so awesome rust+wasm package"
                     license = "WTFPL"
                     name = "whatever"
-                    repository = "https://github.com/drager/wasm-pack.git"
+                    repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                     version = "0.1.0"
 
                     [lib]
@@ -368,7 +368,7 @@ fn build_crates_with_same_names() {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "somename"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             [lib]
@@ -398,7 +398,7 @@ fn build_crates_with_same_names() {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "somename"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.1"
 
             [lib]

--- a/tests/all/lockfile.rs
+++ b/tests/all/lockfile.rs
@@ -41,7 +41,7 @@ fn it_gets_wasm_bindgen_version_in_crate_inside_workspace() {
                 description = "so awesome rust+wasm package"
                 license = "WTFPL"
                 name = "blah"
-                repository = "https://github.com/drager/wasm-pack.git"
+                repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                 version = "0.1.0"
 
                 [lib]
@@ -86,7 +86,7 @@ fn it_gets_wasm_bindgen_version_from_dependencies() {
                 description = "so awesome rust+wasm package"
                 license = "WTFPL"
                 name = "child"
-                repository = "https://github.com/drager/wasm-pack.git"
+                repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                 version = "0.1.0"
 
                 [lib]
@@ -114,7 +114,7 @@ fn it_gets_wasm_bindgen_version_from_dependencies() {
                 description = "so awesome rust+wasm package"
                 license = "WTFPL"
                 name = "parent"
-                repository = "https://github.com/drager/wasm-pack.git"
+                repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                 version = "0.1.0"
 
                 [lib]

--- a/tests/all/manifest.rs
+++ b/tests/all/manifest.rs
@@ -90,7 +90,7 @@ fn it_creates_a_package_json_default_path() {
     assert_eq!(pkg.repository.ty, "git");
     assert_eq!(
         pkg.repository.url,
-        "https://github.com/drager/wasm-pack.git"
+        "https://github.com/wasm-bindgen/wasm-pack.git"
     );
     assert_eq!(pkg.main, "js_hello_world.js");
     assert_eq!(pkg.types, "js_hello_world.d.ts");
@@ -189,7 +189,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_node() {
     assert_eq!(pkg.repository.ty, "git");
     assert_eq!(
         pkg.repository.url,
-        "https://github.com/drager/wasm-pack.git"
+        "https://github.com/wasm-bindgen/wasm-pack.git"
     );
     assert_eq!(pkg.main, "js_hello_world.js");
     assert_eq!(pkg.types, "js_hello_world.d.ts");
@@ -223,7 +223,7 @@ fn it_creates_a_pkg_json_with_correct_files_on_nomodules() {
     assert_eq!(pkg.repository.ty, "git");
     assert_eq!(
         pkg.repository.url,
-        "https://github.com/drager/wasm-pack.git"
+        "https://github.com/wasm-bindgen/wasm-pack.git"
     );
     assert_eq!(pkg.browser, "js_hello_world.js");
     assert_eq!(pkg.types, "js_hello_world.d.ts");
@@ -258,7 +258,7 @@ fn it_creates_a_package_json_with_correct_files_when_out_name_is_provided() {
     assert_eq!(pkg.repository.ty, "git");
     assert_eq!(
         pkg.repository.url,
-        "https://github.com/drager/wasm-pack.git"
+        "https://github.com/wasm-bindgen/wasm-pack.git"
     );
     assert_eq!(pkg.main, "index.js");
     assert_eq!(pkg.types, "index.d.ts");
@@ -306,7 +306,7 @@ fn it_creates_a_package_json_with_correct_keys_when_types_are_skipped() {
     assert_eq!(pkg.repository.ty, "git");
     assert_eq!(
         pkg.repository.url,
-        "https://github.com/drager/wasm-pack.git"
+        "https://github.com/wasm-bindgen/wasm-pack.git"
     );
     assert_eq!(pkg.main, "js_hello_world.js");
     assert_eq!(pkg.description, "so awesome rust+wasm package");
@@ -361,7 +361,7 @@ fn it_creates_a_package_json_with_npm_dependencies_provided_by_wasm_bindgen() {
     assert_eq!(pkg.repository.ty, "git");
     assert_eq!(
         pkg.repository.url,
-        "https://github.com/drager/wasm-pack.git"
+        "https://github.com/wasm-bindgen/wasm-pack.git"
     );
     assert_eq!(pkg.main, "js_hello_world.js");
 
@@ -403,9 +403,9 @@ fn it_sets_homepage_field_if_available_in_cargo_toml() {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "homepage-field-test"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
-            homepage = "https://drager.github.io/wasm-pack/"
+            homepage = "https://wasm-bindgen.github.io/wasm-pack/"
 
             [lib]
             crate-type = ["cdylib"]
@@ -429,7 +429,7 @@ fn it_sets_homepage_field_if_available_in_cargo_toml() {
     let pkg = utils::manifest::read_package_json(&fixture.path, &out_dir).unwrap();
     assert_eq!(
         pkg.homepage,
-        Some("https://drager.github.io/wasm-pack/".to_string()),
+        Some("https://wasm-bindgen.github.io/wasm-pack/".to_string()),
     );
 
     // When 'homepage' is unavailable
@@ -458,7 +458,7 @@ fn it_sets_keywords_field_if_available_in_cargo_toml() {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "homepage-field-test"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
             keywords = ["wasm"]
 
@@ -523,7 +523,7 @@ fn configure_wasm_bindgen_debug_incorrectly_is_error() {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "whatever"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             [lib]
@@ -557,7 +557,7 @@ fn parse_crate_data_returns_unused_keys_in_cargo_toml() {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "whatever"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             [lib]
@@ -626,9 +626,9 @@ fn it_recurses_up_the_path_to_find_cargo_toml() {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "recurse-for-manifest-test"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
-            homepage = "https://drager.github.io/wasm-pack/"
+            homepage = "https://wasm-bindgen.github.io/wasm-pack/"
         "#,
     );
     let path = get_crate_path(None).unwrap();
@@ -648,9 +648,9 @@ fn it_doesnt_recurse_up_the_path_to_find_cargo_toml_when_default() {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "recurse-for-manifest-test"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
-            homepage = "https://drager.github.io/wasm-pack/"
+            homepage = "https://wasm-bindgen.github.io/wasm-pack/"
         "#,
     );
     let path = get_crate_path(Some(PathBuf::from("src"))).unwrap();

--- a/tests/all/readme.rs
+++ b/tests/all/readme.rs
@@ -48,7 +48,7 @@ fn it_copies_a_readme_provided_path() {
             license = "WTFPL"
             name = "js-hello-world"
             readme = "docs/README.md"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             [lib]
@@ -108,7 +108,7 @@ fn it_ignores_a_disabled_readme() {
             description = "so awesome rust+wasm package"
             name = "js-hello-world"
             readme = false
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             [lib]

--- a/tests/all/test.rs
+++ b/tests/all/test.rs
@@ -174,7 +174,7 @@ fn complains_about_missing_wasm_bindgen_test_dependency() {
                 description = "so awesome rust+wasm package"
                 license = "WTFPL"
                 name = "missing-wbg-test"
-                repository = "https://github.com/drager/wasm-pack.git"
+                repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                 version = "0.1.0"
 
                 [lib]

--- a/tests/all/utils/fixture.rs
+++ b/tests/all/utils/fixture.rs
@@ -132,7 +132,7 @@ impl Fixture {
                     description = "so awesome rust+wasm package"
                     license = "WTFPL"
                     name = "{}"
-                    repository = "https://github.com/drager/wasm-pack.git"
+                    repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                     version = "0.1.0"
 
                     [lib]
@@ -170,7 +170,7 @@ impl Fixture {
                     description = "so awesome rust+wasm package"
                     license = "WTFPL"
                     name = "{}"
-                    repository = "https://github.com/drager/wasm-pack.git"
+                    repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                     version = "0.1.0"
 
                     [lib]
@@ -213,7 +213,7 @@ impl Fixture {
                     description = "so awesome rust+wasm package"
                     name = "{}"
                     license-file = "{}"
-                    repository = "https://github.com/drager/wasm-pack.git"
+                    repository = "https://github.com/wasm-bindgen/wasm-pack.git"
                     version = "0.1.0"
 
                     [lib]
@@ -468,7 +468,7 @@ pub fn no_cdylib() -> Fixture {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "foo"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             # [lib]
@@ -639,7 +639,7 @@ pub fn transitive_dependencies() -> Fixture {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "main_project"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             [lib]
@@ -689,7 +689,7 @@ pub fn transitive_dependencies() -> Fixture {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "project_a"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             [lib]
@@ -739,7 +739,7 @@ pub fn transitive_dependencies() -> Fixture {
             description = "so awesome rust+wasm package"
             license = "WTFPL"
             name = "project_b"
-            repository = "https://github.com/drager/wasm-pack.git"
+            repository = "https://github.com/wasm-bindgen/wasm-pack.git"
             version = "0.1.0"
 
             [lib]


### PR DESCRIPTION
This PR fixed documents links and install links, as the repo was moved to wasm-bindgen/wasm-pack, all links was broken.

Fixes: #1563 

Make sure these boxes are checked! 📦✅

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text

✨✨ 😄 Thanks so much for contributing to wasm-pack! 😄 ✨✨
