### PR TITLE
fix: clarify missing npm error for login

### DIFF
--- a/src/npm.rs
+++ b/src/npm.rs
@@ -2,7 +2,7 @@
 
 use crate::child;
 use crate::command::publish::access::Access;
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use log::info;
 
 /// The default npm registry used when we aren't working with a custom registry.
@@ -49,7 +49,16 @@ pub fn npm_login(registry: &str, scope: &Option<String>, auth_type: &Option<Stri
     cmd.args(args);
 
     info!("Running {:?}", cmd);
-    if cmd.status()?.success() {
+    let status = cmd.status().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            anyhow!(
+                "failed to execute `npm login`; make sure the `npm` executable is installed and available on your PATH"
+            )
+        } else {
+            anyhow!("failed to execute `npm login`: {err}")
+        }
+    })?;
+    if status.success() {
         Ok(())
     } else {
         bail!("Login to registry {} failed", registry)

--- a/tests/all/login.rs
+++ b/tests/all/login.rs
@@ -1,0 +1,37 @@
+use crate::utils;
+use assert_cmd::prelude::*;
+use predicates::boolean::PredicateBooleanExt;
+use predicates::prelude::predicate::str::contains;
+use std::env;
+use std::path::Path;
+
+fn has_npm_binary(dir: &Path) -> bool {
+    ["npm", "npm.cmd", "npm.exe"]
+        .iter()
+        .any(|name| dir.join(name).is_file())
+}
+
+#[test]
+fn login_without_npm_mentions_missing_npm_in_path() {
+    let fixture = utils::fixture::Fixture::new();
+    fixture.file("README.md", "");
+    let original_path = env::var_os("PATH").expect("PATH should be set for this test");
+    let filtered_path = env::split_paths(&original_path)
+        .filter(|dir| !has_npm_binary(dir))
+        .collect::<Vec<_>>();
+
+    assert_ne!(
+        filtered_path,
+        env::split_paths(&original_path).collect::<Vec<_>>(),
+        "test requires npm to be present in PATH so it can be removed",
+    );
+
+    fixture
+        .wasm_pack()
+        .env("PATH", env::join_paths(filtered_path).unwrap())
+        .arg("login")
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(contains("npm").and(contains("PATH")));
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -18,6 +18,7 @@ mod generate;
 mod license;
 mod lockfile;
 mod log_level;
+mod login;
 mod manifest;
 mod readme;
 mod stamps;


### PR DESCRIPTION
## Summary
When `wasm-pack login` is run without `npm` on `PATH`, it currently fails with a bare `No such file or directory (os error 2)` message. This adds an explicit spawn error message that tells the user the missing executable is `npm` and that it needs to be available on `PATH`.

## Changes
- add a clearer spawn error for `npm login` when the `npm` executable cannot be started
- add a regression test that runs `wasm-pack login` with `npm` removed from `PATH`

## Test Plan
- [x] You have the latest version of `rustfmt` installed
- [x] You ran `cargo fmt` on the code base before submitting
- [x] You reference which issue is being closed in the PR text
- [x] `cargo test login_without_npm_mentions_missing_npm_in_path --test all`
- [x] Manual repro: `PATH=/usr/bin:/bin ./target/debug/wasm-pack login`

## Related issue
- Closes #1541
