### PR TITLE
fix(webdriver): drop 32-bit Linux geckodriver support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - ### 🤕 Fixes
 
+  - **Drop 32-bit Linux geckodriver support - [guybedford], [pull/1595]**
+
+    Mozilla discontinued 32-bit (x86) Linux geckodriver builds in v0.37.0, so the
+    download URL now 404s. The 32-bit Linux target is removed from `install_geckodriver`
+    and its test is skipped on that platform.
+
+    [pull/1595]: https://github.com/wasm-bindgen/wasm-pack/pull/1595
+
   - **Use prebuilt wasm-bindgen binary on macOS aarch64 - [guybedford], [pull/1585]**
 
     Previously wasm-pack built `wasm-bindgen-cli` from source on Apple Silicon. The

--- a/src/test/webdriver/geckodriver.rs
+++ b/src/test/webdriver/geckodriver.rs
@@ -36,9 +36,7 @@ pub fn get_or_install_geckodriver(cache: &Cache, mode: InstallMode) -> Result<Pa
 
 /// Download and install a pre-built `geckodriver` binary.
 pub fn install_geckodriver(cache: &Cache, installation_allowed: bool) -> Result<PathBuf> {
-    let (target, ext) = if target::LINUX && target::x86 {
-        ("linux32", "tar.gz")
-    } else if target::LINUX && target::x86_64 {
+    let (target, ext) = if target::LINUX && target::x86_64 {
         ("linux64", "tar.gz")
     } else if target::LINUX && target::aarch64 {
         ("linux-aarch64", "tar.gz")

--- a/tests/all/webdriver.rs
+++ b/tests/all/webdriver.rs
@@ -17,7 +17,6 @@ fn can_install_chromedriver() {
 
 #[test]
 #[cfg(any(
-    all(target_os = "linux", target_arch = "x86"),
     all(target_os = "linux", target_arch = "x86_64"),
     all(target_os = "linux", target_arch = "aarch64"),
     all(target_os = "macos", target_arch = "x86_64"),


### PR DESCRIPTION
Mozilla discontinued 32-bit (x86) Linux builds of geckodriver starting in v0.37.0 (aligned with Firefox 145 dropping 32-bit x86 Linux), so the download URL now returns a 404. This breaks the `can_install_geckodriver` test on 32-bit Linux, as reported by an Alpine Linux packager running the full test suite across their arch matrix.

32-bit x86 Linux is effectively dead for desktop/server use, and running headless Firefox wasm tests on it is a vanishingly rare intersection, so rather than pin to an old geckodriver or add a self-build path, this simply drops the platform:

* removes the `linux32` target branch from `install_geckodriver`, so 32-bit Linux now hits the existing `geckodriver binaries are unavailable for this target` bail
* skips `can_install_geckodriver` on 32-bit Linux via its `cfg`

Users who still need Firefox testing on 32-bit Linux can `cargo install geckodriver` or cross-compile it, per Mozilla's own guidance.

Resolves #1594.