### PR TITLE
fix(wasm64): fix tier-3 target handling and bump binaryen to v129

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,13 +496,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1127,6 +1148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1313,17 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2019,6 +2057,7 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
+ "dirs",
  "env_logger",
  "glob",
  "human-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ ureq = { version = "2.12.1", features = ["json", "socks-proxy"] }
 walkdir = "2.5.0"
 which = "8.0.0"
 path-clean = "1.0.1"
+dirs = "6.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"

--- a/docs/src/cargo-toml-configuration.md
+++ b/docs/src/cargo-toml-configuration.md
@@ -21,7 +21,7 @@ The available configuration options and their default values are shown below:
 #
 # In most cases, the `-O[X]` flag is enough. However, if you require extreme
 # optimizations, see the full list of `wasm-opt` optimization flags
-# https://github.com/WebAssembly/binaryen/blob/version_117/test/lit/help/wasm-opt.test
+# https://github.com/WebAssembly/binaryen/blob/version_129/test/lit/help/wasm-opt.test
 wasm-opt = ['-O']
 
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/docs/src/commands/build.md
+++ b/docs/src/commands/build.md
@@ -174,6 +174,68 @@ See [Non-`rustup` setups][non-rustup].
 
 `--panic-unwind` is also available for [`wasm-pack test`](./test.md).
 
+## 64-bit WebAssembly (`wasm64-unknown-unknown`)
+
+The cargo target triple is the source of truth for which WebAssembly ABI
+`wasm-pack` builds. To produce a `memory64` binary, declare the target the
+cargo-native way — either in `.cargo/config.toml`:
+
+```toml
+# .cargo/config.toml
+[build]
+target = "wasm64-unknown-unknown"
+```
+
+or as an extra cargo argument:
+
+```
+wasm-pack build -- --target wasm64-unknown-unknown
+```
+
+or via `CARGO_BUILD_TARGET=wasm64-unknown-unknown` in the environment.
+
+`wasm64-unknown-unknown` is a [tier-3 Rust target][tier-3], so `rustup`
+has no prebuilt artifacts for it. You need to provide two pieces yourself
+via cargo's native config:
+
+1. **A nightly toolchain** — `rust-toolchain.toml` is the cargo-native
+   way to pin one to your project:
+
+   ```toml
+   # rust-toolchain.toml
+   [toolchain]
+   channel = "nightly"
+   components = ["rust-src"]
+   ```
+
+   Or set `RUSTUP_TOOLCHAIN=nightly` for one-off invocations.
+
+2. **`-Z build-std` to build `std` from source**, since there is no
+   prebuilt one. Add to your `.cargo/config.toml`:
+
+   ```toml
+   [unstable]
+   build-std = ["std", "panic_abort"]
+   ```
+
+   Or pass `-Z build-std=std,panic_abort` as an extra cargo argument.
+
+`wasm-pack` itself stays out of the cargo invocation — it does not inject
+`+nightly` or `-Z build-std` (those would override your toolchain pin or
+surprise users who hadn't intended a nightly build). What it does do when
+it sees a `wasm64-*` triple:
+
+- Verifies the active toolchain is nightly, with a helpful error pointing
+  at the config above if it isn't.
+- Installs the `rust-src` component for the active toolchain via `rustup`
+  if missing.
+- Does **not** attempt `rustup target add wasm64-*` (which would always
+  fail for a tier-3 target).
+- Passes `--enable-memory64` to `wasm-opt` so the optimiser accepts
+  64-bit memories and tables.
+
+[tier-3]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
+
 [wbg-catch-unwind]: https://wasm-bindgen.github.io/wasm-bindgen/reference/catch-unwind.html
 [non-rustup]: ../prerequisites/non-rustup-setups.md
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -74,6 +74,13 @@ fn wasm_pack_local_version() -> Option<String> {
     Some(output.to_string())
 }
 
+/// Returns true for tier-3 wasm targets that have no rustup-prebuilt sysroot
+/// and must be built via `-Z build-std`. Currently this is the wasm64 family
+/// (`wasm64-unknown-unknown`, future `wasm64-*` variants).
+pub fn is_tier3_wasm(target_triple: &str) -> bool {
+    target_triple.starts_with("wasm64")
+}
+
 /// Run `cargo build` for Wasm with config derived from the given `BuildProfile`.
 pub fn cargo_build_wasm(
     path: &Path,
@@ -259,4 +266,19 @@ pub fn cargo_build_wasm_tests(
 
     child::run(cmd, "cargo build").context("Compilation of your program failed")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier3_wasm_detection() {
+        assert!(is_tier3_wasm("wasm64-unknown-unknown"));
+        assert!(is_tier3_wasm("wasm64-wasi"));
+        assert!(!is_tier3_wasm("wasm32-unknown-unknown"));
+        assert!(!is_tier3_wasm("wasm32-wasi"));
+        assert!(!is_tier3_wasm("wasm32-unknown-emscripten"));
+        assert!(!is_tier3_wasm("x86_64-unknown-linux-gnu"));
+    }
 }

--- a/src/build/wasm_target.rs
+++ b/src/build/wasm_target.rs
@@ -56,12 +56,84 @@ pub fn check_for_wasm_target(target: &str) -> Result<()> {
     let msg = format!("{}Checking for the Wasm target...", emoji::TARGET);
     PBAR.info(&msg);
 
+    // Tier-3 wasm targets (`wasm64-unknown-unknown`) have no rustup-prebuilt
+    // sysroot — they are built from source via `-Z build-std`, which requires
+    // a nightly toolchain and the `rust-src` component. wasm-pack doesn't
+    // inject `+nightly` or `-Z build-std` itself (those would override the
+    // user's `rust-toolchain.toml` or surprise users who hadn't intended a
+    // nightly build); instead we verify the active toolchain is nightly,
+    // heal the `rust-src` component if missing, and let cargo run.
+    if crate::build::is_tier3_wasm(target) {
+        return check_tier3_wasm_prerequisites(target);
+    }
+
     // Check if wasm32 target is present, otherwise bail.
     match check_target(target) {
         Ok(ref wasm32_check) if wasm32_check.found => Ok(()),
         Ok(wasm32_check) => bail!("{}", wasm32_check),
         Err(err) => Err(err),
     }
+}
+
+/// Tier-3 (currently `wasm64-*`) prerequisites: nightly active toolchain +
+/// `rust-src` component. Does not inject any cargo flags.
+fn check_tier3_wasm_prerequisites(target: &str) -> Result<()> {
+    if !is_active_toolchain_nightly()? {
+        bail!(
+            "`{target}` is a tier-3 Rust target and requires the nightly \
+             toolchain (rustup has no prebuilt artifacts for it).\n\n\
+             Pin nightly for this project by adding a `rust-toolchain.toml`:\n\n\
+                 [toolchain]\n\
+                 channel = \"nightly\"\n\
+                 components = [\"rust-src\"]\n\n\
+             Or set `RUSTUP_TOOLCHAIN=nightly` for a one-off invocation.\n\n\
+             You also need cargo to build `std` from source. Add to your \
+             `.cargo/config.toml`:\n\n\
+                 [unstable]\n\
+                 build-std = [\"std\", \"panic_abort\"]\n\n\
+             Or pass `-Z build-std=std,panic_abort` as an extra cargo argument."
+        );
+    }
+
+    if !has_rust_src_component_for_active_toolchain()? {
+        install_rust_src_for_active_toolchain()?;
+    }
+
+    Ok(())
+}
+
+/// Returns true if the currently-active rustc resolves to a nightly channel.
+fn is_active_toolchain_nightly() -> Result<bool> {
+    let output = Command::new("rustc").arg("--version").output()?;
+    if !output.status.success() {
+        bail!("`rustc --version` failed: {}", output.status);
+    }
+    let stdout = String::from_utf8(output.stdout)?;
+    // `rustc --version` prints e.g. `rustc 1.79.0-nightly (abc123 2024-04-01)`.
+    Ok(stdout.contains("-nightly") || stdout.contains("-dev"))
+}
+
+fn has_rust_src_component_for_active_toolchain() -> Result<bool> {
+    let output = Command::new("rustup")
+        .args(["component", "list", "--installed"])
+        .output()?;
+    if !output.status.success() {
+        return Ok(false);
+    }
+    let stdout = String::from_utf8(output.stdout)?;
+    Ok(stdout.lines().any(|line| line.starts_with("rust-src")))
+}
+
+fn install_rust_src_for_active_toolchain() -> Result<()> {
+    let msg = format!(
+        "{}Installing rust-src component for the active toolchain...",
+        emoji::TARGET
+    );
+    PBAR.info(&msg);
+    let mut cmd = Command::new("rustup");
+    cmd.arg("component").arg("add").arg("rust-src");
+    child::run(cmd, "rustup").context("Adding the rust-src component with rustup")?;
+    Ok(())
 }
 
 /// Get rustc's sysroot as a PathBuf

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -258,17 +258,24 @@ impl Build {
 
         let extra_options = build_opts.extra_options;
 
+        // Resolve the cargo target triple in the same precedence order cargo
+        // uses, so wasm-pack and cargo always agree on what's being built:
+        //   1. `--target` in extra cargo arguments (after `--`)
+        //   2. `CARGO_BUILD_TARGET` env var
+        //   3. `[build] target = "..."` in `.cargo/config.toml` (walking up
+        //      from the crate dir, then `$CARGO_HOME/config.toml`)
+        //   4. fallback to `wasm32-unknown-unknown`
         let target_triple = {
-            let mut extra_options_iter = extra_options.iter();
-            if extra_options_iter
+            let mut iter = extra_options.iter();
+            let from_args = iter
                 .by_ref()
-                .any(|option| option == "--target")
-            {
-                extra_options_iter.next().map(|s| s.as_str())
-            } else {
-                None
-            }
-            .unwrap_or("wasm32-unknown-unknown")
+                .find(|o| o.as_str() == "--target")
+                .and_then(|_| iter.next())
+                .cloned();
+            from_args
+                .or_else(|| std::env::var("CARGO_BUILD_TARGET").ok())
+                .or_else(|| read_cargo_build_target(&crate_path))
+                .unwrap_or_else(|| "wasm32-unknown-unknown".to_string())
         };
 
         Ok(Build {
@@ -287,7 +294,7 @@ impl Build {
             out_name: build_opts.out_name,
             bindgen: None,
             cache: cache::get_wasm_pack_cache()?,
-            target_triple: target_triple.to_owned(),
+            target_triple,
             extra_options,
             panic_unwind: build_opts.panic_unwind,
             wasm_path: None,
@@ -504,7 +511,7 @@ impl Build {
         if self.reference_types {
             args.push("--enable-reference-types".into());
         }
-        if self.target_triple.starts_with("wasm64") {
+        if build::is_tier3_wasm(&self.target_triple) {
             args.push("--enable-memory64".into());
         }
         info!("executing wasm-opt with {:?}", args);
@@ -518,5 +525,98 @@ impl Build {
                 "{}\nTo disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.", e
             )
         })
+    }
+}
+
+/// Read the cargo `[build] target` setting from `.cargo/config.toml`.
+///
+/// Mirrors cargo's own discovery: walk up from `crate_path` checking
+/// `.cargo/config.toml` at each ancestor (workspace-aware) and finally
+/// check `$CARGO_HOME/config.toml` for user-level defaults. The first
+/// file that declares `[build] target = "..."` wins.
+pub(crate) fn read_cargo_build_target(crate_path: &std::path::Path) -> Option<String> {
+    for dir in crate_path.ancestors() {
+        if let Some(target) = parse_build_target(&dir.join(".cargo/config.toml")) {
+            return Some(target);
+        }
+    }
+    // Cargo falls back to $CARGO_HOME/config.toml (default ~/.cargo/config.toml)
+    // for user-wide settings. Honour the same precedence.
+    let cargo_home = std::env::var_os("CARGO_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".cargo")))?;
+    parse_build_target(&cargo_home.join("config.toml"))
+}
+
+/// Parse `[build] target = "..."` from a single config file, if it
+/// exists and is well-formed. Returns `None` for missing files or
+/// configs that don't declare a target.
+fn parse_build_target(path: &std::path::Path) -> Option<String> {
+    let cfg = std::fs::read_to_string(path).ok()?;
+    let parsed: toml::Value = toml::from_str(&cfg).ok()?;
+    parsed
+        .get("build")?
+        .get("target")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_cargo_build_target_walks_up_to_workspace_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        // Workspace root holds the .cargo/config.toml.
+        std::fs::create_dir_all(root.join(".cargo")).unwrap();
+        std::fs::write(
+            root.join(".cargo/config.toml"),
+            "[build]\ntarget = \"wasm64-unknown-unknown\"\n",
+        )
+        .unwrap();
+        // Crate lives two levels deeper with no config of its own.
+        let crate_path = root.join("crates/foo");
+        std::fs::create_dir_all(&crate_path).unwrap();
+
+        assert_eq!(
+            read_cargo_build_target(&crate_path),
+            Some("wasm64-unknown-unknown".to_string())
+        );
+    }
+
+    #[test]
+    fn read_cargo_build_target_prefers_crate_over_workspace() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".cargo")).unwrap();
+        std::fs::write(
+            root.join(".cargo/config.toml"),
+            "[build]\ntarget = \"wasm32-unknown-unknown\"\n",
+        )
+        .unwrap();
+        let crate_path = root.join("crates/foo");
+        std::fs::create_dir_all(crate_path.join(".cargo")).unwrap();
+        std::fs::write(
+            crate_path.join(".cargo/config.toml"),
+            "[build]\ntarget = \"wasm64-unknown-unknown\"\n",
+        )
+        .unwrap();
+
+        // Crate-level config should win.
+        assert_eq!(
+            read_cargo_build_target(&crate_path),
+            Some("wasm64-unknown-unknown".to_string())
+        );
+    }
+
+    #[test]
+    fn read_cargo_build_target_missing_returns_none() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Use a deliberately-unreachable CARGO_HOME so the test is hermetic
+        // (otherwise it would race with developer state).
+        std::env::set_var("CARGO_HOME", tmp.path().join("nonexistent"));
+        assert_eq!(read_cargo_build_target(tmp.path()), None);
     }
 }

--- a/src/command/test.rs
+++ b/src/command/test.rs
@@ -148,15 +148,19 @@ impl Test {
         let crate_data = manifest::CrateData::new(&crate_path, None)?;
         let any_browser = chrome || firefox || safari;
 
+        // Same precedence cargo uses, so wasm-pack and cargo agree on the
+        // target. See `command::build::read_cargo_build_target`.
         let target_triple = {
             let mut iter = extra_options.iter();
-            if iter.by_ref().any(|option| option == "--target") {
-                iter.next().map(|s| s.as_str())
-            } else {
-                None
-            }
-            .unwrap_or("wasm32-unknown-unknown")
-            .to_owned()
+            let from_args = iter
+                .by_ref()
+                .find(|o| o.as_str() == "--target")
+                .and_then(|_| iter.next())
+                .cloned();
+            from_args
+                .or_else(|| std::env::var("CARGO_BUILD_TARGET").ok())
+                .or_else(|| crate::command::build::read_cargo_build_target(&crate_path))
+                .unwrap_or_else(|| "wasm32-unknown-unknown".to_string())
         };
 
         if !node && !any_browser {

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -204,7 +204,7 @@ pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Res
         Tool::WasmOpt => {
             Ok(format!(
         "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_117", // Make sure to update the version in docs/src/cargo-toml-configuration.md as well
+        vers = "version_129", // Make sure to update the version in docs/src/cargo-toml-configuration.md as well
         target = target,
             ))
         }

--- a/tests/all/download.rs
+++ b/tests/all/download.rs
@@ -75,6 +75,25 @@ fn can_download_prebuilt_wasm_opt() {
 }
 
 #[test]
+fn wasm_opt_prebuilt_url_is_pinned_version() {
+    // Ensure the bundled binaryen version is recent enough to handle
+    // 64-bit tables (added in v118). See
+    // https://github.com/wasm-bindgen/wasm-pack/issues/1576.
+    let url =
+        install::prebuilt_url_for(&Tool::WasmOpt, "latest", &Arch::X86_64, &Os::Linux).unwrap();
+    let version = url
+        .split('/')
+        .find(|segment| segment.starts_with("version_"))
+        .and_then(|s| s.trim_start_matches("version_").parse::<u32>().ok())
+        .expect("binaryen prebuilt URL must contain a version_NNN tag");
+    assert!(
+        version >= 118,
+        "bundled binaryen must be >= 118 for wasm64 support, got version_{}",
+        version
+    );
+}
+
+#[test]
 fn all_latest_tool_download_urls_valid() {
     let mut errors = Vec::new();
 


### PR DESCRIPTION
Resolves #1576.

Building for `wasm64-unknown-unknown` was broken in two ways introduced by #1553:

1. `rustup target add wasm64-unknown-unknown` failed because wasm64 is a tier-3 target with no prebuilt artifacts. The user had to work around this with `--mode force`.
2. The bundled `wasm-opt` (binaryen v117) could not parse 64-bit tables; support landed in binaryen v118.

The cargo target triple — declared in `.cargo/config.toml`, `CARGO_BUILD_TARGET`, or as an extra cargo argument (`-- --target wasm64-unknown-unknown`) — is the source of truth for what wasm-pack builds. The target triple resolver now follows the same precedence cargo uses (CLI > env > `.cargo/config.toml` walk-up > `$CARGO_HOME/config.toml` > default), so wasm-pack and cargo always agree on the target.

For tier-3 wasm targets (currently the `wasm64-*` family) wasm-pack stays out of the cargo invocation — it does **not** inject `+nightly` or `-Z build-std`. Those would override a project's `rust-toolchain.toml` pin or surprise users who hadn't intended a nightly build. Cargo-native config is the right place for those choices:

```toml
# rust-toolchain.toml
[toolchain]
channel = "nightly"
components = ["rust-src"]
```

```toml
# .cargo/config.toml
[build]
target = "wasm64-unknown-unknown"

[unstable]
build-std = ["std", "panic_abort"]
```

With that in place, `wasm-pack build` Just Works. wasm-pack's role for tier-3 wasm:

* verifies the active toolchain is nightly, with a helpful error pointing at the config above if it isn't,
* installs the `rust-src` component for the active toolchain via rustup if missing,
* skips the `rustup target add` attempt (which always fails for tier-3 targets),
* passes `--enable-memory64` to wasm-opt so the optimiser accepts 64-bit memories and tables.

The bundled binaryen is bumped from `version_117` to `version_129` (latest stable) so wasm-opt accepts 64-bit memories and tables. The `--enable-memory64` flag was already being passed for wasm64 builds, but the bundled binary was too old to honour it.

`--panic-unwind` is untouched: it remains a flag-driven recipe that injects `+nightly` and the corresponding `-Z build-std=std,panic_unwind` + `RUSTFLAGS=-Cpanic=unwind`.

Tests:

* New unit test `build::tests::tier3_wasm_detection` covers the triple-classification helper.
* New `command::build::tests` unit tests cover the cargo-config walk-up resolution (workspace root, crate-over-workspace precedence, missing-config-returns-none).
* New `wasm_opt_prebuilt_url_is_pinned_version` test guards against regressing the binaryen version below v118 (the first release with 64-bit table support).
* Existing `all_latest_tool_download_urls_valid` validates the v129 release URLs across all supported architectures.