### PR TITLE
Move wasm-pack template into repo

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+sub_templates = ["wasm-pack-template"]

--- a/docs/src/commands/new.md
+++ b/docs/src/commands/new.md
@@ -9,7 +9,8 @@ It takes 3 parameters, name, template, and mode:
 wasm-pack new <name> --template <template> --mode <normal|noinstall|force>
 ```
 
-The default template is [`drager/wasm-pack-template`](https://github.com/drager/wasm-pack-template).
+The default template is [`rustwasm/wasm-pack`](https://github.com/rustwasm/wasm-pack),
+which includes the `wasm-pack-template` cargo-generate template.
 
 ## Name
 
@@ -24,7 +25,7 @@ wasm-pack new myproject
 The `wasm-pack new` command can be given an optional template argument, e.g.:
 
 ```
-wasm-pack new myproject --template https://github.com/drager/wasm-pack-template
+wasm-pack new myproject --template https://github.com/rustwasm/wasm-pack
 ```
 
 The template can be an address to a git repo that contains a [`cargo-generate`]

--- a/docs/src/tutorials/npm-browser-packages/getting-started.md
+++ b/docs/src/tutorials/npm-browser-packages/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-You can create a new Rust-WebAssembly project by using the [rustwasm wasm-pack-template].
+You can create a new Rust-WebAssembly project by using the [wasm-pack template].
 
 To so do, you'll need the `cargo-generate` tool. To install `cargo-generate`:
 
@@ -11,14 +11,14 @@ cargo install cargo-generate
 Then run:
 
 ```
-cargo generate --git https://github.com/drager/wasm-pack-template
+cargo generate --git https://github.com/rustwasm/wasm-pack wasm-pack-template
 ```
 
 You will be prompted to give your project a name. Once you do, you will have a directory
 with a new project, ready to go. We'll talk about what's been included in this template
 further in this guide.
 
-[rustwasm wasm-pack-template]: https://github.com/drager/wasm-pack-template
+[wasm-pack template]: https://github.com/rustwasm/wasm-pack/tree/master/wasm-pack-template
 
 ## Manual Setup
 

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -15,7 +15,9 @@ pub fn generate(template: String, name: String, install_permitted: bool) -> Resu
         "latest",
         install_permitted,
     )?;
-    generate::generate(&template, &name, &download)?;
+    let template_subfolder =
+        (template == generate::DEFAULT_TEMPLATE).then_some(generate::DEFAULT_TEMPLATE_SUBFOLDER);
+    generate::generate(&template, template_subfolder, &name, &download)?;
 
     let msg = format!("🐑 Generated new project at /{}", name);
     PBAR.info(&msg);

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -48,7 +48,7 @@ pub enum Command {
         /// The URL to the template
         #[clap(
             long = "template",
-            default_value = "https://github.com/drager/wasm-pack-template"
+            default_value = crate::generate::DEFAULT_TEMPLATE
         )]
         template: String,
         #[clap(long = "mode", short = 'm', default_value = "normal")]

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -4,17 +4,35 @@ use crate::child;
 use crate::emoji;
 use crate::install::{self, Tool};
 use anyhow::{Context, Result};
+use std::path::Path;
 use std::process::Command;
+
+/// Default git repository used by `wasm-pack new`.
+pub const DEFAULT_TEMPLATE: &str = "https://github.com/rustwasm/wasm-pack";
+/// Template subfolder inside the default git repository.
+pub const DEFAULT_TEMPLATE_SUBFOLDER: &str = "wasm-pack-template";
 
 /// Run `cargo generate` in the current directory to create a new
 /// project from a template
-pub fn generate(template: &str, name: &str, install_status: &install::Status) -> Result<()> {
+pub fn generate(
+    template: &str,
+    template_subfolder: Option<&str>,
+    name: &str,
+    install_status: &install::Status,
+) -> Result<()> {
     let bin_path = install::get_tool_path(install_status, Tool::CargoGenerate)?
         .binary(&Tool::CargoGenerate.to_string())?;
     let mut cmd = Command::new(&bin_path);
     cmd.arg("generate");
-    cmd.arg("--git").arg(&template);
-    cmd.arg("--name").arg(&name);
+    if Path::new(template).exists() {
+        cmd.arg("--path").arg(template);
+    } else {
+        cmd.arg("--git").arg(template);
+    }
+    if let Some(template_subfolder) = template_subfolder {
+        cmd.arg(template_subfolder);
+    }
+    cmd.arg("--name").arg(name);
 
     println!(
         "{} Generating a new rustwasm project with name '{}'...",

--- a/tests/all/build.rs
+++ b/tests/all/build.rs
@@ -345,7 +345,14 @@ fn build_force() {
 fn build_from_new() {
     let fixture = utils::fixture::not_a_crate();
     let name = "generated-project";
-    fixture.wasm_pack().arg("new").arg(name).assert().success();
+    fixture
+        .wasm_pack()
+        .arg("new")
+        .arg(name)
+        .arg("--template")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("wasm-pack-template"))
+        .assert()
+        .success();
     let project_location = fixture.path.join(&name);
     fixture
         .wasm_pack()

--- a/tests/all/generate.rs
+++ b/tests/all/generate.rs
@@ -1,5 +1,6 @@
 use crate::utils;
 use assert_cmd::prelude::*;
+use std::path::Path;
 
 #[test]
 fn new_with_no_name_errors() {
@@ -16,6 +17,8 @@ fn new_with_name_succeeds() {
         .wasm_pack()
         .arg("new")
         .arg("hello")
+        .arg("--template")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("wasm-pack-template"))
         .assert()
         .success();
 }

--- a/wasm-pack-template/.gitignore
+++ b/wasm-pack-template/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/wasm-pack-template/Cargo.toml
+++ b/wasm-pack-template/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "{{project-name}}"
+version = "0.1.0"
+authors = ["{{authors}}"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+wasm-bindgen = "0.2.84"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.7", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.34"
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/wasm-pack-template/LICENSE-APACHE
+++ b/wasm-pack-template/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/wasm-pack-template/LICENSE-MIT
+++ b/wasm-pack-template/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 {{authors}}
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/wasm-pack-template/README.md
+++ b/wasm-pack-template/README.md
@@ -1,0 +1,78 @@
+<div align="center">
+
+  <h1><code>wasm-pack-template</code></h1>
+
+  <strong>A template for kick starting a Rust and WebAssembly project using <a href="https://github.com/rustwasm/wasm-pack">wasm-pack</a>.</strong>
+
+  <h3>
+    <a href="https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/index.html">Tutorial</a>
+    <span> | </span>
+    <a href="https://discordapp.com/channels/442252698964721669/443151097398296587">Chat</a>
+  </h3>
+
+  <sub>Built with Rust and WebAssembly by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
+</div>
+
+## About
+
+[Read this template tutorial][template-docs].
+
+This template is designed for compiling Rust libraries into WebAssembly and
+publishing the resulting package to NPM.
+
+Be sure to check out [other `wasm-pack` tutorials online][tutorials] for other
+templates and usages of `wasm-pack`.
+
+[tutorials]: https://rustwasm.github.io/docs/wasm-pack/tutorials/index.html
+[template-docs]: https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/index.html
+
+## Usage
+
+### Use `wasm-pack new` to Clone this Template
+
+```
+wasm-pack new my-project
+cd my-project
+```
+
+### Build with `wasm-pack build`
+
+```
+wasm-pack build
+```
+
+### Test in Headless Browsers with `wasm-pack test`
+
+```
+wasm-pack test --headless --firefox
+```
+
+### Publish to NPM with `wasm-pack publish`
+
+```
+wasm-pack publish
+```
+
+## Batteries Included
+
+* [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) for communicating
+  between WebAssembly and JavaScript.
+* [`console_error_panic_hook`](https://github.com/rustwasm/console_error_panic_hook)
+  for logging panic messages to the developer console.
+* `LICENSE-APACHE` and `LICENSE-MIT`: most Rust projects are licensed this way, so these are included for you.
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/wasm-pack-template/cargo-generate.toml
+++ b/wasm-pack-template/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+cargo_generate_version = ">=0.9.0"

--- a/wasm-pack-template/src/lib.rs
+++ b/wasm-pack-template/src/lib.rs
@@ -1,0 +1,13 @@
+mod utils;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    fn alert(s: &str);
+}
+
+#[wasm_bindgen]
+pub fn greet() {
+    alert("Hello, {{project-name}}!");
+}

--- a/wasm-pack-template/src/utils.rs
+++ b/wasm-pack-template/src/utils.rs
@@ -1,0 +1,10 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/wasm-pack-template/tests/web.rs
+++ b/wasm-pack-template/tests/web.rs
@@ -1,0 +1,13 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn pass() {
+    assert_eq!(1 + 1, 2);
+}


### PR DESCRIPTION
This moves the cargo-generate wasm-pack template into this repository so the default `wasm-pack new` template can live alongside the CLI that invokes it.

The separate template repository URL is currently baked into `wasm-pack new` and the docs. Keeping the template in this repo makes template changes part of the same review and release flow as the command behavior that depends on it.

Implemented:

* added `wasm-pack-template/` at the repository root with the existing cargo-generate project template
* added root `cargo-generate.toml` metadata for the in-repo sub-template
* changed the default `wasm-pack new` template to `https://github.com/rustwasm/wasm-pack`, passing the `wasm-pack-template` subfolder for the built-in default
* preserved custom `--template` behavior, while allowing local template paths to use cargo-generate's `--path` mode
* updated command and tutorial docs to point at the in-repo template

Test coverage:

* `cargo fmt --check`
* `cargo check`
* `cargo test --test all generate`
* local cargo-generate expansion from the repo root with `wasm-pack-template`
* `cargo check` on a generated template project