### PR TITLE
Update Binaryen to v130

### DIFF
--- a/docs/src/cargo-toml-configuration.md
+++ b/docs/src/cargo-toml-configuration.md
@@ -21,7 +21,7 @@ The available configuration options and their default values are shown below:
 #
 # In most cases, the `-O[X]` flag is enough. However, if you require extreme
 # optimizations, see the full list of `wasm-opt` optimization flags
-# https://github.com/WebAssembly/binaryen/blob/version_129/test/lit/help/wasm-opt.test
+# https://github.com/WebAssembly/binaryen/blob/version_130/test/lit/help/wasm-opt.test
 wasm-opt = ['-O']
 
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -204,7 +204,7 @@ pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Res
         Tool::WasmOpt => {
             Ok(format!(
         "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_129", // Make sure to update the version in docs/src/cargo-toml-configuration.md as well
+        vers = "version_130", // Make sure to update the version in docs/src/cargo-toml-configuration.md as well
         target = target,
             ))
         }


### PR DESCRIPTION
This updates the version of Binaryen from v129 to v130. Closes #1598. I confirmed that with this change, I can build a project with the wide arithmetic target feature enabled.